### PR TITLE
linegraph: allow extra_series to be empty

### DIFF
--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -88,7 +88,7 @@ def plot (data, pconfig={}):
 
     # Add on annotation data series
     try:
-        if 'extra_series' in pconfig:
+        if pconfig.get('extra_series'):
             extra_series = pconfig['extra_series']
             if type(pconfig['extra_series']) == dict:
                 extra_series = [[ pconfig['extra_series'] ]]


### PR DESCRIPTION
Fixes an edge case bug in Qualimap parsing when the species is not set,
it will pass an empty `extra_series` to linegraph:

https://github.com/ewels/MultiQC/blob/9fd1cda139f0295a99f9fa979bc7e6156c56be89/multiqc/modules/qualimap/QM_BamQC.py#L298

resulting in an index error when attempting to access the expected first
element:

https://github.com/ewels/MultiQC/blob/9fd1cda139f0295a99f9fa979bc7e6156c56be89/multiqc/plots/linegraph.py#L95

This provides a more general check to skip this.