### PR TITLE
Upgrades for Qualimap BamQC module 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dist/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   * Fixed swapped axis labels in the Variant Quality plot
 * **STAR**
   * Fixed crash when there are 0 unmapped reads.
+* **Qualimap BamQC**
+  * Add a line for pre-calculated reference genome GC content
+  * Plot cumulative coverage for values above 50x, align with the coverage histogram.
 
 Core Updates:
 * Fixed bar plot bug where missing categories could shift data between samples

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Code contributions from:
 [@mlusignan](https://github.com/mlusignan),
 [@HLWiencko](https://github.com/HLWiencko),
 [@guillermo-carrasco](https://github.com/guillermo-carrasco),
-[@avilella](https://github.com/avilella)
+[@avilella](https://github.com/avilella),
+[@vladsaveliev](https://github.com/vladsaveliev)
 and many others. Thanks for your support!
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -206,7 +206,6 @@ def report_sections(self):
     """ Add results from Qualimap BamQC parsing to the report """
     # Append to self.sections list
 
-    # Section 1 - BamQC Coverage Histogram
     if len(self.qualimap_bamqc_coverage_hist) > 0:
         # Chew back on histogram to prevent long flat tail
         # (find a sensible max x - lose 1% of longest tail)
@@ -229,12 +228,13 @@ def report_sections(self):
                 if thres in rates_within_threshs[s_name]:
                     self.general_stats_data[s_name][thres_name + '_x_pc'] = rates_within_threshs[s_name][thres]
 
+        # Section 1 - BamQC Coverage Histogram
         self.sections.append({
-            'name': 'Coverage Histogram',
+            'name': 'Coverage histogram',
             'anchor': 'qualimap-coverage-histogram',
             'content': plots.linegraph.plot(self.qualimap_bamqc_coverage_hist, {
-                'title': 'Coverage Histogram',
-                'ylab': 'Genome Bin Counts',
+                'title': 'Coverage histogram',
+                'ylab': 'Genome bin counts',
                 'xlab': 'Coverage (X)',
                 'ymin': 0,
                 'xmin': 0,
@@ -243,6 +243,7 @@ def report_sections(self):
                 'tt_label': '<b>{point.x}X</b>: {point.y}',
             })
         })
+        # Section 2 - BamQC cumulative coverage genome fraction
         self.sections.append({
             'name': 'Cumulative coverage genome fraction',
             'anchor': 'qualimap-cumulative-genome-fraction-coverage',
@@ -258,13 +259,13 @@ def report_sections(self):
             })
         })
 
-    # Section 2 - Insert size histogram
+    # Section 3 - Insert size histogram
     if len(self.qualimap_bamqc_insert_size_hist) > 0:
         self.sections.append({
-            'name': 'Insert size Histogram',
+            'name': 'Insert size histogram',
             'anchor': 'qualimap-insert-size-histogram',
             'content': plots.linegraph.plot(self.qualimap_bamqc_insert_size_hist, {
-                'title': 'Insert Size Histogram',
+                'title': 'Insert size histogram',
                 'ylab': 'Fraction of reads',
                 'xlab': 'Insert Size (bp)',
                 'ymin': 0,
@@ -284,10 +285,16 @@ def report_sections(self):
                 'lineWidth': 1,
                 'color': ['#000000', '#E89191'][i % 2],
             })
+        content = ''
+        if len(extra_series) == 1:
+            content += '<p>The dotted line represents a pre-calculated GC destribution for the reference genome.</p>'
+        elif len(extra_series) > 1:
+            content += '<p>The dotted lines represent pre-calculated GC destributions for the reference genomes.</p>'
+
         self.sections.append({
             'name': 'GC content distribution',
             'anchor': 'qualimap-gc-distribution',
-            'content': plots.linegraph.plot(self.qualimap_bamqc_gc_content_dist, {
+            'content': content + plots.linegraph.plot(self.qualimap_bamqc_gc_content_dist, {
                 'title': 'GC content distribution',
                 'ylab': 'Fraction of reads',
                 'xlab': 'GC content (%)',
@@ -311,7 +318,7 @@ def general_stats_headers (self):
     }
     self.general_stats_headers['median_insert_size'] = {
         'title': 'Insert Size',
-        'description': 'Median Insert Size',
+        'description': 'Median insert size',
         'min': 0,
         'suffix': 'bp',
         'scale': 'PuOr',
@@ -392,7 +399,7 @@ def general_stats_headers (self):
         'hidden': True
     }
     self.general_stats_headers['total_reads'] = {
-        'title': 'Total Reads',
+        'title': 'Total reads',
         'description': 'Number of reads (millions)',
         'min': 0,
         'scale': 'Blues',

--- a/multiqc/modules/qualimap/qualimap.py
+++ b/multiqc/modules/qualimap/qualimap.py
@@ -57,5 +57,6 @@ class MultiqcModule(BaseMultiqcModule):
     def get_s_name(self, f):
         s_name = os.path.basename(os.path.dirname(f['root']))
         s_name = self.clean_s_name(s_name, f['root'])
-        s_name = s_name.rstrip('.qc')
+        if s_name.endswith('.qc'):
+            s_name = s_name[:-3]
         return s_name


### PR DESCRIPTION
Two proposed improvements in 2 commits:

1). Add a line for human reference to the GC content distribution plot.
<img width="1062" alt="screen shot 2016-10-30 at 01 18 07" src="https://cloud.githubusercontent.com/assets/1575412/19833069/24a0e7a2-9e3e-11e6-934c-7ba5a88a0bce.png">

2). Draw cumulative coverage ("Genome Fraction Coverage") plot for values above 50x, and align it vertically with the coverage histogram.

Currently both plots' X axes are cut independently. The histogram is cut at values below 1% to prevent long flat tail. "Genome Fraction" is cut at 50x because Qualimap doesn't provide more data for it:

<img width="1118" alt="screen shot 2016-10-30 at 01 22 13" src="https://cloud.githubusercontent.com/assets/1575412/19833088/aefb5798-9e3e-11e6-8b47-9746d4b5674e.png">

I propose to calculate cumulative coverage from the histogram data, so it will contain values above 50x; and cut it at exact same threshold:

<img width="1102" alt="screen shot 2016-10-30 at 01 19 31" src="https://cloud.githubusercontent.com/assets/1575412/19833075/4dd49c90-9e3e-11e6-9a8c-d16c16389a24.png">
