### PR TITLE
bcftools: fix ts/tv value rounding

### DIFF
--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -172,7 +172,7 @@ class StatsReportMixin():
         stats_headers['tstv'] = {
             'title': 'Ts/Tv',
             'description': 'Variant SNP transition / transversion ratio',
-            'min': 0, 'format': '{:.0f}',
+            'min': 0, 'format': '{:.2f}',
         }
         stats_headers['number_of_MNPs'] = {
             'title': 'MNPs',


### PR DESCRIPTION
The ts/tv ratio is reported as integer, fixing to display it as decimal.