### PR TITLE
Added flagstat submodule to samtools

### DIFF
--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from Samtools flagstat """
+
+import logging
+from collections import OrderedDict
+from multiqc import config, plots
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+def parse_reports(self):
+    """ Find Samtools flagstat logs and parse their data """
+
+    self.samtools_flagstat = dict()
+    for f in self.find_log_files(config.sp['samtools']['flagstat']):
+        parsed_data = dict()
+        for line in f['f'].splitlines():
+            if not line.startswith("SN"):
+                continue
+            sections = line.split("\t")
+            field = sections[1].strip()[:-1]
+            field = field.replace(' ','_')
+            value = float(sections[2].strip())
+            parsed_data[field] = value
+        if len(parsed_data) > 0:
+            
+            # Work out some percentages
+            if 'raw_total_sequences' in parsed_data:
+                for k in list(parsed_data.keys()):
+                    if k.startswith('reads_') and k != 'raw_total_sequences':
+                        parsed_data['{}_percent'.format(k)] = (parsed_data[k] / parsed_data['raw_total_sequences']) * 100
+            
+            if f['s_name'] in self.samtools_flagstat:
+                log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))
+            self.add_data_source(f)
+            self.samtools_flagstat[f['s_name']] = parsed_data
+
+    if len(self.samtools_flagstat) > 0:
+
+        # Write parsed report data to a file
+        self.write_data_file(self.samtools_flagstat, 'multiqc_samtools_flagstat')
+
+        # General Stats Table
+        self.general_flagstat_headers['error_rate'] = {
+            'title': 'Error rate',
+            'description': 'Error rate using CIGAR',
+            'min': 0,
+            'max': 100,
+            'suffix': '%',
+            'scale': 'OrRd',
+            'format': '{:.2f}%',
+            'modify': lambda x: x * 100.0
+        }
+        self.general_flagstat_headers['non-primary_alignments'] = {
+            'title': 'M Non-Primary',
+            'description': 'Non-primary alignments (millions)',
+            'min': 0,
+            'scale': 'PuBu',
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
+        }
+        self.general_flagstat_headers['reads_mapped'] = {
+            'title': 'M Reads Mapped',
+            'description': 'Reads Mapped in the bam file',
+            'min': 0,
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
+        }
+        self.general_flagstat_headers['reads_mapped_percent'] = {
+            'title': '% Mapped',
+            'description': '% Mapped Reads',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'scale': 'RdYlGn',
+            'format': '{:.1f}%'
+        }
+        self.general_flagstat_headers['raw_total_sequences'] = {
+            'title': 'M Total seqs',
+            'description': 'Total sequences in the bam file',
+            'min': 0,
+            'modify': lambda x: x / 1000000,
+            'shared_key': 'read_count'
+        }
+        for s_name in self.samtools_flagstat:
+            if s_name not in self.general_flagstat_data:
+                self.general_flagstat_data[s_name] = dict()
+            self.general_flagstat_data[s_name].update( self.samtools_flagstat[s_name] )
+        
+        # Make dot plot of counts
+        keys = OrderedDict()
+        reads = {
+            'min': 0,
+            'modify': lambda x: float(x) / 1000000.0,
+            'suffix': 'M reads',
+            'decimalPlaces': 2,
+            'shared_key': 'read_count'
+        }
+        bases = {
+            'min': 0,
+            'modify': lambda x: float(x) / 1000000.0,
+            'suffix': 'M bases',
+            'decimalPlaces': 2,
+            'shared_key': 'base_count'
+        }
+        keys['raw_total_sequences'] = dict(reads, **{'title': 'Total sequences' })
+        keys['reads_mapped'] = dict(reads, **{'title': 'Mapped reads' })
+        keys['reads_mapped_and_paired'] = dict(reads, **{'title': 'Mapped &amp; paired', 'description': 'Paired-end technology bit set + both mates mapped' })
+        keys['reads_properly_paired'] = dict(reads, **{'title': 'Properly paired', 'description': 'Proper-pair bit set' })
+        keys['reads_duplicated'] = dict(reads, **{'title': 'Duplicated', 'description': 'PCR or optical duplicate bit set' })
+        keys['reads_unmapped'] = dict(reads, **{'title': 'Unmapped reads' })
+        keys['reads_QC_failed'] = dict(reads, **{'title': 'QC Failed'})
+        keys['reads_MQ0'] = dict(reads, **{'title': 'Reads MQ0', 'description': 'Reads mapped and MQ=0' })
+        keys['bases_mapped_(cigar)'] = dict(bases, **{'title': 'Mapped bases (cigar)', 'description': 'Mapped bases (cigar)' })
+        keys['bases_trimmed'] = dict(bases, **{'title': 'Bases Trimmed' })
+        keys['bases_duplicated'] = dict(bases, **{'title': 'Duplicated bases' })
+        keys['pairs_on_different_chromosomes'] = dict(reads, **{'title': 'Diff chromosomes', 'description': 'Pairs on different chromosomes' })
+        keys['pairs_with_other_orientation'] = dict(reads, **{'title': 'Other orientation', 'description': 'Pairs with other orientation' })
+        keys['inward_oriented_pairs'] = dict(reads, **{'title': 'Inward pairs', 'description': 'Inward oriented pairs' })
+        keys['outward_oriented_pairs'] = dict(reads, **{'title': 'Outward pairs', 'description': 'Outward oriented pairs' })
+        
+        self.sections.append({
+            'name': 'Samtools flagstat output',
+            'anchor': 'samtools-flagstat',
+            'content': '<p>This module parses the output from <code>samtools flagstat</code>. All numbers in millions.</p>' +
+                        plots.beeswarm.plot(self.samtools_flagstat, keys, {'id': 'samtools-flagstat-dp'})
+        })
+    
+    # Return the number of logs that were found
+    return len(self.samtools_flagstat)
+
+

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -36,11 +36,7 @@ def parse_single_report(file_thing):
 
     re_groups = ['passed', 'failed', 'passed_pct', 'failed_pct']
     for k, r in REGEXES.items():
-        try: 
-            r_search = re.search(r, file_thing, re.MULTILINE)
-        except:
-            print r
-            raise
+        r_search = re.search(r, file_thing, re.MULTILINE)
         if r_search:
             for i,j in enumerate(re_groups):
                 try:

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -57,23 +57,6 @@ def parse_reports(self):
         # Write parsed report data to a file (restructure first)
         to_write = defaultdict(dict)
         self.write_data_file(self.samtools_flagstat, 'multiqc_samtools_flagstat')
-
-        """
-        LABELS= {1: 'total', 
-                2: 'secondary',
-                3: 'supplementary', 
-                4: 'duplicates', 
-                5: 'mapped', 
-                6: 'paired in sequencing', 
-                7: 'read1', 
-                8: 'read2', 
-                9: 'properly paired', 
-                10: 'with itself and mate mapped', 
-                11: 'singletons',
-                12: 'with mate mapped to a different chr', 
-                13: 'with make mapped to a different chr (mapQ >= 5)', 
-                }
-        """
         
         # Make dot plot of counts
         keys = OrderedDict()

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -14,19 +14,19 @@ log = logging.getLogger(__name__)
 # flagstat has one thing per line, documented here (search for flagstat):
 # http://www.htslib.org/doc/samtools.html 
 REGEXES = {
-        'total':        r"(\d+) \+ (\d+) in total \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'secondary':    r"(\d+) \+ (\d+) secondary \(([\d\.]+|nan)%:([\d\.]+|nan)%\)",
-        'supplementary': r"(\d+) \+ (\d+) supplementary \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'duplicates':   r"(\d+) \+ (\d+) duplicates \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'mapped':       r"(\d+) \+ (\d+) mapped ( \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'paired in sequencing': r"(\d+) \+ (\d+) paired in sequencing \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'read1':        r"(\d+) \+ (\d+) read1 \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'read2':        r"(\d+) \+ (\d+) read2 \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
+        'total':        r"(\d+) \+ (\d+) in total", 
+        'secondary':    r"(\d+) \+ (\d+) secondary",
+        'supplementary': r"(\d+) \+ (\d+) supplementary", 
+        'duplicates':   r"(\d+) \+ (\d+) duplicates", 
+        'mapped':       r"(\d+) \+ (\d+) mapped \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
+        'paired in sequencing': r"(\d+) \+ (\d+) paired in sequencing", 
+        'read1':        r"(\d+) \+ (\d+) read1", 
+        'read2':        r"(\d+) \+ (\d+) read2", 
         'properly paired': r"(\d+) \+ (\d+) properly paired \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'with itself and mate mapped': r"(\d+) \+ (\d+) with itself and mate mapped \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
+        'with itself and mate mapped': r"(\d+) \+ (\d+) with itself and mate mapped", 
         'singletons':       r"(\d+) \+ (\d+) singletons \(([\d\.]+|nan)%:([\d\.]+|nan)%\)",
-        'with mate mapped to a different chr': r"(\d+) \+ (\d+) with mate mapped to a different chr \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
-        'with mate mapped to a different chr (mapQ >= 5)': r"(\d+) \+ (\d+) with mate mapped to a different chr (mapQ>=5) \(([\d\.]+|nan)%:([\d\.]+|nan)%\)", 
+        'with mate mapped to a different chr': r"(\d+) \+ (\d+) with mate mapped to a different chr",
+        'with mate mapped to a different chr (mapQ >= 5)': r"(\d+) \+ (\d+) with mate mapped to a different chr (mapQ>=5)",
         }
 
 """ Take a filename, parse the data assuming it's a flagstat file
@@ -36,7 +36,11 @@ def parse_single_report(file_thing):
 
     re_groups = ['passed', 'failed', 'passed_pct', 'failed_pct']
     for k, r in REGEXES.items():
-        r_search = re.search(r, file_thing, re.MULTILINE)
+        try: 
+            r_search = re.search(r, file_thing, re.MULTILINE)
+        except:
+            print r
+            raise
         if r_search:
             for i,j in enumerate(re_groups):
                 try:

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -56,14 +56,6 @@ def parse_reports(self):
 
         # Write parsed report data to a file (restructure first)
         to_write = defaultdict(dict)
-        """
-        for k, v in self.samtools_flagstat.items():
-            for key, val in v.items():
-                for m, n in val.items():
-                    to_write[k][key + '_' + m] = n 
-        print to_write.keys()
-        self.write_data_file(to_write, 'multiqc_samtools_flagstat')
-        """
         self.write_data_file(self.samtools_flagstat, 'multiqc_samtools_flagstat')
 
         """
@@ -82,53 +74,6 @@ def parse_reports(self):
                 13: 'with make mapped to a different chr (mapQ >= 5)', 
                 }
         """
-
-        # General Stats Table
-        self.general_stats_headers['total'] = {
-            'title': 'Total reads',
-            'description': 'Error rate using CIGAR',
-            'min': 0,
-            'max': 100,
-            'suffix': '%',
-            'scale': 'OrRd',
-            'format': '{:.2f}%',
-            'modify': lambda x: x * 100.0
-        }
-        self.general_stats_headers['secondary'] = {
-            'title': 'M Non-Primary',
-            'description': 'Non-primary alignments (millions)',
-            'min': 0,
-            'scale': 'PuBu',
-            'modify': lambda x: x / 1000000,
-            'shared_key': 'read_count'
-        }
-        self.general_stats_headers['supplementary'] = {
-            'title': 'M Reads Mapped',
-            'description': 'Reads Mapped in the bam file',
-            'min': 0,
-            'modify': lambda x: x / 1000000,
-            'shared_key': 'read_count'
-        }
-        self.general_stats_headers['duplicates'] = {
-            'title': '% Mapped',
-            'description': '% Mapped Reads',
-            'max': 100,
-            'min': 0,
-            'suffix': '%',
-            'scale': 'RdYlGn',
-            'format': '{:.1f}%'
-        }
-        self.general_stats_headers['mapped'] = {
-            'title': 'M Total seqs',
-            'description': 'Total sequences in the bam file',
-            'min': 0,
-            'modify': lambda x: x / 1000000,
-            'shared_key': 'read_count'
-        }
-        for s_name in self.samtools_flagstat:
-            if s_name not in self.general_stats_data:
-                self.general_stats_data[s_name] = dict()
-            self.general_stats_data[s_name].update( self.samtools_flagstat[s_name] )
         
         # Make dot plot of counts
         keys = OrderedDict()
@@ -139,28 +84,32 @@ def parse_reports(self):
             'decimalPlaces': 2,
             'shared_key': 'read_count'
         }
-        bases = {
-            'min': 0,
-            'modify': lambda x: float(x) / 1000000.0,
-            'suffix': 'M bases',
-            'decimalPlaces': 2,
-            'shared_key': 'base_count'
-        }
-        keys['raw_total_sequences'] = dict(reads, **{'title': 'Total sequences' })
-        keys['reads_mapped'] = dict(reads, **{'title': 'Mapped reads' })
-        keys['reads_mapped_and_paired'] = dict(reads, **{'title': 'Mapped &amp; paired', 'description': 'Paired-end technology bit set + both mates mapped' })
-        keys['reads_properly_paired'] = dict(reads, **{'title': 'Properly paired', 'description': 'Proper-pair bit set' })
-        keys['reads_duplicated'] = dict(reads, **{'title': 'Duplicated', 'description': 'PCR or optical duplicate bit set' })
-        keys['reads_unmapped'] = dict(reads, **{'title': 'Unmapped reads' })
-        keys['reads_QC_failed'] = dict(reads, **{'title': 'QC Failed'})
-        keys['reads_MQ0'] = dict(reads, **{'title': 'Reads MQ0', 'description': 'Reads mapped and MQ=0' })
-        keys['bases_mapped_(cigar)'] = dict(bases, **{'title': 'Mapped bases (cigar)', 'description': 'Mapped bases (cigar)' })
-        keys['bases_trimmed'] = dict(bases, **{'title': 'Bases Trimmed' })
-        keys['bases_duplicated'] = dict(bases, **{'title': 'Duplicated bases' })
-        keys['pairs_on_different_chromosomes'] = dict(reads, **{'title': 'Diff chromosomes', 'description': 'Pairs on different chromosomes' })
-        keys['pairs_with_other_orientation'] = dict(reads, **{'title': 'Other orientation', 'description': 'Pairs with other orientation' })
-        keys['inward_oriented_pairs'] = dict(reads, **{'title': 'Inward pairs', 'description': 'Inward oriented pairs' })
-        keys['outward_oriented_pairs'] = dict(reads, **{'title': 'Outward pairs', 'description': 'Outward oriented pairs' })
+        keys['total_pass'] = dict(reads, **{'title': 'Total Passed' })
+        keys['total_fail'] = dict(reads, **{'title': 'Total Failed' })
+        keys['secondary_pass'] = dict(reads, **{'title': 'Secondary Passed' })
+        keys['secondary_fail'] = dict(reads, **{'title': 'Secondary Failed' })
+        keys['supplementary_pass'] = dict(reads, **{'title': 'Supplementary Passed' })
+        keys['supplementary_fail'] = dict(reads, **{'title': 'Supplementary Failed' })
+        keys['duplicates_pass'] = dict(reads, **{'title': 'Duplicate Passed' })
+        keys['duplicates_fail'] = dict(reads, **{'title': 'Duplicate Failed' })
+        keys['mapped_pass'] = dict(reads, **{'title': 'Mapped Passed' })
+        keys['mapped_fail'] = dict(reads, **{'title': 'Mapped Failed' })
+        keys['paired in sequencing_pass'] = dict(reads, **{'title': 'Paired in Sequencing Passed' })
+        keys['paired in sequencing_fail'] = dict(reads, **{'title': 'Paired in Sequencing Failed' })
+        keys['read1_pass'] = dict(reads, **{'title': 'Read1 Passed' })
+        keys['read1_fail'] = dict(reads, **{'title': 'Read1 Failed' })
+        keys['read2_pass'] = dict(reads, **{'title': 'Read2 Passed' })
+        keys['read2_fail'] = dict(reads, **{'title': 'Read2 Failed' })
+        keys['properly paired_pass'] = dict(reads, **{'title': 'Properly Paired Passed' })
+        keys['properly paired_fail'] = dict(reads, **{'title': 'Properly Paired Failed' })
+        keys['with itself and mate mapped_pass'] = dict(reads, **{'title': 'Self and mate Passed' })
+        keys['with itself and mate mapped_fail'] = dict(reads, **{'title': 'Self and mate Failed' })
+        keys['singletons_pass'] = dict(reads, **{'title': 'Mapped Passed' })
+        keys['singletons_fail'] = dict(reads, **{'title': 'Mapped Failed' })
+        keys['with mate mapped to a different chr_pass'] = dict(reads, **{'title': 'Mate mapped to different chr Passed' })
+        keys['with mate mapped to a different chr_fail'] = dict(reads, **{'title': 'Mate mapped to a different chr Failed' })
+        keys['with mate mapped to a different chr (mapQ >= 5)_pass'] = dict(reads, **{'title': 'Mate mapped to different chr (mapQ >= 5) Passed' })
+        keys['with mate mapped to a different chr (mapQ >= 5)_fail'] = dict(reads, **{'title': 'Mate mapped to a different chr (mapQ >= 5) Failed' })
         
         self.sections.append({
             'name': 'Samtools flagstat output',

--- a/multiqc/modules/samtools/samtools.py
+++ b/multiqc/modules/samtools/samtools.py
@@ -9,7 +9,7 @@ import logging
 from multiqc import config, BaseMultiqcModule
 
 # Import the Samtools submodules
-from . import stats
+from . import stats, flagstat
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -38,6 +38,10 @@ class MultiqcModule(BaseMultiqcModule):
         n['stats'] = stats.parse_reports(self)
         if n['stats'] > 0:
             log.info("Found {} stats reports".format(n['stats']))
+
+        n['flagstat'] = flagstat.parse_reports(self)
+        if n['flagstat'] > 0:
+            log.info("Found {} flagstat reports".format(n['flagstat']))
         
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -97,6 +97,8 @@ samblaster:
 samtools:
     stats:
         contents: 'This file was produced by samtools stats'
+    flagstat:
+        contents: 'This file was produced by samtools flagstat'
 skewer:
     contents: 'COMMAND LINE:	skewer'
 snpeff:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -98,7 +98,7 @@ samtools:
     stats:
         contents: 'This file was produced by samtools stats'
     flagstat:
-        contents: 'This file was produced by samtools flagstat'
+        contents: 'in total (QC-passed reads + QC-failed reads)'
 skewer:
     contents: 'COMMAND LINE:	skewer'
 snpeff:


### PR DESCRIPTION
Creates a beeswarm report for samtools flagstat output. 

It lists each category as pass/fail -- it might make more sense to have pass/fail on the same line in the plot, just with different colours. Could also represent as percentages, but I'm not sure how useful that is. 

Next to do: fix it so output labels at the bottom of the table don't run into the plot, combine pass/fail into the same line. 

<img width="1450" alt="multiqc_report" src="https://cloud.githubusercontent.com/assets/5154249/16660640/2f837f62-4467-11e6-8b13-e837fd76acd1.png">
