### PR TITLE
bcftools: fix parsing ts/tv

### DIFF
--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -53,7 +53,7 @@ class StatsReportMixin():
                     fields = ['ts', 'tv', 'tstv', 'ts_1st_ALT', 'tv_1st_ALT', 'tstv_1st_ALT']
                     for i, f in enumerate(fields):
                         value = float(s[i+2].strip())
-                        self.bcftools_stats[s_name][field] = value
+                        self.bcftools_stats[s_name][f] = value
                 
                 # Parse substitution types
                 if s[0] == "ST" and len(s_names) > 0:


### PR DESCRIPTION
Fixing a tiny bug in the `bcftools` module that keeps it from exposing ts/tv.

(By the way, that's why I love using IDEs like PyCharm: such mistakes are just automatically highlighted there).