### PR TITLE
Changed search pattern for prokka from contents : 'organism:'  to fn:…

### DIFF
--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -93,7 +93,7 @@ preseq:
     # contents: 'TOTAL_READS	EXPECTED_DISTINCT'
     # contents: 'TOTAL_BASES	EXPECTED_DISTINCT'
 prokka:
-    contents: 'organism:'
+    fn: '*.txt'
 qualimap:
     bamqc:
         genome_results:


### PR DESCRIPTION
… '*txt'

I changed search pattern for prokka from contents "organism:" to instead search for a file with the extension ".txt" since this is the suffix for all prokka summary statistics files. Unfortunately this is not very specific but I belive this will still be more efficient than searching all files in a folder structure such as the one prokka creates. I have also double checked with @fboulund that the prokka module is written so that it very quickly discards a file if it doesn't start like the one prokka creates, which should make the process as fast as possible.