### PR TITLE
Catch errors if not pconfig or keys given to bargraph

### DIFF
--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -44,6 +44,9 @@ def plot (data, cats=None, pconfig={}):
     :return: HTML and JS, ready to be inserted into the page
     """
     
+    if not pconfig:
+        pconfig = {}
+
     # Given one dataset - turn it into a list
     if type(data) is not list:
         data = [data]
@@ -51,7 +54,7 @@ def plot (data, cats=None, pconfig={}):
     # Check we have a list of cats
     try:
         cats[0].keys()
-    except (KeyError, AttributeError):
+    except (KeyError, AttributeError, TypeError):
         cats = [cats]
     
     # Check that we have cats at all - find them from the data


### PR DESCRIPTION
If `cat` is `None` It will get a `TypeError` exception, because `None` has not `_get_item` (by default, `cat` is `None`)

If I don't give `pconfig`, then only the first bargraph works and the rest are blank. If I re-define config inside the function again, then it works.

I don't fully understand what is happening with pconfig, but it is happening something. 

Not sure if this is the best of the solutions.