### PR TITLE
Module search config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # MultiQC Version History
 
 #### v0.3.2dev
+* All modules now load their log file search parameters from a config
+  file, allowing you to overwrite them using your user config file
+  * This is useful if your analysis pipeline renames program outputs
 * New Picard (sub)modules - Insert Size, GC Bias & HsMetrics
 * New Qualimap (sub)module - RNA-Seq QC
 * Made Picard MarkDups show percent by default instead of counts

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -111,9 +111,45 @@ Log messages can come in a range of formats:
 
 ## Step 1 - Find log files
 The first thing that your module will need to do is to find analysis log
-files. You can use the base function `self.find_log_files()` for this:
+files. You can do this by searching for a filename fragment, or a string
+within the file. It's possible to search for both (a match on either
+will return the file) and also to have multiple strings possible.
+
+First, add your default patterns to:
+```
+install_dir/multiqc/utils/search_patterns.yaml
+```
+
+You should see the patterns for all other modules to give you an idea,
+but you want a yaml key with the name of your module, then either `fn`
+or `contents` for strings to match against filenames or file contents:
+```yaml
+mymod:
+    fn: _myprogram.txt
+myothermod:
+    contents: This is myotherprogram running
+```
+
+Note that if you want to find multiple log files, you can nest these
+dictionaries (though they must end with either `fn` or `contents`).
+For example, see the `FastQC` module:
+```yaml
+fastqc:
+    data:
+        fn: fastqc_data.txt
+    zip:
+        fn: _fastqc.zip
+```
+
+The value of adding these strings here is that they can be overwritten
+by users in their own config files. This is helpful as people have weird
+and wonderful processing pipelines with their own file naming conventions.
+
+Once your strings are added, you can call them in your module with the
+`config.sp['mymod']`. Next, use the base function `self.find_log_files()`
+to look for your files like this:
 ```python
-self.find_log_files(fn_match=None, contents_match=None, filehandles=False)
+self.find_log_files(config.sp['mymod'], filehandles=False)
 ```
 
 This will recursively search the analysis directories looking for a matching

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -51,7 +51,7 @@ class BaseMultiqcModule(object):
             contents_match = patterns['contents']
         if fn_match == None and contents_match == None:
             logger.warning("No file patterns specified for find_log_files")
-            return None
+            yield None
         
         # Step 1 - make a list of files to search
         files = list()

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -29,7 +29,7 @@ class BaseMultiqcModule(object):
             href, target, info, extra
         )
 
-    def find_log_files(self, fn_match=None, contents_match=None, filecontents=True, filehandles=False):
+    def find_log_files(self, patterns, filecontents=True, filehandles=False):
         """
         Search the analysis directory for log files of interest. Can take either a filename
         suffix or a search string to return only log files that contain relevant info.
@@ -41,6 +41,17 @@ class BaseMultiqcModule(object):
                  and either the file contents or file handle for the current matched file.
                  As yield is used, the function can be iterated over without 
         """
+        
+        # Get the search parameters
+        fn_match = None
+        contents_match = None
+        if 'fn' in patterns:
+            fn_match = patterns['fn']
+        if 'contents' in patterns:
+            contents_match = patterns['contents']
+        if fn_match == None and contents_match == None:
+            logger.warning("No file patterns specified for find_log_files")
+            return None
         
         # Step 1 - make a list of files to search
         files = list()

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -80,9 +80,10 @@ class MultiqcModule(BaseMultiqcModule):
             'meth': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}},
             'cov': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}}
         }
+        sp = config['sp']['bismark']
         
         # Find and parse bismark alignment reports
-        for f in self.find_log_files(config['sp']['bismark']['align']):
+        for f in self.find_log_files(sp['align']):
             parsed_data = self.parse_bismark_report(f['f'], regexes['alignment'])
             if parsed_data is not None:
                 if f['s_name'] in self.bismark_data['alignment']:
@@ -96,7 +97,7 @@ class MultiqcModule(BaseMultiqcModule):
                     self.bismark_data['alignment'][f['s_name']] = parsed_data
         
         # Find and parse bismark deduplication reports
-        for f in self.find_log_files(config['sp']['bismark']['dedup']):
+        for f in self.find_log_files(sp['dedup']):
             parsed_data = self.parse_bismark_report(f['f'], regexes['dedup'])
             if parsed_data is not None:
                 if f['s_name'] in self.bismark_data['dedup']:
@@ -104,7 +105,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['dedup'][f['s_name']] = parsed_data
         
         # Find and parse bismark methylation extractor reports
-        for f in self.find_log_files(config['sp']['bismark']['meth_extract']):
+        for f in self.find_log_files(sp['meth_extract']):
         # for f in self.find_log_files(fn_match='_splitting_report.txt'):
             parsed_data = self.parse_bismark_report(f['f'], regexes['methextract'])
             s_name = f['s_name']
@@ -116,7 +117,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['methextract'][s_name] = parsed_data
         
         # Find and parse M-bias plot data
-        for f in self.find_log_files(config['sp']['bismark']['m_bias'], filehandles=True):
+        for f in self.find_log_files(sp['m_bias'], filehandles=True):
             self.parse_bismark_mbias(f)
         
         if len(self.bismark_data['alignment']) == 0 and len(self.bismark_data['dedup']) == 0 and len(self.bismark_data['methextract']) == 0:

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -80,7 +80,7 @@ class MultiqcModule(BaseMultiqcModule):
             'meth': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}},
             'cov': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}}
         }
-        sp = config['sp']['bismark']
+        sp = config.sp['bismark']
         
         # Find and parse bismark alignment reports
         for f in self.find_log_files(sp['align']):

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -82,7 +82,7 @@ class MultiqcModule(BaseMultiqcModule):
         }
         
         # Find and parse bismark alignment reports
-        for f in self.find_log_files(fn_match=['_PE_report.txt', '_SE_report.txt'], contents_match='Writing a C -> T converted version of the input file'):
+        for f in self.find_log_files(config['sp']['bismark']['align']):
             parsed_data = self.parse_bismark_report(f['f'], regexes['alignment'])
             if parsed_data is not None:
                 if f['s_name'] in self.bismark_data['alignment']:
@@ -96,7 +96,7 @@ class MultiqcModule(BaseMultiqcModule):
                     self.bismark_data['alignment'][f['s_name']] = parsed_data
         
         # Find and parse bismark deduplication reports
-        for f in self.find_log_files('.deduplication_report.txt'):
+        for f in self.find_log_files(config['sp']['bismark']['dedup']):
             parsed_data = self.parse_bismark_report(f['f'], regexes['dedup'])
             if parsed_data is not None:
                 if f['s_name'] in self.bismark_data['dedup']:
@@ -104,7 +104,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['dedup'][f['s_name']] = parsed_data
         
         # Find and parse bismark methylation extractor reports
-        for f in self.find_log_files(fn_match='_splitting_report.txt', contents_match='Bismark Extractor Version'):
+        for f in self.find_log_files(config['sp']['bismark']['meth_extract']):
         # for f in self.find_log_files(fn_match='_splitting_report.txt'):
             parsed_data = self.parse_bismark_report(f['f'], regexes['methextract'])
             s_name = f['s_name']
@@ -116,7 +116,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['methextract'][s_name] = parsed_data
         
         # Find and parse M-bias plot data
-        for f in self.find_log_files('M-bias.txt', filehandles=True):
+        for f in self.find_log_files(config['sp']['bismark']['m_bias'], filehandles=True):
             self.parse_bismark_mbias(f)
         
         if len(self.bismark_data['alignment']) == 0 and len(self.bismark_data['dedup']) == 0 and len(self.bismark_data['methextract']) == 0:

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Bowtie reports
         self.bowtie_data = dict()
-        for f in self.find_log_files(config['sp']['bowtie']):
+        for f in self.find_log_files(config.sp['bowtie']):
             parsed_data = self.parse_bowtie_logs(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.bowtie_data:

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Bowtie reports
         self.bowtie_data = dict()
-        for f in self.find_log_files(contents_match='# reads processed:'):
+        for f in self.find_log_files(config['sp']['bowtie']):
             parsed_data = self.parse_bowtie_logs(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.bowtie_data:

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -24,7 +24,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Bowtie 2 reports
         self.bowtie2_data = dict()
-        for f in self.find_log_files(config['sp']['bowtie2']):
+        for f in self.find_log_files(config.sp['bowtie2']):
             parsed_data = self.parse_bowtie2_logs(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.bowtie2_data:

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -24,7 +24,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Bowtie 2 reports
         self.bowtie2_data = dict()
-        for f in self.find_log_files(contents_match='reads; of these:'):
+        for f in self.find_log_files(config['sp']['bowtie2']):
             parsed_data = self.parse_bowtie2_logs(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.bowtie2_data:

--- a/multiqc/modules/cutadapt/cutadapt.py
+++ b/multiqc/modules/cutadapt/cutadapt.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.cutadapt_length_exp = dict()
         self.cutadapt_length_obsexp = dict()
         
-        for f in self.find_log_files(contents_match='This is cutadapt', filehandles=True):
+        for f in self.find_log_files(config['sp']['cutadapt'], filehandles=True):
             self.parse_cutadapt_logs(f)        
 
         if len(self.cutadapt_data) == 0:

--- a/multiqc/modules/cutadapt/cutadapt.py
+++ b/multiqc/modules/cutadapt/cutadapt.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.cutadapt_length_exp = dict()
         self.cutadapt_length_obsexp = dict()
         
-        for f in self.find_log_files(config['sp']['cutadapt'], filehandles=True):
+        for f in self.find_log_files(config.sp['cutadapt'], filehandles=True):
             self.parse_cutadapt_logs(f)        
 
         if len(self.cutadapt_data) == 0:

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any FastQ Screen reports
         self.fq_screen_data = dict()
         self.num_orgs = 0
-        for f in self.find_log_files('_screen.txt', filehandles=True):
+        for f in self.find_log_files(config['sp']['fastq_screen'], filehandles=True):
             parsed_data = self.parse_fqscreen(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.fq_screen_data:

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any FastQ Screen reports
         self.fq_screen_data = dict()
         self.num_orgs = 0
-        for f in self.find_log_files(config['sp']['fastq_screen'], filehandles=True):
+        for f in self.find_log_files(config.sp['fastq_screen'], filehandles=True):
             parsed_data = self.parse_fqscreen(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.fq_screen_data:

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -41,12 +41,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.fastqc_statuses = defaultdict(lambda: defaultdict())
         
         # Find and parse unzipped FastQC reports
-        for f in self.find_log_files('fastqc_data.txt'):
+        for f in self.find_log_files(config['sp']['fastqc']['data']):
             s_name = self.clean_s_name(os.path.basename(f['root']), os.path.dirname(f['root']))
             self.parse_fastqc_report(f['f'], s_name, f['root'])
         
         # Find and parse zipped FastQC reports
-        for f in self.find_log_files('_fastqc.zip', filecontents=False):
+        for f in self.find_log_files(config['sp']['fastqc']['zip'], filecontents=False):
             s_name = f['fn'].rstrip('_fastqc.zip')
             try:
                 fqc_zip = zipfile.ZipFile(os.path.join(f['root'], f['fn']))

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -41,12 +41,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.fastqc_statuses = defaultdict(lambda: defaultdict())
         
         # Find and parse unzipped FastQC reports
-        for f in self.find_log_files(config['sp']['fastqc']['data']):
+        for f in self.find_log_files(config.sp['fastqc']['data']):
             s_name = self.clean_s_name(os.path.basename(f['root']), os.path.dirname(f['root']))
             self.parse_fastqc_report(f['f'], s_name, f['root'])
         
         # Find and parse zipped FastQC reports
-        for f in self.find_log_files(config['sp']['fastqc']['zip'], filecontents=False):
+        for f in self.find_log_files(config.sp['fastqc']['zip'], filecontents=False):
             s_name = f['fn'].rstrip('_fastqc.zip')
             try:
                 fqc_zip = zipfile.ZipFile(os.path.join(f['root'], f['fn']))

--- a/multiqc/modules/featureCounts/feature_counts.py
+++ b/multiqc/modules/featureCounts/feature_counts.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any featureCounts reports
         self.featurecounts_data = dict()
-        for f in self.find_log_files('_counts.txt.summary'):
+        for f in self.find_log_files(config['sp']['featurecounts']):
             parsed_data = self.parse_featurecounts_report(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.featurecounts_data:

--- a/multiqc/modules/featureCounts/feature_counts.py
+++ b/multiqc/modules/featureCounts/feature_counts.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any featureCounts reports
         self.featurecounts_data = dict()
-        for f in self.find_log_files(config['sp']['featurecounts']):
+        for f in self.find_log_files(config.sp['featurecounts']):
             parsed_data = self.parse_featurecounts_report(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.featurecounts_data:

--- a/multiqc/modules/picard/picard.py
+++ b/multiqc/modules/picard/picard.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
         info="is a set of Java command line tools for manipulating high-"\
         "throughput sequencing data.")
         
-        sp = config['sp']['fastqc']['picard']
+        sp = config.sp['picard']
 
         #### MarkDuplicates reports
         self.picard_dupMetrics_data = dict()

--- a/multiqc/modules/picard/picard.py
+++ b/multiqc/modules/picard/picard.py
@@ -22,17 +22,19 @@ class MultiqcModule(BaseMultiqcModule):
         href='http://broadinstitute.github.io/picard/', 
         info="is a set of Java command line tools for manipulating high-"\
         "throughput sequencing data.")
+        
+        sp = config['sp']['fastqc']['picard']
 
         #### MarkDuplicates reports
         self.picard_dupMetrics_data = dict()
-        for f in self.find_log_files(contents_match='picard.sam.MarkDuplicates', filehandles=True):
+        for f in self.find_log_files(sp['markdups'], filehandles=True):
             self.parse_picard_dupMetrics(f)
         
         #### CollectInsertSizeMetrics reports
         self.picard_insertSize_data = dict()
         self.picard_insertSize_histogram = dict()
         self.picard_insertSize_medians = dict()
-        for f in self.find_log_files(contents_match='picard.analysis.CollectInsertSizeMetrics', filehandles=True):
+        for f in self.find_log_files(sp['insertsize'], filehandles=True):
             self.parse_picard_insertSize(f)
         # Calculate summed median values for all read orientations
         for s_name in self.picard_insertSize_histogram:
@@ -46,12 +48,12 @@ class MultiqcModule(BaseMultiqcModule):
         
         #### CollectGcBias reports
         self.picard_GCbias_data = dict()
-        for f in self.find_log_files(contents_match='picard.analysis.CollectGcBiasMetrics', filehandles=True):
+        for f in self.find_log_files(sp['gcbias'], filehandles=True):
             self.parse_picard_GCbiasMetrics(f)
         
         #### CalculateHsMetric
         self.picard_HsMetrics_data = dict()
-        for f in self.find_log_files(contents_match='picard.analysis.directed.HsMetrics', filehandles=True):
+        for f in self.find_log_files(sp['hsmetrics'], filehandles=True):
             self.parse_picard_HsMetrics(f)
         
         num_reports = ( len(self.picard_dupMetrics_data) + len(self.picard_insertSize_data) +

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any Preseq reports
         self.preseq_data = dict()
         self.total_max = 0
-        for f in self.find_log_files(config['sp']['preseq']):
+        for f in self.find_log_files(config.sp['preseq']):
             parsed_data = self.parse_preseq_logs(f)
             if parsed_data is not None:
                 self.preseq_data[f['s_name']] = parsed_data

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any Preseq reports
         self.preseq_data = dict()
         self.total_max = 0
-        for f in self.find_log_files(contents_match='TOTAL_READS	EXPECTED_DISTINCT'):
+        for f in self.find_log_files(config['sp']['preseq']):
             parsed_data = self.parse_preseq_logs(f)
             if parsed_data is not None:
                 self.preseq_data[f['s_name']] = parsed_data

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -27,12 +27,12 @@ def parse_reports(self):
     # Find QualiMap reports
     for directory in config.analysis_dir:
         for root, dirnames, filenames in os.walk(directory, followlinks=True):
-            raw_data_dir = 'raw_data'
+            raw_data_dir = config['sp']['qualimap']['raw_data']
             for d in dirnames:
                 if raw_data_dir in d:
                     raw_data_dir = d
-            if 'genome_results.txt' in filenames and raw_data_dir in dirnames:
-                with io.open(os.path.join(root, 'genome_results.txt'), 'r') as gr:
+            if config['sp']['qualimap']['genome_results'] in filenames and raw_data_dir in dirnames:
+                with io.open(os.path.join(root, config['sp']['qualimap']['genome_results']), 'r') as gr:
                     for l in gr:
                         
                         if 'bam file' in l:
@@ -49,7 +49,7 @@ def parse_reports(self):
                     log.debug("Duplicate sample name found! Overwriting: {}".format(s_name))
         
                 #### Coverage histogram
-                cov_report = os.path.join(root, raw_data_dir, 'coverage_histogram.txt')
+                cov_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['coverage'])
                 if os.path.exists(cov_report):
                     self.qualimap_bamqc_coverage_hist[s_name] = {}
                     with io.open(cov_report, 'r') as fh:
@@ -73,7 +73,7 @@ def parse_reports(self):
                 
                 
                 #### Insert size histogram
-                ins_size = os.path.join(root, raw_data_dir, 'insert_size_histogram.txt')
+                ins_size = os.path.join(root, raw_data_dir, config['sp']['qualimap']['insert_size'])
                 if os.path.exists(ins_size):
                     self.qualimap_bamqc_insert_size_hist[s_name] = {}
                     zero_insertsize = 0
@@ -101,7 +101,7 @@ def parse_reports(self):
                 
                 
                 #### Genome Fraction Coverage
-                frac_cov = os.path.join(root, raw_data_dir, 'genome_fraction_coverage.txt')
+                frac_cov = os.path.join(root, raw_data_dir, config['sp']['qualimap']['genome_fraction'])
                 if os.path.exists(frac_cov):
                     self.qualimap_bamqc_genome_fraction_cov[s_name] = {}
                     thirty_x_pc = 100
@@ -121,7 +121,7 @@ def parse_reports(self):
                 
                 
                 #### GC Distribution
-                gc_report = os.path.join(root, raw_data_dir, 'mapped_reads_gc-content_distribution.txt')
+                gc_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['gc_dist'])
                 if os.path.exists(gc_report):
                     self.qualimap_bamqc_gc_content_dist[s_name] = {}
                     avg_gc = 0

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -24,15 +24,17 @@ def parse_reports(self):
     self.qualimap_bamqc_genome_fraction_cov = dict()
     self.qualimap_bamqc_gc_content_dist = dict()
     
+    sp = config.sp['qualimap']['bamqc']
+    
     # Find QualiMap reports
     for directory in config.analysis_dir:
         for root, dirnames, filenames in os.walk(directory, followlinks=True):
-            raw_data_dir = config['sp']['qualimap']['raw_data']
+            raw_data_dir = sp['raw_data']
             for d in dirnames:
                 if raw_data_dir in d:
                     raw_data_dir = d
-            if config['sp']['qualimap']['genome_results'] in filenames and raw_data_dir in dirnames:
-                with io.open(os.path.join(root, config['sp']['qualimap']['genome_results']), 'r') as gr:
+            if sp['genome_results'] in filenames and raw_data_dir in dirnames:
+                with io.open(os.path.join(root, sp['genome_results']), 'r') as gr:
                     for l in gr:
                         
                         if 'bam file' in l:
@@ -49,7 +51,7 @@ def parse_reports(self):
                     log.debug("Duplicate sample name found! Overwriting: {}".format(s_name))
         
                 #### Coverage histogram
-                cov_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['coverage'])
+                cov_report = os.path.join(root, raw_data_dir, sp['coverage'])
                 if os.path.exists(cov_report):
                     self.qualimap_bamqc_coverage_hist[s_name] = {}
                     with io.open(cov_report, 'r') as fh:
@@ -73,7 +75,7 @@ def parse_reports(self):
                 
                 
                 #### Insert size histogram
-                ins_size = os.path.join(root, raw_data_dir, config['sp']['qualimap']['insert_size'])
+                ins_size = os.path.join(root, raw_data_dir, sp['insert_size'])
                 if os.path.exists(ins_size):
                     self.qualimap_bamqc_insert_size_hist[s_name] = {}
                     zero_insertsize = 0
@@ -101,7 +103,7 @@ def parse_reports(self):
                 
                 
                 #### Genome Fraction Coverage
-                frac_cov = os.path.join(root, raw_data_dir, config['sp']['qualimap']['genome_fraction'])
+                frac_cov = os.path.join(root, raw_data_dir, sp['genome_fraction'])
                 if os.path.exists(frac_cov):
                     self.qualimap_bamqc_genome_fraction_cov[s_name] = {}
                     thirty_x_pc = 100
@@ -121,7 +123,7 @@ def parse_reports(self):
                 
                 
                 #### GC Distribution
-                gc_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['gc_dist'])
+                gc_report = os.path.join(root, raw_data_dir, sp['gc_dist'])
                 if os.path.exists(gc_report):
                     self.qualimap_bamqc_gc_content_dist[s_name] = {}
                     avg_gc = 0

--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -25,12 +25,12 @@ def parse_reports(self):
     # Find QualiMap reports
     for directory in config.analysis_dir:
         for root, dirnames, filenames in os.walk(directory, followlinks=True):
-            raw_data_dir = 'raw_data'
+            raw_data_dir = config['sp']['qualimap']['raw_data']
             for d in dirnames:
                 if raw_data_dir in d:
                     raw_data_dir = d
-            if 'rnaseq_qc_results.txt' in filenames and raw_data_dir in dirnames:
-                with io.open(os.path.join(root, 'rnaseq_qc_results.txt'), 'r') as gr:
+            if config['sp']['qualimap']['rnaseq_results'] in filenames and raw_data_dir in dirnames:
+                with io.open(os.path.join(root, config['sp']['qualimap']['rnaseq_results']), 'r') as gr:
                     for l in gr:
                         rhs = l.split(' = ')[-1].replace(',','')
                         num = rhs.split('(')[0]
@@ -61,7 +61,7 @@ def parse_reports(self):
                             self.qualimap_rnaseq_gorigin[s_name]['reads_aligned_overlapping_exon'] = float( num )
                 
                 #### Coverage profile
-                cov_report = os.path.join(root, raw_data_dir, 'coverage_profile_along_genes_(total).txt')
+                cov_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['coverage'])
                 if os.path.exists(cov_report):
                     self.qualimap_rnaseq_cov_hist[s_name] = {}
                     with io.open(cov_report, 'r') as fh:

--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -22,15 +22,17 @@ def parse_reports(self):
     self.qualimap_rnaseq_gorigin = dict()
     self.qualimap_rnaseq_cov_hist = dict()
     
+    sp = config.sp['qualimap']['rnaseq']
+    
     # Find QualiMap reports
     for directory in config.analysis_dir:
         for root, dirnames, filenames in os.walk(directory, followlinks=True):
-            raw_data_dir = config['sp']['qualimap']['raw_data']
+            raw_data_dir = sp['raw_data']
             for d in dirnames:
                 if raw_data_dir in d:
                     raw_data_dir = d
-            if config['sp']['qualimap']['rnaseq_results'] in filenames and raw_data_dir in dirnames:
-                with io.open(os.path.join(root, config['sp']['qualimap']['rnaseq_results']), 'r') as gr:
+            if sp['rnaseq_results'] in filenames and raw_data_dir in dirnames:
+                with io.open(os.path.join(root, sp['rnaseq_results']), 'r') as gr:
                     for l in gr:
                         rhs = l.split(' = ')[-1].replace(',','')
                         num = rhs.split('(')[0]
@@ -61,7 +63,7 @@ def parse_reports(self):
                             self.qualimap_rnaseq_gorigin[s_name]['reads_aligned_overlapping_exon'] = float( num )
                 
                 #### Coverage profile
-                cov_report = os.path.join(root, raw_data_dir, config['sp']['qualimap']['coverage'])
+                cov_report = os.path.join(root, raw_data_dir, sp['coverage'])
                 if os.path.exists(cov_report):
                     self.qualimap_rnaseq_cov_hist[s_name] = {}
                     with io.open(cov_report, 'r') as fh:

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any STAR reports
         self.star_data = dict()
-        for f in self.find_log_files('Log.final.out'):
+        for f in self.find_log_files(config['sp']['star']):
             parsed_data = self.parse_star_report(f['f'])
             if parsed_data is not None:
                 s_name = f['s_name'].split('Log.final.out', 1)[0]

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any STAR reports
         self.star_data = dict()
-        for f in self.find_log_files(config['sp']['star']):
+        for f in self.find_log_files(config.sp['star']):
             parsed_data = self.parse_star_report(f['f'])
             if parsed_data is not None:
                 s_name = f['s_name'].split('Log.final.out', 1)[0]

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Tophat reports
         self.tophat_data = dict()
-        for f in self.find_log_files('align_summary.txt'):
+        for f in self.find_log_files(config['sp']['tophat']):
             parsed_data = self.parse_tophat_log(f['f'])
             if parsed_data is not None:
                 if f['s_name'] == "align_summary.txt":

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Tophat reports
         self.tophat_data = dict()
-        for f in self.find_log_files(config['sp']['tophat']):
+        for f in self.find_log_files(config.sp['tophat']):
             parsed_data = self.parse_tophat_log(f['f'])
             if parsed_data is not None:
                 if f['s_name'] == "align_summary.txt":

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -43,7 +43,7 @@ log_filesize_limit = 1000000
 # Module fn search patterns
 #######################
 # Load here so that they can be overwritten by user configs
-searchp_fn = os.path.join( os.path.dirname(__FILE__), 'search_patterns.yaml')
+searchp_fn = os.path.join( MULTIQC_DIR, 'utils', 'search_patterns.yaml')
 with open(searchp_fn) as f:
     sp = yaml.load(f)
 

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -39,6 +39,13 @@ report_id = 'mqc_report_{}'.format(''.join(random.sample('abcdefghijklmnopqrstuv
 num_datasets_plot_limit = 50
 log_filesize_limit = 1000000
 
+#######################
+# Module fn search patterns
+#######################
+# Load here so that they can be overwritten by user configs
+searchp_fn = os.path.join( os.path.dirname(__FILE__), 'search_patterns.yaml')
+with open(searchp_fn) as f:
+    sp = yaml.load(f)
 
 #######################
 # Available modules

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -1,0 +1,18 @@
+
+# MultiQC search patterns.
+# Default configurations for how modules can find their log files.
+# Loaded by the config module so that these patterns can be overwritten in user config files.
+
+bismark:
+    align:
+        fn:
+            - _PE_report.txt
+            - _SE_report.txt
+        # contents: Writing a C -> T converted version of the input file
+    dedup:
+        fn: .deduplication_report.txt
+    meth_extract:
+        fn: _splitting_report.txt
+        # contents: Bismark Extractor Version
+    m_bias:
+        fn: M-bias.txt

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -19,7 +19,7 @@ bismark:
 bowtie:
     contents: '# reads processed:'
 bowtie2:
-    contents: reads; of these:
+    contents: 'reads; of these:'
 cutadapt:
     contents: This is cutadapt
 fastq_screen:
@@ -41,7 +41,7 @@ picard:
     hsmetrics:
         contents: picard.analysis.directed.HsMetrics
 preseq:
-    contents: TOTAL_READS	EXPECTED_DISTINCT
+    contents: 'TOTAL_READS	EXPECTED_DISTINCT'
 qualimap:
     bamqc:
         raw_data: raw_data

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -16,3 +16,45 @@ bismark:
         # contents: Bismark Extractor Version
     m_bias:
         fn: M-bias.txt
+bowtie:
+    contents: '# reads processed:'
+bowtie2:
+    contents: reads; of these:
+cutadapt:
+    contents: This is cutadapt
+fastq_screen:
+    fn: _screen.txt
+fastqc:
+    data:
+        fn: fastqc_data.txt
+    zip:
+        fn: _fastqc.zip
+featurecounts:
+    fn: _counts.txt.summary
+picard:
+    markdups:
+        contents: picard.sam.MarkDuplicates
+    insertsize:
+        contents: picard.analysis.CollectInsertSizeMetrics
+    gcbias:
+        contents: picard.analysis.CollectGcBiasMetrics
+    hsmetrics:
+        contents: picard.analysis.directed.HsMetrics
+preseq:
+    contents: TOTAL_READS	EXPECTED_DISTINCT
+qualimap:
+    bamqc:
+        raw_data: raw_data
+        genome_results: genome_results.txt
+        coverage: coverage_histogram.txt
+        insert_size: insert_size_histogram.txt
+        genome_fraction: genome_fraction_coverage.txt
+        gc_dist: mapped_reads_gc-content_distribution.txt
+    rnaseq:
+        raw_data: raw_data
+        rnaseq_results: rnaseq_qc_results.txt
+        coverage: coverage_profile_along_genes_(total).txt
+star:
+    fn: Log.final.out
+tophat:
+    fn: align_summary.txt

--- a/multiqc_config.yaml.example
+++ b/multiqc_config.yaml.example
@@ -53,3 +53,13 @@ log_filesize_limit: 1000000
 # this, the user will need to click 'plot graph' to see the data.
 # This is to prevent very large graphs from locking up the browser on load.
 num_datasets_plot_limit: 50
+
+# Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
+# for the defaults. Remove a default by setting it to None.
+sp:
+    bismark:
+        meth_extract:
+            contents: Bismark Extractor Version
+
+
+


### PR DESCRIPTION
New method to allow module log file searching customisation.

Modules now load from a yaml file containing defaults. This is loaded into `config`, which can be overwritten in user config files.