### PR TITLE
use `ID` to get `s_name`

### DIFF
--- a/multiqc/modules/samblaster/samblaster.py
+++ b/multiqc/modules/samblaster/samblaster.py
@@ -66,7 +66,7 @@ class MultiqcModule(BaseMultiqcModule):
         Grab the name from the RG tag of the preceding bwa command """
         dups_regex = "samblaster: (Removed|Marked) (\d+) of (\d+) \((\d+.\d+)%\) read ids as duplicates"
         input_file_regex = "samblaster: Opening (\S+) for read."
-        rgtag_name_regex = "\\\\tSM:(\S*?)\\\\t"
+        rgtag_name_regex = "\\\\tID:(\S*?)\\\\t"
         data = {}
         s_name = None
         fh = f['f']


### PR DESCRIPTION
`SM` can be shared between libraries if multiple libraries are generated from a single biological sample. Duplicates should be reported as fine-grained as possible.