### PR TITLE
Support for Custom content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # MultiQC Version History
 
 #### v0.9dev
+A major new feature is released in v0.9 - support for _custom content_. This means
+that MultiQC can now easily include output from custom scripts within reports without
+the need for a new module or plugin. For more information, please see the
+[MultiQC documentation](http://multiqc.info/docs/#custom-content).
+
 Module updates:
 * [**Prokka**](http://www.vicbioinformatics.com/software.prokka.shtml) - new module!
   * Prokka is a software tool for the rapid annotation of prokaryotic genomes.
@@ -39,6 +44,7 @@ Module updates:
     (see the [docs](http://multiqc.info/docs/#qualimap) for info).
 
 Core Updates:
+* Support for _custom content_ (see top of release notes).
 * Plot data now saved in `multiqc_data` when 'flat' image plots are created
   * Allows you easily re-plot the data (eg. in Excel) for further downstream investigation
 * Added _'Apply'_ button to Highlight / Rename / Hide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Core Updates:
 * Fixed a few back end nasties for Tables
   * Shared-key columns are no longer forced to share colour schemes
   * Fixed bug in lambda modified values when format string breaks
+  * Supplying just data with no header information now works as advertised
 * Improvements to back end code for bar plots
   * New `tt_decimals` and `tt_suffix` options for bar plots
   * Bar plots now support `yCeiling`, `yFloor` and `yMinRange`, as with line plots.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ Read QC & pre-processing     | Aligners / quantifiers | Post-alignment processin
                              | [STAR][star]           | [SnpEff][snpeff]          |
                              | [Tophat][tophat]       | [Subread featureCounts][featurecounts] |
 
-Please note that some modules only recognise output from certain subcommands. Please follow the
-above links to the [module documentation](http://multiqc.info/docs/#multiqc-modules) for more information.
+MultiQC can also easily parse data from custom scripts, if correctly formatted / configured.
+See the [MultiQC documentation](http://multiqc.info/docs/#custom-content) for more information.
+
+Please note that some modules only recognise output from certain tool subcommands. Please follow the
+links in the above table to the [module documentation](http://multiqc.info/docs/#multiqc-modules)
+for more information.
 
 More modules are being written all of the time. Please suggest any ideas as a new
-[issue](https://github.com/ewels/MultiQC/issues) _(include an example log
-file if possible)_.
+[issue](https://github.com/ewels/MultiQC/issues) _(include an example log file if possible)_.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ MultiQC Modules:
     Samtools: modules/samtools.md
     Slamdunk: modules/slamdunk.md
     SnpEff: modules/snpeff.md
+Custom Content:
+  Introduction: custom_content.md
 Coding with MultiQC:
   Writing new templates: templates.md
   Writing new modules: modules.md
@@ -64,6 +66,7 @@ The documentation has the following pages:
    - [Customising Reports](customisation.md)
    - [Common Problems](troubleshooting.md)
  - [MultiQC Modules](modules/)
+ - [Custom Content](custom_content.md)
  - Coding with MultiQC
    - [Writing new templates](templates.md)
    - [Writing new modules](modules.md)

--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -1,0 +1,207 @@
+# Custom Content
+
+> **WARNING** - This feature is new and is very much in a beta status.
+> It is expected to be further developed in future releases, which may break backwards
+> compatibility. There are also probably quite a few bugs. Use at your own risk!
+> Please report bugs or missing functionality as a
+> [new GitHub issue](https://github.com/ewels/MultiQC/issues/new).
+
+## Introduction
+Bioinformatics projects often include non-standardised analyses, with results from custom
+scripts or in-house packages. It can be frustrating to have a MultiQC report describing
+results from 90% of your pipeline but missing the final key plot. To help with this,
+MultiQC has a special _"custom content"_ module.
+
+Custom content parsing is a little more restricted than standard modules. Specifically:
+
+* Only one plot per section is possible
+* Plot customisation is more limited
+
+## Configuration
+Data should typically be submitted alongside some configuration, to specify how
+MultiQC should parse and display the data. All of these configuration parameters
+are optional, and MultiQC will do its best to guess sensible defaults if they are
+not specified.
+
+All possible configuration keys and their default values are shown below:
+```yaml
+id: null                # Unique ID for report section.
+section_anchor: <id>    # Used in report section #soft-links
+section_name: <id>      # Nice name used for the report section header
+section_href: null      # External URL for the data, to find more information
+description: null       # Introductory text to be printed under the section header
+file_format: null       # File format of the data (typically csv / tsv - see below for more information)
+plot_type: null         # The plot type to visualise the data with.
+                        # - Possible options: generalstats | table | bargraph | linegraph | scatter | heatmap | beeswarm
+pconfig: {}             # Configuration for the plot. See http://multiqc.info/docs/#plotting-functions
+```
+
+## Data formats
+MultiQC can parse custom data from a few different sources, in a number of different
+formats. Which one you use depends on how the data is being produced.
+
+### Data from a released tool
+If your data comes from a released bioinformatics tool, you shouldn't be using this
+feature of MultiQC! Sure, you can probably get it to work, but it's better if a
+fully-fledged core MultiQC module is written instead. That way, other users of MultiQC
+can also benefit from results parsing.
+
+Note that proper MultiQC modules are more robust and powerful than this custom-content
+feature. You can also [write modules](http://multiqc.info/docs/#writing-new-modules)
+in [MultiQC plugins](http://multiqc.info/docs/#multiqc-plugins) if they're not suitable for
+general release.
+
+### Data as part of MultiQC config
+If you are already using a MultiQC config file to add data to your report (for example,
+[titles / introductory text](http://multiqc.info/docs/#customising-reports)), you can
+give data within this file too. This can be in any MultiQC config file (for example,
+passed on the command line with `-c my_yaml_file.yaml`). This is useful as you can
+keep everything contained within a single file (including stuff unrelated to this
+specific _custom content_ feature of MultiQC).
+
+If you're not using this file for other MultiQC configuration, you're probably
+better off using a stand-alone YAML file (see [section below](#multiqc-specific-data-file)).
+
+To be understood by MultiQC, the `custom_data` key must be found. This must contain
+a section with a unique id, specific to your new report section. This in turn
+must contain a section called `data`. Other configuration keys can be held alongside this.
+For example:
+
+```yaml
+# Other MultiQC config stuff here
+custom_data:
+    my_data_type:
+        id: 'mqc_config_file_section'
+        section_name: 'My Custom Section'
+        description: 'This data comes from a single multiqc_config.yaml file'
+        plot_type: 'bargraph'
+        pconfig:
+            id: 'barplot_config_only'
+            title: 'MultiQC Config Data Plot'
+            ylab: 'Number of things'
+        data:
+            sample_a:
+                first_thing: 12
+                second_thing: 14
+            sample_b:
+                first_thing: 8
+                second_thing: 6
+            sample_c:
+                first_thing: 11
+                second_thing: 5
+            sample_d:
+                first_thing: 12
+                second_thing: 9
+```
+
+### MultiQC-specific data file
+If you can choose exactly how your data output looks, then the easiest way to parse it
+is to use a MultiQC-specific format. If the filename ends in `*_mqc.(yaml|json|txt|csv|out)`
+then it will be found by any standard MultiQC installation with no additional customisation
+required (v0.9 onwards).
+
+These files contain configuration information specifying how the data should be parsed, along
+side the data. If using YAML, this looks just the same as if in a MultiQC config file (see above),
+but without having to be within a `custom_data` section:
+
+```yaml
+id: 'my_pca_section'
+section_name: 'PCA Analysis'
+description: 'This plot shows the first two components from a principal component analysis.'
+plot_type: 'scatter'
+pconfig:
+    id: 'pca_scatter_plot'
+    title: 'PCA Plot'
+    xlab: 'PC1'
+    ylab: 'PC2'
+data:
+    sample_1: {x: 12, y: 14}
+    sample_2: {x: 8, y: 6 }
+    sample_3: {x: 5, y: 11}
+    sample_4: {x: 9, y: 12}
+```
+
+The file format can also be JSON:
+```json
+{
+    "id": "custom_data_lineplot",
+    "section_name": "Custom JSON File",
+    "description": "This plot is a self-contained JSON file.",
+    "plot_type": "linegraph",
+    "pconfig": {
+        "id": "custom_data_linegraph",
+        "title": "Output from my JSON file",
+        "ylab": "Number of things",
+        "xDecimals": false
+    },
+    "data": {
+        "sample_1": { "1": 12, "2": 14, "3": 10, "4": 7, "5": 16 },
+        "sample_2": { "1": 9, "2": 11, "3": 15, "4": 18, "5": 21 }
+    }
+}
+```
+
+If you want the data to be easy to open in Excel / other tools, you can also use
+comma-separated or tab-separated file. To customise plot output, include commented
+header lines with plot configuration in YAML format:
+
+```bash
+# title: 'Output from my script'
+# description: 'This output is described in the file header. Any MultiQC installation will understand it without prior configuration.'
+# section: 'Custom Data File'
+# format: 'tsv'
+# plot_type: 'bargraph'
+# pconfig:
+#    id: 'custom_bargraph_w_header'
+#    ylab: 'Number of things'
+Category_1    374
+Category_2    229
+Category_3    39
+Category_4    253
+```
+
+If no configuration is given, MultiQC will do its best to guess how to visualise your data appropriately.
+Something will be probably be shown, but it can produce unexpected results.
+
+### Separate configuration and data files
+It's not always possible or desirable to include MultiQC configuration within a data file.
+If this is the case, you can add to the MultiQC configuration to specify how input files
+should be parsed.
+
+As described in the above [_Data as part of MultiQC config_](#data-as-part-of-multiqc-config) section,
+this configuration should be held within a section called `custom_data` with a section-specific id.
+The only difference is that no `data` subsection should be present and the `sp` key _must_ be present.
+
+The `sp` key tells MultiQC how to find files. This should have `fn` and/or `contents` under it, as
+described in the [Module search patterns](http://multiqc.info/docs/#module-search-patterns) section
+of the docs.
+
+For example:
+```yaml
+# Other MultiQC config stuff here
+custom_data:
+    example_files:
+        sp:
+            fn: 'example_files_*'
+        file_format: 'tsv'
+        section_name: 'Coverage Decay'
+        description: 'This plot comes from files acommpanied by a mutliqc_config.yaml file for configuration'
+        plot_type: 'linegraph'
+        pconfig:
+            id: 'example_coverage_lineplot'
+            title: 'Coverage Decay'
+            ylab: 'X Coverage'
+            ymax: 100
+            ymin: 0
+```
+A data file within the MultiQC search directories could then simply look like this:
+
+`example_files_Sample_1.txt`:
+```
+0	98.22076066
+1	97.96764159
+2	97.78227175
+3	97.61262195
+[...]
+```
+

--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -36,9 +36,25 @@ plot_type: null         # The plot type to visualise the data with.
 pconfig: {}             # Configuration for the plot. See http://multiqc.info/docs/#plotting-functions
 ```
 
+Note that any _custom content_ data found with the same section `id` will be merged
+into the same report section / plot. The other section configuration keys are merged
+for each file, with identical keys overwriting what was previously parsed.
+
+This approach means that it's possible to have a single file containing data for multiple
+samples, but it's also possible to have one file per sample and still have all of them
+summarised.
+
+If you're using `plot_type: 'generalstats'` then a report section will not be created and
+most of the configuration keys above are ignored.
+
 ## Data formats
 MultiQC can parse custom data from a few different sources, in a number of different
 formats. Which one you use depends on how the data is being produced.
+
+For more complete examples of the data formats understood by MultiQC, please see the
+[`data/custom_content`](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content)
+directory in the [MultiQC_TestData](https://github.com/ewels/MultiQC_TestData)
+GitHub repository.
 
 ### Data from a released tool
 If your data comes from a released bioinformatics tool, you shouldn't be using this
@@ -93,6 +109,33 @@ custom_data:
                 first_thing: 12
                 second_thing: 9
 ```
+
+Or to add data to the General Statistics table:
+```yaml
+custom_data:
+    my_genstats:
+        plot_type: 'generalstats'
+        pconfig:
+            - col_1:
+                max: 100
+                min: 0
+                scale: 'RdYlGn'
+                format: '{:.1f}%'
+            - col_2:
+                min: 0
+        data:
+            sample_a:
+                col_1: 14.32
+                col_2: 1.2
+            sample_b:
+                col_1: 84.84
+                col_2: 1.9
+```
+> **Note:** Use a list of headers in `pconfig` (prepend with `-`) to specify the order
+> of columns in the table.
+
+See the [general statistics docs](http://multiqc.info/docs/#step-4-adding-to-the-general-statistics-table)
+for more information about configuring data for the General Statistics table.
 
 ### MultiQC-specific data file
 If you can choose exactly how your data output looks, then the easiest way to parse it

--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -47,9 +47,24 @@ summarised.
 If you're using `plot_type: 'generalstats'` then a report section will not be created and
 most of the configuration keys above are ignored.
 
+Data types `generalstats` and `beeswarm` are _only_ possible by setting the above
+configuration keys (these can't be guessed by data format).
+
 ## Data formats
 MultiQC can parse custom data from a few different sources, in a number of different
 formats. Which one you use depends on how the data is being produced.
+
+A quick summary of which approach to use looks something like this:
+
+* Additional data when already using custom MultiQC config files
+  * _Data as part of MultiQC config_
+* Data specifically for MultiQC from a custom script
+  * _MultiQC-specific data file_
+* Data from a custom script which is also used by other processes
+  * _Separate configuration and data files_
+  * Add `_mqc.txt` to filename and hope that MultiQC guesses correctly
+* Anything more complicated, or data from a released tool
+  * Write a proper MultiQC module instead.
 
 For more complete examples of the data formats understood by MultiQC, please see the
 [`data/custom_content`](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content)
@@ -184,7 +199,7 @@ The file format can also be JSON:
 }
 ```
 
-If you want the data to be easy to open in Excel / other tools, you can also use
+If you want the data to be easy to use with other tools, you can also use
 comma-separated or tab-separated file. To customise plot output, include commented
 header lines with plot configuration in YAML format:
 
@@ -204,7 +219,9 @@ Category_4    253
 ```
 
 If no configuration is given, MultiQC will do its best to guess how to visualise your data appropriately.
-Something will be probably be shown, but it can produce unexpected results.
+To see examples of typical file structures which are understood, see the
+[test data](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content/no_config)
+used to develop this code. Something will be probably be shown, but it may produce unexpected results.
 
 ### Separate configuration and data files
 It's not always possible or desirable to include MultiQC configuration within a data file.
@@ -247,4 +264,9 @@ A data file within the MultiQC search directories could then simply look like th
 3	97.61262195
 [...]
 ```
+
+As mentioned above - if no configuration is given, MultiQC will do its best to guess how to visualise
+your data appropriately. To see examples of typical file structures which are understood, see the
+[test data](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content/no_config)
+used to develop this code.
 

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -17,14 +17,16 @@ letters = 'abcdefghijklmnopqrstuvwxyz'
 
 class BaseMultiqcModule(object):
 
-    def __init__(self, name='base', anchor='base', target='',href='', info='', extra=''):
+    def __init__(self, name='base', anchor='base', target=None, href=None, info='', extra=''):
         self.name = name
         self.anchor = anchor
-        if not target:
+        if target is None:
             target = self.name
-        self.intro = '<p><a href="{0}" target="_blank">{1}</a> {2}</p>{3}'.format(
-            href, target, info, extra
-        )
+        if href is not None:
+            mname = '<a href="{}" target="_blank">{}</a>'.format(href, target)
+        else:
+            mname = target
+        self.intro = '<p>{} {}</p>{}'.format( mname, info, extra )
 
     def find_log_files(self, patterns, filecontents=True, filehandles=False):
         """

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -2,18 +2,17 @@
 
 """ MultiQC modules base class, contains helper functions """
 
+from __future__ import print_function
+from collections import OrderedDict
 import fnmatch
 import io
 import logging
 import os
-import random
 import re
 
 from multiqc import plots
 from multiqc.utils import report, config, util_functions
 logger = logging.getLogger(__name__)
-
-letters = 'abcdefghijklmnopqrstuvwxyz'
 
 class BaseMultiqcModule(object):
 
@@ -164,15 +163,24 @@ class BaseMultiqcModule(object):
         if namespace is None:
             namespace = self.name
 
+        # Guess the column headers from the data if not supplied
+        if headers is None or len(headers) == 0:
+            hs = set()
+            for d in data.values():
+                hs.update(d.keys())
+            hs = list(hs)
+            hs.sort()
+            headers = OrderedDict()
+            for k in hs:
+                headers[k] = dict()
+
         # Add the module name to the description if not already done
-        keys = data.keys()
-        if len(headers.keys()) > 0:
-            keys = headers.keys()
+        keys = headers.keys()
         for k in keys:
-            headers[k]['namespace'] = namespace
-            desc = headers[k].get('description', headers[k].get('title', k))
+            if 'namespace' not in headers[k]:
+                headers[k]['namespace'] = namespace
             if 'description' not in headers[k]:
-                headers[k]['description'] = desc
+                headers[k]['description'] = headers[k].get('title', k)
 
         # Append to report.general_stats for later assembly into table
         report.general_stats_data.append(data)

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -16,9 +16,13 @@ logger = logging.getLogger(__name__)
 
 class BaseMultiqcModule(object):
 
-    def __init__(self, name='base', anchor='base', target=None, href=None, info='', extra=''):
+    def __init__(self, name='base', anchor='base', target=None, href=None, info=None, extra=None):
         self.name = name
         self.anchor = anchor
+        if info is None:
+            info = ''
+        if extra is None:
+            extra = ''
         if target is None:
             target = self.name
         if href is not None:

--- a/multiqc/modules/custom_content/__init__.py
+++ b/multiqc/modules/custom_content/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 
-from .custom_content import MultiqcModule
+from .custom_content import *

--- a/multiqc/modules/custom_content/__init__.py
+++ b/multiqc/modules/custom_content/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .custom_content import MultiqcModule

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -7,7 +7,6 @@ from collections import defaultdict, OrderedDict
 import logging
 import json
 import os
-import re
 import yaml
 
 from multiqc import config, BaseMultiqcModule, plots
@@ -21,35 +20,35 @@ def custom_module_classes():
     things depending on the input and is as flexible as possible.
     NB: THIS IS TOTALLY DIFFERENT TO ALL OTHER MODULES
     """
-        
+
     # Dict to hold parsed data. Each key should contain a custom data type
     # eg. output from a particular script. Note that this script may pick
     # up many different types of data from many different sources.
     # Second level keys should be 'config' and 'data'. Data key should then
     # contain sample names, and finally data.
     cust_mods = defaultdict(lambda: defaultdict(lambda: dict()))
-    
+
     # Dictionary to hold search patterns - start with those defined in the config
     search_patterns = OrderedDict()
     search_patterns['core_sp'] = config.sp['custom_content']
-    
+
     # First - find files using patterns described in the config
     config_data = getattr(config, 'custom_data', {})
     for k,f in config_data.items():
-        
+
         # Check that we have a dictionary
         if type(f) != dict:
             log.debug("config.custom_data row was not a dictionary: {}".format(k))
             continue
         c_id = f.get('id', k)
-        
+
         # Data supplied in with config (eg. from a multiqc_config.yaml file in working directory)
         if 'data' in f:
             cust_mods[c_id]['data'].update( f['data'] )
             if 'config' in f:
                 cust_mods[c_id]['config'].update( f['config'] )
             continue
-        
+
         # File name patterns supplied in config
         sp = {}
         if 'fn' in f:
@@ -61,14 +60,14 @@ def custom_module_classes():
         else:
             cust_mods[c_id]['config'].update(f)
             search_patterns[c_id] = sp
-    
+
     # Now go through each of the file search patterns
     bm = BaseMultiqcModule()
     for k, sp in search_patterns.items():
         for f in bm.find_log_files(sp):
-            
+
             f_extension = os.path.splitext(f['fn'])[1]
-            
+
             # YAML and JSON files are the easiest
             parsed_data = None
             if f_extension == '.yaml' or f_extension == '.yml':
@@ -82,7 +81,7 @@ def custom_module_classes():
                     cust_mods[c_id]['config'].update ( { j:k for j,k in parsed_data.items() if j != 'data' } )
                 else:
                     log.warning("No data found in {}".format(f['fn']))
-            
+
             # txt, csv, tsv etc
             else:
                 # Look for configuration details in the header
@@ -94,25 +93,25 @@ def custom_module_classes():
                     s_name = m_config.get('sample_name')
                 else:
                     c_id = k
-                
+
                 # Add information about the file to the config dict
                 cust_mods[c_id]['config']['files'] = { s_name : { 'fn': f['fn'], 'root': f['root'] } }
-                
+
                 # Guess sample name if not given
                 if s_name is None:
                     s_name = bm.clean_s_name(f['s_name'], f['root'])
-                
+
                 # Guess file format if not given
                 if cust_mods[c_id]['config'].get('file_format') is None:
                     cust_mods[c_id]['config']['file_format'] = _guess_file_format( f['f'] )
-                
+
                 # Parse data
                 parsed_data = _parse_txt( f['f'], cust_mods[c_id]['config'] )
                 if parsed_data is None:
                     log.warning("Not able to parse custom data in {}".format(f['fn']))
                 else:
                     cust_mods[c_id]['data'][s_name] = parsed_data
-                    
+
                     # Guess plot type if not given
                     if cust_mods[c_id]['config'].get('plot_type') is None:
                         cust_mods[c_id]['config']['plot_type'] = _guess_plot_type( parsed_data )
@@ -121,19 +120,19 @@ def custom_module_classes():
     remove_cids = [ k for k in cust_mods if len(cust_mods[k]['data']) == 0 ]
     for k in remove_cids:
         del cust_mods[k]
-    
+
     if len(cust_mods) == 0:
         log.debug("No custom content found")
         raise UserWarning
-    
+
     # Go through each data type
     parsed_modules = list()
     for k, mod in cust_mods.items():
-        
+
         # Initialise this new module class and append to list
         parsed_modules.append( MultiqcModule(k, mod) )
         log.info("{}: Found {} reports".format(k, len(mod['data'])), extra={'mname': k})
-        
+
     return parsed_modules
 
 
@@ -141,9 +140,9 @@ class MultiqcModule(BaseMultiqcModule):
     """ Module class, used for each custom content type """
 
     def __init__(self, c_id, mod):
-        
+
         modname = mod['config'].get('section_name', c_id.replace('_', ' ').title())
-        
+
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
             name = modname,
@@ -155,35 +154,35 @@ class MultiqcModule(BaseMultiqcModule):
         # General Stats
         if mod['config'].get('plot_type') == 'generalstats':
             self.general_stats_addcols(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Table
         elif mod['config'].get('plot_type') == 'table':
             self.intro += plots.table.plot(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Bar plot
         elif mod['config'].get('plot_type') == 'bargraph':
             self.intro += plots.bargraph.plot(mod['data'], mod['config'].get('categories'), mod['config'].get('pconfig'))
-        
+
         # Line plot
         elif mod['config'].get('plot_type') == 'linegraph':
             self.intro += plots.linegraph.plot(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Scatter plot
         elif mod['config'].get('plot_type') == 'scatter':
             self.intro += plots.scatter.plot(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Heatmap
         elif mod['config'].get('plot_type') == 'heatmap':
             self.intro += plots.heatmap.plot(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Beeswarm plot
         elif mod['config'].get('plot_type') == 'beeswarm':
             self.intro += plots.beeswarm.plot(mod['data'], mod['config'].get('pconfig'))
-        
+
         # Not supplied
         elif mod['config'].get('plot_type') == None:
             log.warning("Plot type not found for content ID '{}'".format(c_id))
-        
+
         # Not recognised
         else:
             log.warning("Error - custom content plot type '{}' not recognised for content ID {}".format(mod['config'].get('plot_type'), c_id))
@@ -213,6 +212,7 @@ def _guess_plot_type(d):
             col2_num = True
         except ValueError:
             col2_str = True
+
     if col1_num and col2_num:
         return 'linegraph'
     if col1_str and col2_num:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+""" Core MultiQC module to parse output from custom script output """
+
+from __future__ import print_function
+import logging
+import json
+import os
+import re
+import yaml
+
+from multiqc import config, BaseMultiqcModule, plots
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class MultiqcModule(BaseMultiqcModule):
+    """
+    MultiQC Custom Content class. This module does a lot of different
+    things depending on the input and is as flexible as possible.
+    """
+
+    def __init__(self):
+        
+        # Dict to hold parsed data. Each key should contain a custom data type
+        # eg. output from a particular script. Note that this script may pick
+        # up many different types of data from many different sources.
+        # Second level keys should be 'config' and 'data'. Data key should then
+        # contain sample names, and finally data.
+        self.cust_mods = {}
+        
+        # Dictionary to hold search patterns - start with those defined in the config
+        search_patterns = [ config.sp['custom_content'] ]
+        
+        # First - find files using patterns described in the config
+        config_data = getattr(config, 'custom_data', {})
+        for k,f in config_data.items():
+            
+            # Check that we have a dictionary
+            if type(f) != dict:
+                log.debug("config.custom_data row was not a dictionary: {}".format(k))
+                continue
+            c_id = f.get('id', k)
+            
+            # Data supplied in with config (eg. from a multiqc_config.yaml file in working directory)
+            if 'data' in f:
+                self.init_data_dict(c_id)
+                self.cust_mods[c_id]['data'].update( f['data'] )
+                if 'config' in f:
+                    self.cust_mods[c_id]['config'].update( f['config'] )
+                continue
+            
+            # File name patterns supplied in config
+            sp = {}
+            if 'fn' in f:
+                sp['fn'] = f['fn']
+            if 'contents' in f:
+                sp['contents'] = f['contents']
+            if len(sp) == 0:
+                log.debug("Search pattern not found for custom module: {}".format(c_id))
+            else:
+                self.init_data_dict(c_id)
+                self.cust_mods[c_id]['config'].update(f)
+                search_patterns.append(sp)
+        
+        # Now go through each of the file search patterns
+        for sp in search_patterns:
+            for f in self.find_log_files(sp):
+                
+                f_extension = os.path.splitext(f['fn'])[1]
+                
+                # YAML and JSON files are the easiest
+                parsed_data = None
+                if f_extension == '.yaml' or f_extension == '.yml':
+                    parsed_data = yaml.load(f['f'])
+                elif f_extension == '.json':
+                    parsed_data = json.loads(f['f'])
+                if parsed_data is not None:
+                    c_id = parsed_data.get('id', f['fn'])
+                    self.init_data_dict(c_id)
+                    if len(parsed_data.get('data', {})) > 0:
+                        self.cust_mods[c_id]['data'].update( parsed_data['data'] )
+                        self.cust_mods[c_id]['config'].update ( { j:k for j,k in parsed_data.items() if j != 'data' } )
+                    else:
+                        log.warning("No data found in {}".format(f['fn']))
+                
+                # txt, csv, tsv etc
+                else:
+                    # Look for configuration details in the header
+                    m_config = self.find_file_header( f['f'].splitlines() )
+                    log.warning("Parsing custom data that isn't YAML / JSON isn't written yet. Coming soon...")
+                    
+                    # Guess file format if not given
+                    
+                    # Guess plot type if not given
+                    
+                    # Parse data
+
+        
+        if len(self.cust_mods) == 0:
+            log.debug("No custom content found")
+            raise UserWarning
+        
+        # Go through each data type
+        for k, mod in self.cust_mods.items():
+            # General Stats
+            
+            # Table
+            
+            # Bar plot
+            
+            # Line plot
+            
+            # Scatter plot
+            
+            # Heatmap
+            
+            # Beeswarm plot
+            break
+        
+
+        
+        print(json.dumps(self.cust_mods, indent=4))
+
+    def init_data_dict(self, c_id):
+        if c_id not in self.cust_mods:
+            self.cust_mods[c_id] = dict()
+        if 'data' not in self.cust_mods[c_id]:
+            self.cust_mods[c_id]['data'] = dict()
+        if 'config' not in self.cust_mods[c_id]:
+            self.cust_mods[c_id]['config'] = dict()
+    
+    def find_file_header(self, lines):
+        for l in lines:
+            break
+        return None

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -268,9 +268,9 @@ def _guess_file_format(f):
         tab_mode = max(set(tabs), key=tabs.count)
         commas_mode = max(set(commas), key=commas.count)
         spaces_mode = max(set(spaces), key=spaces.count)
-        tab_lc = tabs.count(tab_mode) if tab_mode > 1 else None
-        commas_lc = commas.count(commas_mode) if commas_mode > 1 else None
-        spaces_lc = spaces.count(spaces_mode) if spaces_mode > 1 else None
+        tab_lc = tabs.count(tab_mode) if tab_mode > 1 else 0
+        commas_lc = commas.count(commas_mode) if commas_mode > 1 else 0
+        spaces_lc = spaces.count(spaces_mode) if spaces_mode > 1 else 0
         if tab_lc == j:
             return 'tsv'
         elif commas_lc == j:

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -205,7 +205,7 @@ def highcharts_bargraph (plotdata, plotsamples=None, pconfig={}):
                 ymax = 'data-ymax="{}"'.format(pconfig['data_labels'][k]['ymax'])
             except:
                 ymax = ''
-            html += '<button class="btn btn-default btn-sm {a}" data-action="set_data" {y} data-newdata="{k}" data-target="{id}">{n}</button>\n'.format(a=active, id=pconfig['id'], n=name, y=ylab, k=k)
+            html += '<button class="btn btn-default btn-sm {a}" data-action="set_data" {y} {ym} data-newdata="{k}" data-target="{id}">{n}</button>\n'.format(a=active, id=pconfig['id'], n=name, y=ylab, ym=ymax, k=k)
         html += '</div>\n\n'
 
     # Plot and javascript function

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -68,7 +68,11 @@ def plot (data, cats=None, pconfig={}):
         try:
             cats[idx]
         except (IndexError):
-            cats.append( list(set(k for s in data[idx].keys() for k in data[idx][s].keys() )) )
+            cats.append(list())
+            for s in data[idx].keys():
+                for k in data[idx][s].keys():
+                    if k not in cats[idx]:
+                        cats[idx].append(k)
 
     # If we have cats in lists, turn them into dicts
     for idx, cat in enumerate(cats):

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -30,7 +30,7 @@ def plot (data, pconfig={}):
         d = list()
         for s_name in ds:
             if type(ds[s_name]) is not list:
-                ds[s_name] = list(ds[s_name])
+                ds[s_name] = [ ds[s_name] ]
             for k in ds[s_name]:
                 this_series = { 'x': k['x'], 'y': k['y'] }
                 try:

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -3,9 +3,7 @@
 """ MultiQC functions to plot a table """
 
 from collections import defaultdict, OrderedDict
-import json
 import logging
-import os
 import random
 
 from multiqc.utils import config, report, util_functions

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -2,7 +2,7 @@
 
 """ MultiQC datatable class, used by tables and beeswarm plots """
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import logging
 import random
 
@@ -35,14 +35,25 @@ class datatable (object):
             try:
                 keys = headers[idx].keys()
                 assert len(keys) > 0
-            except (IndexError, AssertionError):
-                keys = d.keys()
+            except (IndexError, AttributeError, AssertionError):
+                keys = list()
+                for samp in d.values():
+                    for k in samp.keys():
+                        if k not in keys:
+                            keys.append(k)
+                try:
+                    headers[idx]
+                except IndexError:
+                    headers.append(list)
+                headers[idx] = OrderedDict()
+                for k in keys:
+                    headers[idx][k] = {}
 
             # Check that we have some data in each column
             empties = list()
             for k in keys:
                 n = 0
-                for samp in data[idx].values():
+                for samp in d.values():
                     if k in samp:
                         n += 1
                 if n == 0:

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -116,6 +116,11 @@ fn_clean_trim:
     - '_val'
     - '.idxstats'
     - '_trimmed'
+    - '.csv'
+    - '.yaml'
+    - '.yml'
+    - '.json'
+    - '_mqc'
 
 # Files to ignore when indexing files.
 # Grep file match patterns.

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -140,6 +140,8 @@ top_modules: []
 # Order that modules should appear in report. Try to list in order of analysis,
 # eg. FastQC is usually the first step, so should be last in this list.
 module_order:
+    # MultiQC general module for catching output from custom scripts
+    - 'custom_content'
     # Post-alignment analysis results
     - 'quast'
     - 'snpeff'

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -29,6 +29,7 @@ custom_content:
     fn:
         - '*_mqc.yaml'
         - '*_mqc.yml'
+        - '*_mqc.json'
         - '*_mqc.txt'
         - '*_mqc.csv'
         - '*_mqc.tsv'

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -25,6 +25,15 @@ bowtie:
     contents: '# reads processed:'
 bowtie2:
     contents: 'reads; of these:'
+custom_content:
+    fn:
+        - '*_mqc.yaml'
+        - '*_mqc.yml'
+        - '*_mqc.txt'
+        - '*_mqc.csv'
+        - '*_mqc.tsv'
+        - '*_mqc.log'
+        - '*_mqc.out'
 cutadapt:
     contents: 'This is cutadapt'
     # contents: 'cutadapt version' # Use this instead if using very old versions of cutadapt (eg. v1.2)

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -7,13 +7,10 @@ from __future__ import print_function
 
 import base64
 import click
-from collections import defaultdict
 from distutils import version
 from distutils.dir_util import copy_tree
-import importlib
 import io
 import jinja2
-import logging
 import os
 import pkg_resources
 import re
@@ -149,33 +146,33 @@ def multiqc(analysis_dir, dirs, dirs_depth, no_clean_sname, title, report_commen
 ignore, file_list, filename, make_data_dir, no_data_dir, data_format, zip_data_dir, force, export_plots,
 plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
-    
+
         It searches a given directory for analysis logs and compiles a HTML report.
         It's a general use tool, perfect for summarising the output from numerous
         bioinformatics tools.
-        
+
         To run, supply with one or more directory to scan for analysis results.
         To run here, use 'multiqc .'
-        
+
         See http://multiqc.info for more details.
-        
+
         Author: Phil Ewels (http://phil.ewels.co.uk)
     """
-    
+
     # Set up logging level
     loglevel = log.LEVELS.get(min(verbose,1), "INFO")
     if quiet:
         loglevel = 'WARNING'
     log.init_log(logger, loglevel=loglevel)
-    
+
     # Load config files
     config.mqc_load_userconfig(config_file)
     plugin_hooks.mqc_trigger('config_loaded')
-    
+
     # Log the command used to launch MultiQC
     report.multiqc_command = " ".join(sys.argv)
     logger.debug("Command used: {}".format(report.multiqc_command))
-    
+
     # Check that we're running the latest version of MultiQC
     if config.no_version_check is not True:
         try:
@@ -185,7 +182,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                 logger.warn('MultiQC Version {} now available!'.format(remote_version))
         except:
             logger.debug('Could not connect to multiqc.info for version check')
-    
+
     # Set up key variables (overwrite config vars from command line)
     if template is not None:
         config.template = template
@@ -219,9 +216,9 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
     if make_pdf:
         config.template = 'simple'
     config.kwargs = kwargs # Plugin command line options
-    
+
     plugin_hooks.mqc_trigger('execution_start')
-    
+
     logger.info("This is MultiQC v{}".format(__version__))
     logger.debug("Command     : {}".format(' '.join(sys.argv)))
     logger.debug("Working dir : {}".format(os.getcwd()))
@@ -262,7 +259,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
             config.data_dir_name = '{}_data'.format(filename)
         if not config.output_fn_name.endswith('.html'):
             config.output_fn_name = '{}.html'.format(config.output_fn_name)
-        
+
         # Check that we're not going to overwrite anything before we run
         config.output_fn = os.path.join(config.output_dir, config.output_fn_name)
         config.data_dir = os.path.join(config.output_dir, config.data_dir_name)
@@ -281,8 +278,8 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                 sys.exit(1)
         else:
             logger.debug('Running in --force mode, will overwrite any existing reports.')
-            
-    
+
+
     # Print some status updates
     if config.title is not None:
         logger.info("Report title: {}".format(config.title))
@@ -290,12 +287,12 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         logger.info("Prepending directory to sample names")
     for d in config.analysis_dir:
         logger.info("Searching '{}'".format(d))
-    
+
     # Get the list of modules we want to run, in the order that we want them
     run_modules = [ m for m in config.top_modules if m in config.avail_modules.keys() ]
     run_modules.extend( [ m for m in config.avail_modules.keys() if m not in config.module_order and m not in run_modules ] )
     run_modules.extend( [ m for m in config.module_order if m in config.avail_modules.keys() and m not in run_modules ] )
-    
+
     if module:
         run_modules = [m for m in run_modules if m in module]
         logger.info('Only using modules {}'.format(', '.join(module)))
@@ -309,7 +306,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         logger.critical('No analysis modules specified!')
         sys.exit(1)
     logger.debug("Analysing modules: {}".format(', '.join(run_modules)))
-    
+
     # Create the temporary working directories
     tmp_dir = tempfile.mkdtemp()
     logger.debug('Using temporary directory for creating report: {}'.format(tmp_dir))
@@ -323,20 +320,20 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
     if filename != 'stdout' and config.export_plots == True:
         config.plots_dir = config.plots_tmp_dir
         os.makedirs(config.plots_dir)
-    
+
     # Load the template
     template_mod = config.avail_templates[config.template].load()
-    
+
     # Add an output subdirectory if specified by template
     try:
         config.output_dir = os.path.join(config.output_dir, template_mod.output_subdir)
     except AttributeError:
         pass # No subdirectory variable given
-    
-    
+
+
     # Get the list of files to search
     report.get_filelist()
-    
+
     # Run the modules!
     plugin_hooks.mqc_trigger('before_modules')
     report.modules_output = list()
@@ -392,9 +389,9 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         logger.info("MultiQC complete")
         # Exit with an error code if a module broke
         sys.exit(sys_exit_code)
-    
+
     plugin_hooks.mqc_trigger('after_modules')
-    
+
     # Generate the General Statistics HTML & write to file
     if len(report.general_stats_data) > 0:
         pconfig = {
@@ -406,13 +403,13 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         report.general_stats_html = plots.table.plot(report.general_stats_data, report.general_stats_headers, pconfig)
     else:
         config.skip_generalstats = True
-    
+
     # Write the report sources to disk
     if config.data_dir is not None:
         report.data_sources_tofile()
-    
+
     plugin_hooks.mqc_trigger('before_report_generation')
-    
+
     # Make the final report path & data directories
     if filename != 'stdout':
         # Check for existing reports and remove if -f was specified
@@ -431,7 +428,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         if not os.path.exists(os.path.dirname(config.output_fn)):
             os.makedirs(os.path.dirname(config.output_fn))
         logger.info("Report      : {}".format(os.path.relpath(config.output_fn)))
-        
+
         # Now do the same for the data directory
         if config.make_data_dir == False:
             logger.info("Data        : None")
@@ -448,13 +445,13 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                     sys.exit(1)
             os.makedirs(config.data_dir)
             logger.info("Data        : {}".format(os.path.relpath(config.data_dir)))
-            
+
             # Modules have run, so data directory should be complete by now. Move its contents.
             for f in os.listdir(config.data_tmp_dir):
                 fn = os.path.join(config.data_tmp_dir, f)
                 logger.debug("Moving data file from '{}' to '{}'".format(fn, config.data_dir))
                 shutil.move(fn, config.data_dir)
-        
+
         # Finally, copy across the plots
         if config.export_plots:
             config.plots_dir = os.path.join(config.output_dir, config.plots_dir_name)
@@ -469,25 +466,25 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                     sys.exit(1)
             os.makedirs(config.plots_dir)
             logger.info("Plots       : {}".format(os.path.relpath(config.plots_dir)))
-            
+
             # Modules have run, so plots directory should be complete by now. Move its contents.
             for f in os.listdir(config.plots_tmp_dir):
                 fn = os.path.join(config.plots_tmp_dir, f)
                 logger.debug("Moving plots directory from '{}' to '{}'".format(fn, config.plots_dir))
                 shutil.move(fn, config.plots_dir)
-    
+
     plugin_hooks.mqc_trigger('before_template')
-    
+
     # Load in parent template files first if a child theme
     try:
         parent_template = config.avail_templates[template_mod.template_parent].load()
         copy_tree(parent_template.template_dir, tmp_dir)
     except AttributeError:
         pass # Not a child theme
-    
+
     # Copy the template files to the tmp directory (distutils overwrites parent theme files)
     copy_tree(template_mod.template_dir, tmp_dir)
-    
+
     # Function to include file contents in Jinja template
     def include_file(name, fdir=tmp_dir, b64=False):
         if b64:
@@ -496,7 +493,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
         else:
             with io.open (os.path.join(fdir, name), "r", encoding='utf-8') as f:
                 return f.read()
-    
+
     # Load the report template
     try:
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(tmp_dir))
@@ -516,7 +513,7 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                 print(report_output, file=f)
         except IOError as e:
             raise IOError ("Could not print report to '{}' - {}".format(config.output_fn, IOError(e)))
-        
+
         # Copy over files if requested by the theme
         try:
             for f in template_mod.copy_files:
@@ -525,15 +522,15 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
                 copy_tree(fn, dest_dir)
         except AttributeError:
             pass # No files to copy
-    
+
     # Clean up temporary directory
     shutil.rmtree(tmp_dir)
-    
+
     # Zip the data directory if requested
     if config.zip_data_dir and config.data_dir is not None:
         shutil.make_archive(config.data_dir, 'zip', config.data_dir)
         shutil.rmtree(config.data_dir)
-    
+
     # Try to create a PDF if requestted
     if make_pdf:
         try:
@@ -562,17 +559,17 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
             else:
                 logger.error("Error creating PDF! Something went wrong when creating the PDF\n"+
                     ('='*60)+"\n{}\n".format(traceback.format_exc()) + ('='*60))
-    
+
     plugin_hooks.mqc_trigger('execution_finish')
 
     logger.info("MultiQC complete")
-    
+
     # Move the log file into the data directory
     log.copy_tmp_log(logger)
-    
+
     # Exit with an error code if a module broke
     sys.exit(sys_exit_code)
-    
+
 
 if __name__ == "__main__":
     # Add any extra plugin command line options

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -344,7 +344,11 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
     for this_module in run_modules:
         try:
             mod = config.avail_modules[this_module].load()
-            report.modules_output.append(mod())
+            output = mod()
+            if type(output) != list:
+                output = [output]
+            for m in output:
+                report.modules_output.append(m)
 
             # Copy over css & js files if requested by the theme
             try:

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,12 @@ setup(
     ],
     entry_points = {
         'multiqc.modules.v1': [
+            'custom_content = multiqc.modules.custom_content:custom_module_classes', # special case
             'bamtools = multiqc.modules.bamtools:MultiqcModule',
             'bcftools = multiqc.modules.bcftools:MultiqcModule',
             'bismark = multiqc.modules.bismark:MultiqcModule',
             'bowtie2 = multiqc.modules.bowtie2:MultiqcModule',
             'bowtie1 = multiqc.modules.bowtie1:MultiqcModule',
-            'custom_content = multiqc.modules.custom_content:MultiqcModule',
             'cutadapt = multiqc.modules.cutadapt:MultiqcModule',
             'fastq_screen = multiqc.modules.fastq_screen:MultiqcModule',
             'fastqc = multiqc.modules.fastqc:MultiqcModule',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             'bismark = multiqc.modules.bismark:MultiqcModule',
             'bowtie2 = multiqc.modules.bowtie2:MultiqcModule',
             'bowtie1 = multiqc.modules.bowtie1:MultiqcModule',
+            'custom_content = multiqc.modules.custom_content:MultiqcModule',
             'cutadapt = multiqc.modules.cutadapt:MultiqcModule',
             'fastq_screen = multiqc.modules.fastq_screen:MultiqcModule',
             'fastqc = multiqc.modules.fastqc:MultiqcModule',


### PR DESCRIPTION
Due to popular demand, MultiQC can now parse _'custom content'_ - files that you generate with your own scripts, no need to write a MultiQC module.

This closes issue #300. See that issue and also the [new documentation](http://multiqc.info/docs/#custom-content) for more information and examples.

This code was written with the following example data files, which can be seen to get an idea of what kind of data you can feed MultiQC with: https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content