### PR TITLE
picard 2.3.0 has renamed `CalculateHsMetrics` to `c`

### DIFF
--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -68,7 +68,8 @@ def parse_reports(self):
         keys = None
         for l in f['f']:
             # New log starting
-            if 'picard.analysis.directed.CalculateHsMetrics' in l and 'INPUT' in l:
+            if 'picard.analysis.directed.CalculateHsMetrics' in l or \
+               'picard.analysis.directed.CollectHsMetrics' in l and 'INPUT' in l:
                 s_name = None
                 keys = None
                 


### PR DESCRIPTION
...to `CollectHsMetrics`.

... therefore in order to support both, the module needs to check for both those strings. AFAIK, the output data is the same in both `CalculateHsMetrics ` and `CollectHsMetrics `.