### PR TITLE
multiqc: config: Catch FileNotFoundError when git is not installed.

### DIFF
--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -31,7 +31,7 @@ try:
     git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.STDOUT)
     git_hash_short = git_hash[:7]
     version = '{} ({})'.format(version, git_hash_short)
-except subprocess.CalledProcessError:
+except (subprocess.CalledProcessError, FileNotFoundError):
     pass
 os.chdir(cwd)
 


### PR DESCRIPTION
Without this patch, the incorrect exception is caught when `git` is not in `PATH`.