### PR TITLE
Share mod data

### DIFF
--- a/docs/writing_python.md
+++ b/docs/writing_python.md
@@ -64,9 +64,15 @@ headers['name'] = {
     'min': None,                    # Maximum value in range, for bar / colour coding
     'scale': 'GnBu',                # Colour scale for colour coding
     'format': '{:.1f}',             # Output format() string
-    'modify': None                  # Lambda function to modify values
+    'modify': None,                 # Lambda function to modify values
+    'shared_key': None              # See below for description
 }
 ```
+Note the `shared_key` config variable - any string can be specified here, if
+other columns are found that share the same key, a consistent colour scheme
+and data scale will be used in the table. Typically this is used with
+`headers['shared_key'] = 'read_count'`, so that the read count in a sample
+can be seen varying across analysis modules. Any string can be used, however.
 
 Example of supplied data and headers dicts:
 
@@ -100,20 +106,16 @@ self.general_stats_addcols(data, headers)
 ```
 
 ## Writing data to a file
-`self.dict_to_csv (data, delim="\t")`
+`self.write_csv_file (data, filename)`
 
-This function takes a 2D dictionary and returns a string suitable for
-writing to a .csv file. First key should be sample name (row header),
-second key should be field (column header).
-
-The function takes a dictionary as input, plus an optional 'delim'
-field to specify column delimiter (default: tab).
+This function takes a 2D dictionary and creates a tab-delimited data file
+in the report directory. Data should be supplied as a dict,
+first key should be sample name (row header), second key should be field
+(column header).
 
 You can see an example of this function in the featureCounts module:
 ```python
-# Write parsed report data to a file
-with open (os.path.join(self.output_dir, 'report_data', 'multiqc_featureCounts.txt'), "w") as f:
-    print( self.dict_to_csv( self.featurecounts_data ), file=f)
+self.write_csv_file(self.featurecounts_data, 'multiqc_featureCounts.txt')
 ```
 
 ## Plotting line graphs

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -12,7 +12,7 @@ import os
 import random
 import shutil
 
-from multiqc import config
+from multiqc import report, config
 logger = logging.getLogger(__name__)
 
 letters = 'abcdefghijklmnopqrstuvwxyz'
@@ -132,7 +132,7 @@ class BaseMultiqcModule(object):
     
     def general_stats_addcols(self, data, headers=None):
         """ Helper function to add to the General Statistics table.
-        Adds to config.general_stats and does not return anything.
+        Adds to report.general_stats and does not return anything.
         :param data: A dict with the data. First key should be sample name,
                      then the data key, then the data.
         :param headers: Dict / OrderedDict with information for the headers, 
@@ -189,7 +189,7 @@ class BaseMultiqcModule(object):
             try: title = '<span data-toggle="tooltip" title="{}: {}">{}</span>'.format(self.name, headers[k]['description'], title)
             except KeyError: pass
             
-            config.general_stats['headers'][rid] = '<th id="header_{}" class="chroma-col" data-chroma-scale="{}" data-chroma-max="{}" data-chroma-min="{}">{}</th>'.format(rid, scale, dmax, dmin, title)
+            report.general_stats['headers'][rid] = '<th id="header_{}" class="chroma-col" data-chroma-scale="{}" data-chroma-max="{}" data-chroma-min="{}">{}</th>'.format(rid, scale, dmax, dmin, title)
             
             # Add the data cells
             nrows = 0
@@ -210,12 +210,12 @@ class BaseMultiqcModule(object):
                     except ValueError: val = formatstring.format(float(samp[k]))
                     except: val = samp[k]
                     
-                    config.general_stats['rows'][sname][rid] = '<td class="data-coloured {}"><div class="wrapper"><span class="bar" style="width:{}%;"></span><span class="val">{}</span></div></td>'.format(rid, percentage, val)
+                    report.general_stats['rows'][sname][rid] = '<td class="data-coloured {}"><div class="wrapper"><span class="bar" style="width:{}%;"></span><span class="val">{}</span></div></td>'.format(rid, percentage, val)
                     nrows += 1
             
             # Remove header if we don't have any filled cells for it
             if nrows == 0:
-                config.general_stats['headers'].pop(rid, None)
+                report.general_stats['headers'].pop(rid, None)
                 logger.debug('Removing header {} from general stats table, as no data'.format(k))
         
         return None # it's good to be explicit, right?

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -130,9 +130,10 @@ class BaseMultiqcModule(object):
         return s_name
     
     
-    def general_stats_addcols(self, data, headers=None):
-        """ Helper function to add to the General Statistics table.
-        Adds to report.general_stats and does not return anything.
+    def general_stats_addcols(self, data, headers={}):
+        """ Helper function to add to the General Statistics variable.
+        Adds to report.general_stats and does not return anything. Fills
+        in required config variables if not supplied.
         :param data: A dict with the data. First key should be sample name,
                      then the data key, then the data.
         :param headers: Dict / OrderedDict with information for the headers, 
@@ -141,98 +142,62 @@ class BaseMultiqcModule(object):
         :return: None
         """
         keys = data.keys()
-        if headers is not None:
+        if len(headers.keys()) > 0:
             keys = headers.keys()
         for k in keys:
             # Unique id to avoid overwriting by other modules
             if self.name is None:
-                rid = '{}_{}'.format(''.join(random.sample(letters, 4)), k)
+                headers[k]['rid'] = '{}_{}'.format(''.join(random.sample(letters, 4)), k)
             else:
                 safe_name = ''.join(c for c in self.name if c.isalnum()).lower()
-                rid = '{}_{}'.format(safe_name, k)
+                headers[k]['rid'] = '{}_{}'.format(safe_name, k)
             
-            # Get min, max & colscheme from shared key if using it
-            sk = headers[k].get('shared_key', None)
-            if sk in report.general_stats['shared_keys']:
-                scale = report.general_stats['shared_keys'][sk]['scale']
-                dmax  = report.general_stats['shared_keys'][sk]['dmax']
-                dmin  = report.general_stats['shared_keys'][sk]['dmin']
+            # Use defaults / data keys if headers not given
+            if 'title' not in headers[k]:
+                headers[k]['title'] = k
             
-            # Figure out colour scheme and min / max
-            else:
-                try: scale = headers[k]['scale']
-                except KeyError: scale = 'GnBu'
+            try:
+                headers[k]['description'] = '{}: {}'.format(self.name, headers[k]['description'])
+            except KeyError: 
+                headers[k]['description'] = '{}: {}'.format(self.name, headers[k]['title'])
                 
-                try:
-                    dmax = float(headers[k]['max'])
-                except KeyError:
-                    dmax = None
-                
-                try:
-                    dmin = float(headers[k]['min'])
-                except KeyError:
-                    dmin = None
-                
-                if dmax is None or dmin is None:
-                    setdmax = False
-                    setdmin = False
-                    for (sname, samp) in data.items():
-                        val = float(samp[k])
-                        if 'modify' in headers[k] and callable(headers[k]['modify']):
-                            val = float(headers[k]['modify'](val))
-                        if dmax is None:
-                            dmax = val
-                            setdmax = True
-                        if dmin is None:
-                            dmin = val
-                            setdmin = True
-                        if setdmax:
-                            dmax = max(dmax, val)
-                        if setdmin:
-                            dmin = min(dmin, val)
-                
-                # Set if shared key is specified - must be the first time we've seen it
-                if sk is not None:
-                    report.general_stats['shared_keys'][sk]['scale'] = scale
-                    report.general_stats['shared_keys'][sk]['dmax']  = dmax
-                    report.general_stats['shared_keys'][sk]['dmin']  = dmin
+            if 'scale' not in headers[k]:
+                headers[k]['scale'] = 'GnBu'
             
-            try: title = headers[k]['title']
-            except KeyError: title = k
+            if 'format' not in headers[k]:
+                headers[k]['format'] = '{:.1f}'
             
-            try: title = '<span data-toggle="tooltip" title="{}: {}">{}</span>'.format(self.name, headers[k]['description'], title)
-            except KeyError: pass
+            setdmax = False
+            setdmin = False
+            try:
+                headers[k]['dmax'] = float(headers[k]['max'])
+            except KeyError:
+                headers[k]['dmax'] = float("-inf")
+                setdmax = True
             
-            report.general_stats['headers'][rid] = '<th id="header_{}" class="chroma-col" data-chroma-scale="{}" data-chroma-max="{}" data-chroma-min="{}">{}</th>'.format(rid, scale, dmax, dmin, title)
+            try:
+                headers[k]['dmin'] = float(headers[k]['min'])
+            except KeyError:
+                headers[k]['dmin'] = float("inf")
+                setdmin = True
             
-            # Add the data cells
-            nrows = 0
-            for (sname, samp) in data.items():
-                if k in samp:
-                    val = samp[k]
+            # Figure out the min / max if not supplied
+            if setdmax or setdmin:
+                for (sname, samp) in data.items():
+                    val = float(samp[k])
                     if 'modify' in headers[k] and callable(headers[k]['modify']):
-                        val = headers[k]['modify'](val)
-                    
-                    percentage = ((float(val) - dmin) / (dmax - dmin)) * 100;
-                    percentage = min(percentage, 100)
-                    percentage = max(percentage, 0)
-                        
-                    formatstring = headers[k].get('')
-                    try: formatstring = headers[k]['format']
-                    except: formatstring = '{:.1f}'
-                    try: val = formatstring.format(val)
-                    except ValueError: val = formatstring.format(float(samp[k]))
-                    except: val = samp[k]
-                    
-                    report.general_stats['rows'][sname][rid] = '<td class="data-coloured {}"><div class="wrapper"><span class="bar" style="width:{}%;"></span><span class="val">{}</span></div></td>'.format(rid, percentage, val)
-                    nrows += 1
-            
-            # Remove header if we don't have any filled cells for it
-            if nrows == 0:
-                report.general_stats['headers'].pop(rid, None)
-                logger.debug('Removing header {} from general stats table, as no data'.format(k))
+                        val = float(headers[k]['modify'](val))
+                    if setdmax:
+                        headers[k]['dmax'] = max(headers[k]['dmax'], val)
+                    if setdmin:
+                        headers[k]['dmin'] = min(headers[k]['dmin'], val)
         
-        return None # it's good to be explicit, right?
+        report.general_stats[self.name] = {
+            'data': data,
+            'headers': headers
+        }
+        
+        return None
         
         
     
@@ -399,30 +364,10 @@ class BaseMultiqcModule(object):
         
     
     def write_csv_file(self, data, fn):
+        """ Write a tab-delimited data file to the reports directory.
+        :param: data - a 2D dict, first key sample name (row header),
+                second key field (column header). 
+        :param: fn - Desired filename. Directory will be prepended automatically.
+        :return: None """
         with io.open (os.path.join(config.data_dir, fn), "w", encoding='utf-8') as f:
-            print( self.dict_to_csv( data ), file=f)
-            
-            
-    def dict_to_csv (self, d, delim="\t"):
-        """ Converts a dict to a CSV string
-        :param d: 2D dictionary, first keys sample names and second key
-                  column headers. If second key is not a string, it is skipped.
-        :param delim: optional delimiter character. Default: \t
-        :return: Flattened string, suitable to write to a CSV file.
-        """
-
-        h = None    # Headers
-        l = list()  # File lines
-        for sn in sorted(d.keys()):
-            # Create the header row
-            if h is None:
-                h = list()
-                for k in d[sn].keys():
-                    # Skip if another dict
-                    if type(d[sn][k]) is not dict:
-                        h.append(k)
-                l.append(delim.join(['Sample'] + h))
-            # Make a list starting with the sample name, then each field in order of the header cols
-            thesefields = [sn] + [ str(d[sn].get(k, '')) for k in h ]
-            l.append( delim.join( thesefields ) )
-        return ('\n'.join(l)).encode('utf-8', 'ignore').decode('utf-8')
+            print( report.dict_to_csv( data ), file=f)

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -31,10 +31,6 @@ analysis_dir = [os.getcwd()]
 output_dir = os.path.realpath(os.getcwd())
 output_fn_name = 'multiqc_report.html'
 data_dir_name = 'multiqc_data'
-general_stats = {
-    'headers': OrderedDict(),
-    'rows': defaultdict(lambda:dict())
-}
 fn_clean_exts = [ '.gz', '.fastq', '.fq', '.bam', '.sam', '_tophat', '_star_aligned', '_fastqc' ]
 fn_ignore_files = ['.DS_Store']
 

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -198,14 +198,16 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'Deduplicated Alignments (millions)',
             'min': 0,
             'scale': 'Greens',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         headers['aligned_reads'] = {
             'title': 'M Aligned',
             'description': 'Total Aligned Sequences (millions)',
             'min': 0,
             'scale': 'PuRd',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         headers['percent_aligned'] = {
             'title': '% Aligned',

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -90,7 +90,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'reads with at least one reported alignment (millions)',
             'min': 0,
             'scale': 'PuRd',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.bowtie_data, headers)
 

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -94,7 +94,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'reads aligned (millions)',
             'min': 0,
             'scale': 'PuRd',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.bowtie2_data, headers)
 

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -285,7 +285,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'Total Sequences (millions)',
             'min': 0,
             'scale': 'Blues',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.fastqc_stats, headers)
 

--- a/multiqc/modules/featureCounts/feature_counts.py
+++ b/multiqc/modules/featureCounts/feature_counts.py
@@ -102,7 +102,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'Assigned reads (millions)',
             'min': 0,
             'scale': 'PuBu',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.featurecounts_data, headers)
 

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -117,7 +117,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'Uniquely mapped reads (millions)',
             'min': 0,
             'scale': 'PuRd',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.star_data, headers)
 

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -102,7 +102,8 @@ class MultiqcModule(BaseMultiqcModule):
             'description': 'Aligned reads, not multimapped or discordant (millions)',
             'min': 0,
             'scale': 'PuRd',
-            'modify': lambda x: x / 1000000
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
         }
         self.general_stats_addcols(self.tophat_data, headers)
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -7,6 +7,7 @@ from collections import defaultdict, OrderedDict
 
 general_stats = {
     'headers': OrderedDict(),
-    'rows': defaultdict(lambda:dict())
+    'rows': defaultdict(lambda:dict()),
+    'shared_keys': defaultdict(lambda:dict())
 }
 

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -1,13 +1,117 @@
 #!/usr/bin/env python
 
 """ MultiQC report module. Holds the output from each
-module. Is available to subsequent modules. """
+module. Is available to subsequent modules. Contains
+helper functions to generate markup for report. """
 
 from collections import defaultdict, OrderedDict
 
-general_stats = {
+general_stats = OrderedDict()
+general_stats_html = {
     'headers': OrderedDict(),
-    'rows': defaultdict(lambda:dict()),
-    'shared_keys': defaultdict(lambda:dict())
+    'rows': defaultdict(lambda:dict())
 }
 
+
+
+def general_stats_build_html():
+    """ Helper function to add to the General Statistics table.
+    Parses report.general_stats and returns HTML for general stats table.
+    :param data: A dict with the data. First key should be sample name,
+                 then the data key, then the data.
+    :param headers: Dict / OrderedDict with information for the headers, 
+                    such as colour scales, min and max values etc.
+                    See docs/writing_python.md for more information.
+    :return: None
+    """
+    
+    # First - collect settings for shared keys
+    shared_keys = defaultdict(lambda: dict())
+    for mod in general_stats.keys():
+        headers = general_stats[mod]['headers']
+        for k in headers.keys():
+            sk = headers[k].get('shared_key', None)
+            if sk is not None:
+                shared_keys[sk]['scale'] = headers[k]['scale']
+                shared_keys[sk]['dmax']  = max(headers[k]['dmax'], shared_keys[sk].get('dmax', headers[k]['dmax']))
+                shared_keys[sk]['dmin']  = max(headers[k]['dmin'], shared_keys[sk].get('dmin', headers[k]['dmin']))
+    
+    # Now build required HTML
+    for mod in general_stats.keys():
+        headers = general_stats[mod]['headers']
+        for k in headers.keys():
+            
+            rid = headers[k]['rid']
+            
+            # Overwrite config with shared key settings
+            sk = headers[k].get('shared_key', None)
+            if sk is not None:
+                headers[k]['scale'] = shared_keys[sk]['scale']
+                headers[k]['dmax']  = shared_keys[sk]['dmax']
+                headers[k]['dmin']  = shared_keys[sk]['dmin']
+                sk = ' data-shared-key={}'.format(sk)
+            else:
+                sk = ''
+            
+            general_stats_html['headers'][rid] = '<th \
+                    id="header_{rid}" \
+                    class="chroma-col" \
+                    data-chroma-scale="{scale}" \
+                    data-chroma-max="{max}" \
+                    data-chroma-min="{min}" \
+                    {sk}><span data-toggle="tooltip" title="{descrip}">{title}</span></th>' \
+                        .format(rid=rid, scale=headers[k]['scale'], max=headers[k]['dmax'],
+                            min=headers[k]['dmin'], sk=sk, \
+                            descrip=headers[k]['description'], title=headers[k]['title'])
+            
+            # Add the data table cells
+            nrows = 0
+            for (sname, samp) in general_stats[mod]['data'].items():
+                if k in samp:
+                    val = samp[k]
+                    if 'modify' in headers[k] and callable(headers[k]['modify']):
+                        val = headers[k]['modify'](val)
+                    
+                    percentage = ((float(val) - headers[k]['dmin']) / (headers[k]['dmax'] - headers[k]['dmin'])) * 100;
+                    percentage = min(percentage, 100)
+                    percentage = max(percentage, 0)
+                    
+                    try: val = headers[k]['format'].format(val)
+                    except ValueError: val = headers[k]['format'].format(float(samp[k]))
+                    except: val = samp[k]
+                    
+                    general_stats_html['rows'][sname][rid] = '<td class="data-coloured {}"><div class="wrapper"><span class="bar" style="width:{}%;"></span><span class="val">{}</span></div></td>'.format(rid, percentage, val)
+                    nrows += 1
+            
+            # Remove header if we don't have any filled cells for it
+            if nrows == 0:
+                general_stats_html['headers'].pop(rid, None)
+                logger.debug('Removing header {} from general stats table, as no data'.format(k))
+        
+    return None
+    
+    
+    
+def dict_to_csv (d, delim="\t"):
+    """ Converts a dict to a CSV string
+    :param d: 2D dictionary, first keys sample names and second key
+              column headers. If second key is not a string, it is skipped.
+    :param delim: optional delimiter character. Default: \t
+    :return: Flattened string, suitable to write to a CSV file.
+    """
+
+    h = None    # Headers
+    l = list()  # File lines
+    for sn in sorted(d.keys()):
+        # Create the header row
+        if h is None:
+            h = list()
+            for k in d[sn].keys():
+                # Skip if another dict
+                if type(d[sn][k]) is not dict:
+                    h.append(k)
+            l.append(delim.join(['Sample'] + h))
+        # Make a list starting with the sample name, then each field in order of the header cols
+        thesefields = [sn] + [ str(d[sn].get(k, '')) for k in h ]
+        l.append( delim.join( thesefields ) )
+    return ('\n'.join(l)).encode('utf-8', 'ignore').decode('utf-8')

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+""" MultiQC report module. Holds the output from each
+module. Is available to subsequent modules. """
+
+from collections import defaultdict, OrderedDict
+
+general_stats = {
+    'headers': OrderedDict(),
+    'rows': defaultdict(lambda:dict())
+}
+

--- a/multiqc/templates/default/multiqc_report.html
+++ b/multiqc/templates/default/multiqc_report.html
@@ -28,7 +28,7 @@
   <style type="text/css">{{ include_file('assets/css/bootstrap.min.css') }}</style>
   <style type="text/css">{{ include_file('assets/css/bootstrap-tour.min.css') }}</style>
   <style type="text/css">{{ include_file('assets/css/default_multiqc.css') }}</style>
-  {%- for m in modules %}{% if m.css and m.css|length > 0 -%}{% for css_href in m.css %}
+  {%- for m in report.modules_output %}{% if m.css and m.css|length > 0 -%}{% for css_href in m.css %}
   <style type="text/css">{{ include_file(css_href, None) }}</style>
   {%- endfor %}{% endif %}{% endfor %}
   
@@ -48,7 +48,7 @@
   <script type="text/javascript">{{ include_file('assets/js/multiqc_plotting.js') }}</script>
   <script type="text/javascript">{{ include_file('assets/js/multiqc_tour.js') }}</script>
   <script src="multiqc_config.js"></script>
-  {%- for m in modules %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js %}
+  {%- for m in report.modules_output %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js %}
   <script type="text/javascript">{{ include_file( js_href, None ) }}</script>
   {%- endfor %}{% endif %}{% endfor %}
 
@@ -66,7 +66,7 @@
     {% if report.general_stats['headers']|length > 0 %}
     <li><a href="#general_stats">General Stats</a></li>
     {% endif -%}
-    {% for m in modules %}
+    {% for m in report.modules_output %}
     <li>
       <a href="#{{ m.anchor }}">{{ m.name }}</a>
       <ul>
@@ -212,7 +212,7 @@
   </div>
   {% endif %}
 
-  {% for m in modules %}
+  {% for m in report.modules_output %}
     <div id="mqc-module-section-{{ m.anchor }}" class="mqc-module-section">
       <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
       {{ m.intro if m.intro }}

--- a/multiqc/templates/default/multiqc_report.html
+++ b/multiqc/templates/default/multiqc_report.html
@@ -63,7 +63,7 @@
     </a>
   </h1>
   <ul class="mqc-nav">
-    {% if report.general_stats['headers']|length > 0 %}
+    {% if report.general_stats_html['headers']|length > 0 %}
     <li><a href="#general_stats">General Stats</a></li>
     {% endif -%}
     {% for m in report.modules_output %}
@@ -128,7 +128,7 @@
           <input id="mqc_hidesamples_filter" type="text" placeholder="Custom Pattern" class="form-control input-sm">
           <button type="submit" id="mqc_hidesamples_filter_update" class="btn btn-default btn-sm">+</button>
         </form>
-        {% if report.general_stats['rows'] | length > 10 %}<p>Warning! This can take a few seconds.</p>{% endif %}
+        {% if report.general_stats_html['rows'] | length > 10 %}<p>Warning! This can take a few seconds.</p>{% endif %}
         <p class="mqc_regex_mode">Regex mode <span class="off">off</span></p>
         <ul id="mqc_hidesamples_filters" class="mqc_filters"></ul>
       </div>
@@ -180,7 +180,7 @@
     <button id="mqc-launch-into-tour" class="btn btn-info btn-sm">Take the tour</button>
   </div>
   
-  {% if report.general_stats['headers']|length > 0 %}
+  {% if report.general_stats_html['headers']|length > 0 %}
   <div id="general_stats">
     <h2>General Statistics</h2>
     <div id="general_stats_table_container">
@@ -190,17 +190,17 @@
             <tr>
               <td class="sorthandle">&nbsp;</td>
               <th class="rowheader">Sample Name</th>
-              {%- for k, h in report.general_stats['headers'].items() %}
+              {%- for k, h in report.general_stats_html['headers'].items() %}
                 {{ h }}
               {%- endfor -%}
             </tr>
           </thead>
           <tbody>
-            {% for sn, r in report.general_stats['rows']|dictsort %}
+            {% for sn, r in report.general_stats_html['rows']|dictsort %}
             <tr>
               <td class="sorthandle">||</td>
               <th class="rowheader">{{ sn }}</th>
-              {%- for k, h in report.general_stats['headers'].items() %}
+              {%- for k, h in report.general_stats_html['headers'].items() %}
                 {{ r[k] if r[k] else '<td></td>' }}
               {%- endfor -%}
             </tr>

--- a/multiqc/templates/default/multiqc_report.html
+++ b/multiqc/templates/default/multiqc_report.html
@@ -63,7 +63,7 @@
     </a>
   </h1>
   <ul class="mqc-nav">
-    {% if config.general_stats['headers']|length > 0 %}
+    {% if report.general_stats['headers']|length > 0 %}
     <li><a href="#general_stats">General Stats</a></li>
     {% endif -%}
     {% for m in modules %}
@@ -128,7 +128,7 @@
           <input id="mqc_hidesamples_filter" type="text" placeholder="Custom Pattern" class="form-control input-sm">
           <button type="submit" id="mqc_hidesamples_filter_update" class="btn btn-default btn-sm">+</button>
         </form>
-        {% if config.general_stats['rows'] | length > 10 %}<p>Warning! This can take a few seconds.</p>{% endif %}
+        {% if report.general_stats['rows'] | length > 10 %}<p>Warning! This can take a few seconds.</p>{% endif %}
         <p class="mqc_regex_mode">Regex mode <span class="off">off</span></p>
         <ul id="mqc_hidesamples_filters" class="mqc_filters"></ul>
       </div>
@@ -180,7 +180,7 @@
     <button id="mqc-launch-into-tour" class="btn btn-info btn-sm">Take the tour</button>
   </div>
   
-  {% if config.general_stats['headers']|length > 0 %}
+  {% if report.general_stats['headers']|length > 0 %}
   <div id="general_stats">
     <h2>General Statistics</h2>
     <div id="general_stats_table_container">
@@ -190,17 +190,17 @@
             <tr>
               <td class="sorthandle">&nbsp;</td>
               <th class="rowheader">Sample Name</th>
-              {%- for k, h in config.general_stats['headers'].items() %}
+              {%- for k, h in report.general_stats['headers'].items() %}
                 {{ h }}
               {%- endfor -%}
             </tr>
           </thead>
           <tbody>
-            {% for sn, r in config.general_stats['rows']|dictsort %}
+            {% for sn, r in report.general_stats['rows']|dictsort %}
             <tr>
               <td class="sorthandle">||</td>
               <th class="rowheader">{{ sn }}</th>
-              {%- for k, h in config.general_stats['headers'].items() %}
+              {%- for k, h in report.general_stats['headers'].items() %}
                 {{ r[k] if r[k] else '<td></td>' }}
               {%- endfor -%}
             </tr>

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -179,12 +179,12 @@ force, verbose, quiet):
     os.makedirs(config.data_dir)
 
     # Run the modules!
-    modules_output = list()
+    report.modules_output = list()
     sys_exit_code = 0
     for this_module in run_modules:
         try:
             mod = config.avail_modules[this_module].load()
-            modules_output.append(mod.MultiqcModule())
+            report.modules_output.append(mod.MultiqcModule())
         except UserWarning:
             pass # No samples found
         except:
@@ -198,7 +198,7 @@ force, verbose, quiet):
             sys_exit_code = 1
 
     # Did we find anything?
-    if len(modules_output) == 0:
+    if len(report.modules_output) == 0:
         logger.warn("No analysis results found. Cleaning up..")
         shutil.rmtree(config.data_dir)
         logger.info("MultiQC complete")
@@ -234,7 +234,7 @@ force, verbose, quiet):
 
     # Use jinja2 to render the template and overwrite
     config.analysis_dir = [os.path.realpath(d) for d in config.analysis_dir]
-    report_output = j_template.render(report=report, config=config, modules=modules_output)
+    report_output = j_template.render(report=report, config=config)
     try:
         with io.open (config.output_fn, "w", encoding='utf-8') as f:
             print(report_output, file=f)

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -204,16 +204,17 @@ force, verbose, quiet):
         logger.info("MultiQC complete")
         # Exit with an error code if a module broke
         sys.exit(sys_exit_code)
-
+    
+    # Generate the General Statistics table HTML
+    report.general_stats_build_html()
+    
     # Print the general stats table to a file
-    with open (os.path.join(config.data_dir, 'multiqc_general_stats.txt'), "w") as f:
-        hrow = '\t'.join([''] + list(report.general_stats['headers'].keys()) )
-        l = [hrow]
-        for sn, r in iter(sorted(report.general_stats['rows'].items())):
-            thesefields = [sn] + [ str(r.get(k, '')) for k in report.general_stats['headers'] ]
-            thesefields = [ re.sub('<[^<]+?>', '', field) for field in thesefields ]
-            l.append( '\t'.join( thesefields ) )
-        print( '\n'.join(l), file=f)
+    with io.open (os.path.join(config.data_dir, 'multiqc_general_stats.txt'), "w", encoding='utf-8') as f:
+        d = {}
+        for m in report.general_stats.keys():
+            for (k, v) in report.general_stats[m]['data'].items():
+                d[k] = v
+        print( report.dict_to_csv( d ), file=f)
 
     # Function to include file contents in Jinja template
     def include_file(name, fdir=template_dir, b64=False):

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -18,7 +18,7 @@ import importlib
 
 import click
 
-from multiqc import (config, logger, __version__)
+from multiqc import (report, config, logger, __version__)
 from multiqc.log import init_log, LEVELS
 
 @click.command()
@@ -207,10 +207,10 @@ force, verbose, quiet):
 
     # Print the general stats table to a file
     with open (os.path.join(config.data_dir, 'multiqc_general_stats.txt'), "w") as f:
-        hrow = '\t'.join([''] + list(config.general_stats['headers'].keys()) )
+        hrow = '\t'.join([''] + list(report.general_stats['headers'].keys()) )
         l = [hrow]
-        for sn, r in iter(sorted(config.general_stats['rows'].items())):
-            thesefields = [sn] + [ str(r.get(k, '')) for k in config.general_stats['headers'] ]
+        for sn, r in iter(sorted(report.general_stats['rows'].items())):
+            thesefields = [sn] + [ str(r.get(k, '')) for k in report.general_stats['headers'] ]
             thesefields = [ re.sub('<[^<]+?>', '', field) for field in thesefields ]
             l.append( '\t'.join( thesefields ) )
         print( '\n'.join(l), file=f)
@@ -234,10 +234,10 @@ force, verbose, quiet):
 
     # Use jinja2 to render the template and overwrite
     config.analysis_dir = [os.path.realpath(d) for d in config.analysis_dir]
-    report = j_template.render(config=config, modules=modules_output)
+    report_output = j_template.render(report=report, config=config, modules=modules_output)
     try:
         with io.open (config.output_fn, "w", encoding='utf-8') as f:
-            print(report, file=f)
+            print(report_output, file=f)
     except IOError as e:
         raise IOError ("Could not print report to '{}' - {}".format(output_path, IOError(e)))
 


### PR DESCRIPTION
Restructured the code that generates the General Statistics table.

**Base Module:** `self.general_stats_addcols()` still exists, but instead of directly generating the HTML markup, it fills in any blanks (data min / max values etc) and saves this to the central `report.general_stats`
`dict_to_csv()` also moved to `report` instead of base module. Made little difference as was only called by one other base module function.

**Main script:** Instead of manually scraping and cleaning the HTML to write `multiqc_general_stats.txt` (yuk), it now uses the nice data structure created by `self.general_stats_addcols()` and the same `report.dict_to_csv()` function as everyone else.

**report.py** New common submodule created, designed for maintaining generated data throughout the report, so that it can be shared between modules. Now also contains a couple of helper functions related to generating the report output, such as `report.general_stats_build_html()`

**Modules** Modules sending read counts to the general statistics table now mark them as a shared key with `read_count`.

Closes #4 and makes a start on #29.