### PR TITLE
Use logging.shutdown() to cleanly shutdown the logging facilities

### DIFF
--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -54,8 +54,7 @@ def copy_tmp_log(logger):
     try:
         shutil.copyfile(log_tmp_fn, os.path.join(config.data_dir, '.multiqc.log'))
         # https://stackoverflow.com/questions/15435652/python-does-not-release-filehandles-to-logfile
-        logger.handlers[0].close()
-        logger.removeHandler(logger.handlers[0])
+        logger.shutdown()
         util_functions.robust_rmtree(log_tmp_dir)
     except (AttributeError, TypeError, IOError):
         pass


### PR DESCRIPTION
This is related to PR #267.