### PR TITLE
Allow a file with a list of files as input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - multiqc data -f --flat
   - multiqc data -o tests/multiqc_report_dev -t default_dev -k json
   - multiqc data -o tests/multiqc_report_geo -t geo -k yaml -v
+  - multiqc --is-file-list data/special_cases/file_list.txt 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ script:
   - multiqc data -f --flat
   - multiqc data -o tests/multiqc_report_dev -t default_dev -k json
   - multiqc data -o tests/multiqc_report_geo -t geo -k yaml -v
-  - multiqc --is-file-list data/special_cases/file_list.txt 
+  - multiqc --is-file-list data/special_cases/file_list.txt -f
   

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,12 @@ multiqc data/ --ignore *_R2*
 multiqc . --ignore run_two/
 ```
 
+You can point to a file that contains a list of file paths, one per row, and MultiQC
+will search there.
+```
+multiqc --is-file-list my_file_list.txt
+```
+
 ## Renaming reports
 The report is called `multiqc_report.html` by default. Tab-delimited data files
 are created in `multiqc_data/`, containing additional information.

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -27,6 +27,7 @@ modules_dir = os.path.join(MULTIQC_DIR, 'modules')
 creation_date = datetime.now().strftime("%Y-%m-%d, %H:%m")
 working_dir = os.getcwd()
 analysis_dir = [os.getcwd()]
+is_file_list = False
 output_dir = os.path.realpath(os.getcwd())
 output_fn_name = 'multiqc_report.html'
 data_dir_name = 'multiqc_data'

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -44,6 +44,12 @@ plugin_hooks.mqc_trigger('config_loaded')
                     required = True,
                     metavar = "<analysis directory>"
 )
+
+@click.option('-l', '--is-file-list',
+                    is_flag = True,
+                    help = "The file given as analysis_dir has a list of file paths "
+                           "to be searched, one per row"
+)
 @click.option('-f', '--force',
                     is_flag = True,
                     help = "Overwrite any existing reports"
@@ -125,7 +131,7 @@ plugin_hooks.mqc_trigger('config_loaded')
 )
 @click.version_option(__version__)
 
-def multiqc(analysis_dir, dirs, no_clean_sname, title, template, module, exclude, outdir, ignore, filename, 
+def multiqc(analysis_dir, dirs, is_file_list, no_clean_sname, title, template, module, exclude, outdir, ignore, filename, 
 make_data_dir, data_format, zip_data_dir, force, plots_flat, plots_interactive, config_file, verbose, quiet, **kwargs):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
     
@@ -181,6 +187,22 @@ make_data_dir, data_format, zip_data_dir, force, plots_flat, plots_interactive, 
     config.plots_force_flat = plots_flat
     config.plots_force_interactive = plots_interactive
     config.kwargs = kwargs # Plugin command line options
+
+    # Add files if --is-file-list option is given
+    if is_file_list:
+        if len(analysis_dir) > 1:
+            raise ValueError("If --is-file-list is giving, analysis_dir should have only one plain text file.")
+        if os.path.isdir(analysis_dir[0]):
+            raise ValueError("If --is-file-list is giving, analysis_dir should be a plain text file.")
+        config.analysis_dir = ()
+        with (open(analysis_dir[0])) as in_handle:
+            for line in in_handle:
+                if os.path.exists(line.strip()):
+                    config.analysis_dir += (os.path.abspath(line.strip()),)
+        if len(config.analysis_dir) == 0:
+            logger.warning("No files were added from %s using --is-file-list option." % analysis_dir[0])
+            logger.watning("Please, check that %s contains correct file paths." % analysis_dir[0])
+
     if no_clean_sname:
         config.fn_clean_exts = []
         logger.info("Not cleaning sample names")

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -192,16 +192,14 @@ make_data_dir, data_format, zip_data_dir, force, plots_flat, plots_interactive, 
     if is_file_list:
         if len(analysis_dir) > 1:
             raise ValueError("If --is-file-list is giving, analysis_dir should have only one plain text file.")
-        if os.path.isdir(analysis_dir[0]):
-            raise ValueError("If --is-file-list is giving, analysis_dir should be a plain text file.")
         config.analysis_dir = ()
         with (open(analysis_dir[0])) as in_handle:
             for line in in_handle:
                 if os.path.exists(line.strip()):
                     config.analysis_dir += (os.path.abspath(line.strip()),)
         if len(config.analysis_dir) == 0:
-            logger.warning("No files were added from %s using --is-file-list option." % analysis_dir[0])
-            logger.watning("Please, check that %s contains correct file paths." % analysis_dir[0])
+            logger.warning("No files were added from {} using --is-file-list option.".format(analysis_dir[0]))
+            logger.warning("Please, check that {} contains correct file paths.".format(analysis_dir[0]))
 
     if no_clean_sname:
         config.fn_clean_exts = []

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -198,8 +198,9 @@ make_data_dir, data_format, zip_data_dir, force, plots_flat, plots_interactive, 
                 if os.path.exists(line.strip()):
                     config.analysis_dir += (os.path.abspath(line.strip()),)
         if len(config.analysis_dir) == 0:
-            logger.warning("No files were added from {} using --is-file-list option.".format(analysis_dir[0]))
-            logger.warning("Please, check that {} contains correct file paths.".format(analysis_dir[0]))
+            logger.error("No files were added from {} using --is-file-list option.".format(analysis_dir[0]))
+            logger.error("Please, check that {} contains correct file paths.".format(analysis_dir[0]))
+            raise ValueError("Any files to be searched.")
 
     if no_clean_sname:
         config.fn_clean_exts = []


### PR DESCRIPTION
Hi!

this is a suggestion PR, since probably you have a better idea how to integrate it.

But we had some problems with a person with so many arguments (files) in the command line that it cannot run. (https://github.com/chapmanb/bcbio-nextgen/issues/1380)

In bcbio, we are moving to CWL, what has many advantages, but one of the inconvenient is that we cannot use commands assuming that we are in the same machine or in a standard file system. So we can not use `multiqc qc/*` etc. Instead we are passing the specific path.

So, @chapmanb thought that maybe it would be good to have an argument to allow a file that contains a list of files to be used by multiqc.

As I said, this is a suggestion, because I like to offer some kind of solution instead of just asking, but feel free to adapt however you think is better.

thanks! 

PS: another problem it is if 700 samples make any sense inside multiqc, but I think we can change things to allow a proper report in the future.
