### PR TITLE
include picard.analysis.GcBiasSummaryMetrics in picard.gcbias module

### DIFF
--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -88,7 +88,9 @@ picard:
     basedistributionbycycle:
         contents: 'picard.analysis.BaseDistributionByCycleMetrics'
     gcbias:
-        contents: 'picard.analysis.GcBiasDetailMetrics'
+        contents:
+          - 'picard.analysis.GcBiasDetailMetrics'
+          - 'picard.analysis.GcBiasSummaryMetrics'
     hsmetrics:
         contents: 'picard.analysis.directed.HsMetrics'
     insertsize:


### PR DESCRIPTION
addresses #434 

Modeled after the behavior of other picard modules, this aggregates GcBiasSummaryMetrics so they can be written to `multiqc_data/multiqc_picard_gcbias.txt`