### PR TITLE
Fix keeping input image files if config.report_imgskips is set

### DIFF
--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -53,7 +53,7 @@ def get_filelist():
         if ftype is not None and ftype.startswith('image'):
             if config.report_imgskips:
                 logger.debug("Ignoring file as has filetype '{}': {}".format(ftype, fn))
-            return None
+                return None
         
         # Limit search to files under 5MB to avoid 30GB FastQ files etc.
         try:


### PR DESCRIPTION
Am I correct that config.report_imgskips parameter is supposed to control whether the images are to be skipped or not during the file look up? In this case this PR fixes it.