### PR TITLE
Closing logger handle before attempting to remove it.

### DIFF
--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -47,12 +47,15 @@ def init_log(logger, loglevel=0):
     file_handler.setFormatter(logging.Formatter(debug_template))
     logger.addHandler(file_handler)
 
-def copy_tmp_log():
+def copy_tmp_log(logger):
     """ Copy the temporary log file to the MultiQC data directory
     if it exists. """
     
     try:
         shutil.copyfile(log_tmp_fn, os.path.join(config.data_dir, '.multiqc.log'))
+        # https://stackoverflow.com/questions/15435652/python-does-not-release-filehandles-to-logfile
+        logger.handlers[0].close()
+        logger.removeHandler(logger.handlers[0])
         util_functions.robust_rmtree(log_tmp_dir)
     except (AttributeError, TypeError, IOError):
         pass

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -461,7 +461,7 @@ make_data_dir, no_data_dir, data_format, zip_data_dir, force, plots_flat, plots_
     logger.info("MultiQC complete")
     
     # Move the log file into the data directory
-    log.copy_tmp_log()
+    log.copy_tmp_log(logger)
     
     # Exit with an error code if a module broke
     sys.exit(sys_exit_code)


### PR DESCRIPTION
This is a followup on PR #265 since we are still seeing stale log handlers not closing up.