### PR TITLE
Implement retrying on cleanup

### DIFF
--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -7,8 +7,31 @@ import io
 import json
 import os
 import yaml
+import time
+import shutil
 
 from multiqc import config
+
+def robust_rmtree(path, logger=None, max_retries=5):
+    """Robustly tries to delete paths.
+    Retries several times (with increasing delays) if an OSError
+    occurs.  If the final attempt fails, the Exception is propagated
+    to the caller.
+    """
+
+    for i in range(max_retries):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            if logger:
+                logger.info('Unable to remove path: %s' % path)
+                logger.info('Retrying after %d seconds' % i)
+            time.sleep(i)
+
+    # Final attempt, pass any Exceptions up to caller.
+    shutil.rmtree(path)
+
 
 def write_data_file(data, fn, sort_cols=False, data_format=None):
     """ Write a data file to the report directory. Will not do anything

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setup(
         'simplejson',
         'pyyaml',
         'click',
-        'matplotlib'
+        'matplotlib',
+        'retrying'
     ],
     entry_points = {
         'multiqc.modules.v1': [

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,7 @@ setup(
         'simplejson',
         'pyyaml',
         'click',
-        'matplotlib',
-        'retrying'
+        'matplotlib'
     ],
     entry_points = {
         'multiqc.modules.v1': [


### PR DESCRIPTION
Tjena Phil!

This is related to the following backtrace seen on a new cluster with NFS mounts.

Seems that my mantra on "Filesystems **are** evil and logs should be streamed" is paying dividends in this particular instance, @ewels ;P

```
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/bcbio/provenance/do.py", line 21, in run                                                                                                  [0/1999]
    _do_run(cmd, checks, log_stdout)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/bcbio/provenance/do.py", line 95, in _do_run
    raise subprocess.CalledProcessError(exitcode, error_msg)
subprocess.CalledProcessError: Command 'set -o pipefail; export TMPDIR=/scratch/hofmann/projects/NA12878-exome-eval/tmp && /home/hofmann/local/share/bcbio/anaconda/bin/multiqc -f /scratch/hofmann/projects/NA12878-exome-eval
/work_local/qc/NA12878-1/variants /scratch/hofmann/projects/NA12878-exome-eval/work_local/multiqc/report/metrics /scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/fastqc /scratch/hofmann/projects/NA12878-
exome-eval/work_local/qc/NA12878-2/fastqc /scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/samtools /scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/samtools /scratch/hofmann/projects
/NA12878-exome-eval/work_local/qc/NA12878-2/variants /scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/gemini /scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/gemini   -o /scratch/hofm
ann/projects/NA12878-exome-eval/tmp/bcbiotx/c24eb7d9-9a37-45c7-9410-b5cf4d2c9a03/tmp9O6oxf 
[INFO   ]         multiqc : This is MultiQC v0.7
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/variants'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/multiqc/report/metrics'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/fastqc'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/fastqc'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/samtools'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/samtools'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/variants'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-1/gemini'
[INFO   ]         multiqc : Searching '/scratch/hofmann/projects/NA12878-exome-eval/work_local/qc/NA12878-2/gemini'
[INFO   ]        samtools : Found 2 stats reports
[INFO   ]          fastqc : Found 2 reports
[INFO   ]         multiqc : Report      : ../tmp/bcbiotx/c24eb7d9-9a37-45c7-9410-b5cf4d2c9a03/tmp9O6oxf/multiqc_report.html
[INFO   ]         multiqc : Data        : ../tmp/bcbiotx/c24eb7d9-9a37-45c7-9410-b5cf4d2c9a03/tmp9O6oxf/multiqc_data
[INFO   ]         multiqc : MultiQC complete
Traceback (most recent call last):
  File "/home/hofmann/local/share/bcbio/anaconda/bin/multiqc", line 4, in <module>
    __import__('pkg_resources').run_script('multiqc==0.7', 'multiqc')
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/setuptools-20.3-py2.7.egg/pkg_resources/__init__.py", line 726, in run_script
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/setuptools-20.3-py2.7.egg/pkg_resources/__init__.py", line 1484, in run_script
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/multiqc-0.7-py2.7.egg/EGG-INFO/scripts/multiqc", line 467, in <module>
    multiqc()
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/multiqc-0.7-py2.7.egg/EGG-INFO/scripts/multiqc", line 456, in multiqc
    log.copy_tmp_log()
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/site-packages/multiqc-0.7-py2.7.egg/multiqc/utils/log.py", line 57, in copy_tmp_log
    shutil.rmtree(log_tmp_dir)
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/shutil.py", line 256, in rmtree
    onerror(os.rmdir, path, sys.exc_info())
  File "/home/hofmann/local/share/bcbio/anaconda/lib/python2.7/shutil.py", line 254, in rmtree
    os.rmdir(path)
OSError: [Errno 39] Directory not empty: '/scratch/hofmann/projects/NA12878-exome-eval/tmp/tmp5e2RDe'
' returned non-zero exit status 1
```

Bits that deserve some attention before merging this up:

1) [Tune up the default waiting time](https://pypi.python.org/pypi/retrying), ideally backed by experience. Panasas took around 30min on average on my experience... but do we really want to introduce that delay?
2) Bubble up that error and/or apply it to other disk ops/functions.

@ohofmann, perhaps you can apply this to your cluster "manually" as a "Hotfix" for now, in the interest of time.

@chapmanb 