### PR TITLE
Improve descriptions of section headers

### DIFF
--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -89,7 +89,7 @@ class StatsReportMixin():
                 'cpswitch_counts_label': 'Number of Substitutions'
             }
             self.sections.append({
-                'name': 'Substitution Types',
+                'name': 'Variant Substitution Types',
                 'anchor': 'bcftools-stats',
                 'content': plots.bargraph.plot(self.bcftools_stats, keys, pconfig)
             })

--- a/multiqc/modules/samtools/idxstats.py
+++ b/multiqc/modules/samtools/idxstats.py
@@ -134,7 +134,7 @@ class IdxstatsReportMixin():
                 ]
             }
             self.sections.append({
-                'name': 'Samtools idxstats',
+                'name': 'Mapped reads per contig from samtools idxstats',
                 'anchor': 'samtools-idxstats',
                 'content': '<p>The <code>samtools idxstats</code> tool counts the number of mapped reads per chromosome / contig. ' +
                     'Chromosomes with &lt; {}% of the total aligned reads are omitted from this plot.</p>'.format(cutoff*100) +

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -128,7 +128,7 @@ class StatsReportMixin():
             plot_html = plots.beeswarm.plot(self.samtools_stats, keys,
                                             {'id': 'samtools-stats-dp'})
             self.sections.append({
-                'name': 'Alignment metrics from samtools stats',
+                'name': 'Alignment metrics',
                 'anchor': 'samtools-stats',
                 'content': "<p>This module parses the output from <code>samtools stats</code>. All numbers in millions.</p> {}".format(plot_html)
             })
@@ -149,7 +149,7 @@ def alignment_section(samples_data):
                      "skipping samtools plot for: {}".format(sample_id))
     bargraph = alignment_chart(bedgraph_data)
     section = {
-        'name': 'Alignment',
+        'name': 'Percent Mapped',
         'anchor': 'samtools-stats-alignment',
         'content': ("<p>Alignment metrics from <code>samtools stats</code>;"
                     " mapped vs. unmapped reads.</p> {}".format(bargraph))

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -128,7 +128,7 @@ class StatsReportMixin():
             plot_html = plots.beeswarm.plot(self.samtools_stats, keys,
                                             {'id': 'samtools-stats-dp'})
             self.sections.append({
-                'name': 'Samtools Stats',
+                'name': 'Alignment metrics from samtools stats',
                 'anchor': 'samtools-stats',
                 'content': "<p>This module parses the output from <code>samtools stats</code>. All numbers in millions.</p> {}".format(plot_html)
             })

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -44,7 +44,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Report sections
         self.sections = list()
         self.sections.append({
-            'name': 'Variant Counts by Genomic Region',
+            'name': 'Variants by Genomic Region',
             'anchor': 'snpeff-genomic-regions',
             'content': self.count_genomic_region_plot()
         })

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -44,23 +44,23 @@ class MultiqcModule(BaseMultiqcModule):
         # Report sections
         self.sections = list()
         self.sections.append({
-            'name': 'Counts by Genomic Region',
+            'name': 'Variant Counts by Genomic Region',
             'anchor': 'snpeff-genomic-regions',
             'content': self.count_genomic_region_plot()
         })
         self.sections.append({
-            'name': 'Effects by Impact',
+            'name': 'Variant Effects by Impact',
             'anchor': 'snpeff-effects-impact',
             'content': self.effects_impact_plot()
         })
         self.sections.append({
-            'name': 'Effects by Class',
+            'name': 'Variant Effects by Class',
             'anchor': 'snpeff-functional-class',
             'content': self.effects_function_plot()
         })
         if len(self.snpeff_qualities) > 0:
             self.sections.append({
-                'name': 'Qualities',
+                'name': 'Variant Qualities',
                 'anchor': 'snpeff-qualities',
                 'content': self.qualities_plot()
             })


### PR DESCRIPTION
Some of the output section headers we're a bit too technical and require
knowledge of the individual programs (ie you need to know samtools stats
deals with alignments). This tries to make some small improvements to
make MultiQC reports more accessible to biologists with less tool experience.