### PR TITLE
Plugin hooks

### DIFF
--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import logging
 import pkgutil

--- a/multiqc/utils/plugin_hooks.py
+++ b/multiqc/utils/plugin_hooks.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+""" MultiQC plugin hooks. Enables MultiQC plugins
+to run their own custom subroutines at predefined
+trigger points during MultiQC execution. """
+
+import logging
+import pkg_resources
+
+import multiqc
+from multiqc import (logger)
+from multiqc.utils.log import init_log, LEVELS
+
+# Load the hooks
+hook_functions = []
+for entry_point in pkg_resources.iter_entry_points('multiqc.hooks.v1'):
+  hook_functions.append(entry_point.load())
+
+# Function to run the hooks
+def mqc_trigger (trigger):
+  for h in hook_functions:
+    h(trigger)

--- a/multiqc/utils/plugin_hooks.py
+++ b/multiqc/utils/plugin_hooks.py
@@ -12,11 +12,15 @@ from multiqc import (logger)
 from multiqc.utils.log import init_log, LEVELS
 
 # Load the hooks
-hook_functions = []
+hook_functions = {}
 for entry_point in pkg_resources.iter_entry_points('multiqc.hooks.v1'):
-  hook_functions.append(entry_point.load())
+  nicename = str(entry_point).split('=')[0].strip()
+  try:
+    hook_functions[nicename].append(entry_point.load())
+  except KeyError:
+    hook_functions[nicename] = [entry_point.load()]
 
 # Function to run the hooks
 def mqc_trigger (trigger):
-  for h in hook_functions:
-    h(trigger)
+  for hook in hook_functions.get(trigger, []):
+    hook()

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -21,7 +21,7 @@ import importlib
 import click
 
 from multiqc import (logger, __version__)
-from multiqc.utils import (report, config)
+from multiqc.utils import (report, plugin_hooks, config)
 from multiqc.utils.log import init_log, LEVELS
 
 @click.command()
@@ -89,6 +89,8 @@ force, verbose, quiet):
     if quiet:
         loglevel = 'WARNING'
     init_log(logger, loglevel=loglevel)
+    
+    plugin_hooks.mqc_trigger('execution_start')
     
     logger.info("Working dir : {0}".format(os.getcwd()))
     logger.info("Template    : {0}".format(template))
@@ -194,6 +196,7 @@ force, verbose, quiet):
         os.makedirs(os.path.dirname(config.output_fn))
 
     # Run the modules!
+    plugin_hooks.mqc_trigger('before_modules')
     report.modules_output = list()
     sys_exit_code = 0
     for this_module in run_modules:
@@ -219,6 +222,8 @@ force, verbose, quiet):
         logger.info("MultiQC complete")
         # Exit with an error code if a module broke
         sys.exit(sys_exit_code)
+    
+    plugin_hooks.mqc_trigger('after_modules')
     
     # Generate the General Statistics table HTML
     report.general_stats_build_html()
@@ -277,6 +282,8 @@ force, verbose, quiet):
     
     # Clean up temporary directory
     shutil.rmtree(tmp_dir)
+    
+    plugin_hooks.mqc_trigger('execution_finish')
 
     logger.info("MultiQC complete")
     if osx_app: 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
             'default = multiqc.templates.default',
             'default_dev = multiqc.templates.default_dev',
             'geo = multiqc.templates.geo',
-        ]
+        ],
+        'multiqc.hooks.v1': []
     },
     classifiers = [
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,12 @@ setup(
             'default_dev = multiqc.templates.default_dev',
             'geo = multiqc.templates.geo',
         ],
-        'multiqc.hooks.v1': []
+        # 'multiqc.hooks.v1': [
+            # 'execution_start = myplugin.hooks:execution_start',
+            # 'before_modules = myplugin.hooks:before_modules',
+            # 'after_modules = myplugin.hooks:after_modules',
+            # 'execution_finish = myplugin.hooks:execution_finish',
+        # ]
     },
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
New system for Python plugins to extend the core code of MultiQC. Uses triggers within the core that can run external functions.

Closes #29 and works with code in MultiQC_NGI (as an example). See https://github.com/ewels/MultiQC_NGI/commit/a4e2f662006f10b2af1ab9f1f00340d9993367d8