### PR TITLE
adapt log formatter to log level

### DIFF
--- a/multiqc/log.py
+++ b/multiqc/log.py
@@ -1,23 +1,22 @@
-import os
-import sys
+# -*- coding: utf-8 -*-
 import logging
 
-LEVELS = {
-    0 : 'INFO',
-    1 : 'DEBUG',
-}
+LEVELS = {0: 'INFO', 1: 'DEBUG'}
+
 
 def init_log(logger, filename=None, loglevel=None):
     """
     Initializes the log file in the proper format.
 
-    Arguments:
-
+    Args:
         filename (str): Path to a file. Or None if logging is to
-                         be disabled.
+                        be disabled.
         loglevel (str): Determines the level of the log output.
     """
-    template = '[%(asctime)s] %(levelname)-5s: %(name)-30s: %(message)s'
+    if loglevel == 'DEBUG':
+        template = '[%(asctime)s] %(name)-50s [%(levelname)-7s]  %(message)s'
+    else:
+        template = '%(module)-25s [%(levelname)-7s]  %(message)s'
     formatter = logging.Formatter(template)
 
     if loglevel:
@@ -41,6 +40,7 @@ def init_log(logger, filename=None, loglevel=None):
             console.setLevel(getattr(logging, loglevel))
 
     logger.addHandler(console)
+
 
 def get_log_stream(logger):
     """


### PR DESCRIPTION
This is my suggestion for how to handle logging at different levels
I couldn't help but tweaking the order in the formatter :stuck_out_tongue: 

Normal logging:

```bash
$ multiqc tests/data
multiqc                   [INFO   ]  Using template default
multiqc                   [INFO   ]  Using title None for report
multiqc                   [INFO   ]  Checking files in tests/data
multiqc                   [INFO   ]  Using output dir /Users/robinandeer/projects/work/MultiQC/multiqc_report
multiqc                   [INFO   ]  Analysing modules qualimap, featureCounts, picard, bismark, star, tophat, bowtie2, bowtie1, cutadapt, fastq_screen, fastqc
multiqc                   [INFO   ]  Saving to /Users/robinandeer/projects/work/MultiQC/multiqc_report
qualimap_module           [INFO   ]  Found 1 reports
feature_counts_module     [INFO   ]  Found 2 reports
picard_module             [INFO   ]  Found 4 reports
bismark_module            [INFO   ]  Found 1 reports
star_module               [INFO   ]  Found 2 reports
tophat_module             [INFO   ]  Found 2 reports
bowtie_module             [INFO   ]  Found 2 reports
bowtie_module             [INFO   ]  Found 2 reports
fastq_screen_module       [INFO   ]  Found 2 reports
multiqc                   [INFO   ]  MultiQC complete
```

... and using `debug`

```bash
$ multiqc tests/data -vvv -f
[2015-09-28 14:23:31,373] multiqc.utils.check_modules                        [DEBUG  ]  Adding modules in sorted order to sorted_modules
[2015-09-28 14:23:31,373] multiqc                                            [INFO   ]  Using template default
[2015-09-28 14:23:31,373] multiqc                                            [INFO   ]  Using title None for report
[2015-09-28 14:23:31,373] multiqc                                            [INFO   ]  Checking files in tests/data
[2015-09-28 14:23:31,373] multiqc                                            [INFO   ]  Using output dir /Users/robinandeer/projects/work/MultiQC/multiqc_report
[2015-09-28 14:23:31,373] multiqc                                            [INFO   ]  Analysing modules qualimap, featureCounts, picard, bismark, star, tophat, bowtie2, bowtie1, cutadapt, fastq_screen, fastqc
[2015-09-28 14:23:31,374] multiqc                                            [WARNING]  Deleting /Users/robinandeer/projects/work/MultiQC/multiqc_report because -f was specified.
[2015-09-28 14:23:31,377] multiqc                                            [INFO   ]  Saving to /Users/robinandeer/projects/work/MultiQC/multiqc_report
[2015-09-28 14:23:31,395] multiqc.modules.qualimap.qualimap_module           [INFO   ]  Found 1 reports
[2015-09-28 14:23:31,418] multiqc.modules.featureCounts.feature_counts_module [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,438] multiqc.modules.picard.picard_module               [INFO   ]  Found 4 reports
[2015-09-28 14:23:31,450] multiqc.modules.bismark.bismark_module             [INFO   ]  Found 1 reports
[2015-09-28 14:23:31,457] multiqc.modules.star.star_module                   [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,465] multiqc.modules.tophat.tophat_module               [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,481] multiqc.modules.bowtie2.bowtie_module              [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,497] multiqc.modules.bowtie1.bowtie_module              [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,521] multiqc.modules.fastq_screen.fastq_screen_module   [INFO   ]  Found 2 reports
[2015-09-28 14:23:31,527] multiqc.modules.fastqc.fastqc_module               [DEBUG  ]  Could not find any reports in ('tests/data',)
[2015-09-28 14:23:31,730] multiqc                                            [INFO   ]  MultiQC complete
```