### PR TITLE
Fix parsing "None" values in linegraph

### DIFF
--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -73,14 +73,16 @@ def plot (data, pconfig={}):
                     maxval = max(maxval, d[s][k])
             else:
                 for k in sorted(d[s].keys()):
-                    if 'xmax' in pconfig and float(k) > float(pconfig['xmax']):
-                        continue
-                    if 'xmin' in pconfig and float(k) < float(pconfig['xmin']):
-                        continue
-                    if 'ymax' in pconfig and float(d[s][k]) > float(pconfig['ymax']):
-                        continue
-                    if 'ymin' in pconfig and float(d[s][k]) < float(pconfig['ymin']):
-                        continue
+                    if k is not None:
+                        if 'xmax' in pconfig and float(k) > float(pconfig['xmax']):
+                            continue
+                        if 'xmin' in pconfig and float(k) < float(pconfig['xmin']):
+                            continue
+                    if d[s][k] is not None:
+                        if 'ymax' in pconfig and float(d[s][k]) > float(pconfig['ymax']):
+                            continue
+                        if 'ymin' in pconfig and float(d[s][k]) < float(pconfig['ymin']):
+                            continue
                     pairs.append([k, d[s][k]])
                     try:
                         maxval = max(maxval, d[s][k])


### PR DESCRIPTION
Hi Phil, 

After this commit https://github.com/ewels/MultiQC/commit/44c89b3483e8f3076b0f2de69f3e8e71b421e2fa#diff-6779b900d2a994ae35f19feecbc3a7cbR40, the `bcftools` module started to crash (at the line highlighted), while building the indel distribution plot. Because the point x=0 is set to `None` to avoid joining disjoint parts of the plot: https://github.com/ewels/MultiQC/blob/master/multiqc/modules/bcftools/stats.py#L43, the plotter failed to parse that `None` as `float`.

This can be reproduced only when the number of samples is higher than 1 (https://github.com/ewels/MultiQC/blob/master/multiqc/modules/bcftools/stats.py#L116), so the tests didn't catch this.

I'm not sure what would be the right solution, but this one seem to work.

Also, not sure if plotting the indel plot only for 2 or more samples was not a bug.