### PR TITLE
UTF-8 as default for Python 2

### DIFF
--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -26,13 +26,12 @@ try:
     from urllib.request import urlopen #py3
 except ImportError:
     from urllib import urlopen #py2
+    # Use UTF-8 encoding by default
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 
 from multiqc import logger, __version__
 from multiqc.utils import report, plugin_hooks, config, log
-
-# Use UTF-8 encoding by default
-reload(sys)
-sys.setdefaultencoding('utf8')
 
 plugin_hooks.mqc_trigger('config_loaded') 
 

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -30,6 +30,10 @@ except ImportError:
 from multiqc import logger, __version__
 from multiqc.utils import report, plugin_hooks, config, log
 
+# Use UTF-8 encoding by default
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 plugin_hooks.mqc_trigger('config_loaded') 
 
 @click.command(


### PR DESCRIPTION
Fixes #172 (hopefully)

Also added [new test cases](https://github.com/ewels/MultiQC_TestData/commit/6f359c6743b1cb224bcb4e5862fda0448912aa6c) to MultiQC_TestData to keep testing this in the future.