### PR TITLE
fix divide by zero exception in samtools stats

### DIFF
--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -33,7 +33,7 @@ class StatsReportMixin():
                 # Work out some percentages
                 if 'raw_total_sequences' in parsed_data:
                     for k in list(parsed_data.keys()):
-                        if k.startswith('reads_') and k != 'raw_total_sequences':
+                        if k.startswith('reads_') and k != 'raw_total_sequences' and parsed_data['raw_total_sequences'] > 0:
                             parsed_data['{}_percent'.format(k)] = (parsed_data[k] / parsed_data['raw_total_sequences']) * 100
 
                 if f['s_name'] in self.samtools_stats:


### PR DESCRIPTION
This fixes the following exception, which you would get if one of your files was empty:

```
[ERROR  ]         multiqc : Oops! The 'samtools' MultiQC module broke... 
                    Please copy the following traceback and report it at https://github.com/ewels/MultiQC/issues 
                    (if possible, include a log file that triggers the error) 
============================================================
Module samtools raised an exception: Traceback (most recent call last):
  File "/package/multiqc/0.7/bin/multiqc", line 296, in multiqc
    report.modules_output.append(mod())
  File "/package/multiqc/0.7/lib/python2.7/site-packages/multiqc/modules/samtools/samtools.py", line 38, in __init__
    n['stats'] = stats.parse_reports(self)
  File "/package/multiqc/0.7/lib/python2.7/site-packages/multiqc/modules/samtools/stats.py", line 33, in parse_reports
    parsed_data['{}_percent'.format(k)] = (parsed_data[k] / parsed_data['raw_total_sequences']) * 100
ZeroDivisionError: float division by zero
============================================================
[WARNING]         multiqc : No analysis results found. Cleaning up..
```