### PR TITLE
Qualimap: handle outputs with infinity

### DIFF
--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -51,7 +51,11 @@ def parse_reports(self):
                         if 'aligned to genes' in l:
                             self.general_stats[s_name]['reads_aligned_genes'] = float( num )
                         if "5'-3' bias" in l:
-                            self.general_stats[s_name]['5_3_bias'] = float( num )
+                            try:
+                                self.general_stats[s_name]['5_3_bias'] = float( num )
+                            # Qualimap reports infinity (\u221e) when 3' bias denominator is zero
+                            except UnicodeEncodeError:
+                                pass
                         
                         # Reads genomic origin section
                         if 'exonic' in l:


### PR DESCRIPTION
Phil -- thanks for MultiQC. It's brilliant and looking forward to moving to it in bcbio. This is a small fix for an issue I ran into when testing.

For 5'/3' ratios where the 3' number is zero, Qualimap reports a
unicode infinity character. This occurs on small test cases, but
breaks the current qualimap parsing due to looking for an integer.
This fix leaves it unset in this case.