### PR TITLE
Added "number of predicted genes" barchart to quast module

### DIFF
--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -259,4 +259,7 @@ class MultiqcModule(BaseMultiqcModule):
         cats = [ ourpat.format(low,-high if high else "")
                  for low,high in zip(all_thresholds, all_thresholds[1:]+[None]) ]
 
-        return "\n".join([html, plots.bargraph.plot(data, cats)])
+        if len(cats) > 0:
+            return "\n".join([html, plots.bargraph.plot(data, cats)])
+        else:
+            return None

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -53,7 +53,12 @@ class MultiqcModule(BaseMultiqcModule):
             'anchor': 'quast-contigs',
             'content': self.quast_contigs_barplot()
         })
-
+        # Number of genes plot
+        self.sections.append({
+            'name': 'Number of Predicted Genes',
+            'anchor': 'quast-genes',
+            'content': self.quast_predicted_genes_barplot()
+        })
 
     def parse_quast_log(self, f):
         lines = f['f'].splitlines()
@@ -205,3 +210,53 @@ class MultiqcModule(BaseMultiqcModule):
 
         return "{}{}".format(html, plots.bargraph.plot(data, cats, pconfig))
 
+    def quast_predicted_genes_barplot(self):
+        """
+        Make a bar plot showing the number and length of predicted genes
+        for each assembly
+        """
+
+        # Intro text
+        html = """<p>This plot shows the number of predicted genes found for each
+                  assembly, broken down by length.</p>"""
+
+        # Prep the data
+        # extract the ranges given to quast with "--gene-thresholds"
+        prefix = '# predicted genes (>= '
+        suffix = ' bp)'
+        all_thresholds = sorted(list(set([
+            int(key[len(prefix):-len(suffix)])
+            for _, d in self.quast_data.items()
+            for key in d.keys()
+            if key.startswith(prefix)
+            ])))
+
+        data = {}
+        ourpat = '>= {}{} bp'
+        theirpat = prefix+"{}"+suffix
+        for s_name, d in self.quast_data.items():
+            thresholds = sorted(list(set([
+                int(key[len(prefix):-len(suffix)])
+                for _, x in self.quast_data.items()
+                for key in x.keys()
+                if key.startswith(prefix)
+            ])))
+            if len(thresholds)<2: continue
+
+            p = dict()
+            try:
+                p = { ourpat.format(thresholds[-1],""): d[theirpat.format(thresholds[-1])] }
+                for low,high in zip(thresholds[:-1], thresholds[1:]):
+                    p[ourpat.format(low,-high)] = d[theirpat.format(low)] - d[theirpat.format(high)]
+
+                assert sum(p.values()) == d[theirpat.format(0)]
+            except AssertionError:
+                log.warning("Predicted gene counts didn't add up properly for \"{}\"".format(s_name))
+            except KeyError:
+                log.warning("Not all predicted gene thresholds available for \"{}\"".format(s_name))
+            data[s_name] = p
+
+        cats = [ ourpat.format(low,-high if high else "")
+                 for low,high in zip(all_thresholds, all_thresholds[1:]+[None]) ]
+
+        return "\n".join([html, plots.bargraph.plot(data, cats)])


### PR DESCRIPTION
The barchart mirrors the existing contig length barchart. Code differences mainly because the thresholds at which quast bins the lengths of the predicted genes is configurable when running quast, so must be detected at runtime. 