### PR TITLE
A basic working module to parse SortMeRNA output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ it ideal for routine fast quality control.
 
 Currently, supported tools include:
 
+
+
 |Read QC & pre-processing     | Aligners / quantifiers | Post-alignment processing | Post-alignment QC    |
 |-----------------------------|------------------------|---------------------------|----------------------|
 |[Cluster Flow][clusterflow]  | [Bismark][bismark]     | [Bamtools][bamtools]      | [methylQA][methylqa] |
@@ -35,8 +37,8 @@ Currently, supported tools include:
 |[FastQC][fastqc]             | [Bowtie 2][bowtie-2]   | [GATK][gatk]              | [Preseq][preseq]     |
 |[FastQ Screen][fastq-screen] | [HiCUP][hicup]         | [HTSeq][htseq]            | [Qualimap][qualimap] |
 |[Skewer][skewer]             | [Kallisto][kallisto]   | [Picard][picard]          | [QUAST][quast]       |
-|[Trimmomatic][trimmomatic]   | [Salmon][salmon]       | [Prokka][prokka]          | [RNA-SeQC][rna_seqc] |
-|[SortMeRNA][sortmerna]       | [Slamdunk][slamdunk]   | [Samblaster][samblaster]  | [RSeQC][rseqc]       |
+|[SortMeRNA][sortmerna]       | [Salmon][salmon]       | [Prokka][prokka]          | [RNA-SeQC][rna_seqc] |
+|[Trimmomatic][trimmomatic]   | [Slamdunk][slamdunk]   | [Samblaster][samblaster]  | [RSeQC][rseqc]       |
 |                             | [STAR][star]           | [Samtools][samtools]      | [BUSCO][busco]       |
 |                             | [Tophat][tophat]       | [SnpEff][snpeff]          | [goleft][goleft]     |
 |                             |                        | [Subread featureCounts][featurecounts] |         |
@@ -142,9 +144,10 @@ Code contributions from:
 [@HLWiencko](https://github.com/HLWiencko),
 [@guillermo-carrasco](https://github.com/guillermo-carrasco),
 [@avilella](https://github.com/avilella),
-[@vladsaveliev](https://github.com/vladsaveliev)
-[@t-neumann](https://github.com/t-neumann)
-[@ahvigil](https://github.com/ahvigil)
+[@vladsaveliev](https://github.com/vladsaveliev),
+[@t-neumann](https://github.com/t-neumann),
+[@ahvigil](https://github.com/ahvigil),
+[@bschiffthaler](https://github.com/bschiffthaler)
 and many others. Thanks for your support!
 
 [bamtools]:       http://multiqc.info/docs/#bamtools

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Currently, supported tools include:
 |[FastQ Screen][fastq-screen] | [HiCUP][hicup]         | [HTSeq][htseq]            | [Qualimap][qualimap] |
 |[Skewer][skewer]             | [Kallisto][kallisto]   | [Picard][picard]          | [QUAST][quast]       |
 |[Trimmomatic][trimmomatic]   | [Salmon][salmon]       | [Prokka][prokka]          | [RNA-SeQC][rna_seqc] |
-|                             | [Slamdunk][slamdunk]   | [Samblaster][samblaster]  | [RSeQC][rseqc]       |
+|[SortMeRNA][sortmerna]       | [Slamdunk][slamdunk]   | [Samblaster][samblaster]  | [RSeQC][rseqc]       |
 |                             | [STAR][star]           | [Samtools][samtools]      | [BUSCO][busco]       |
 |                             | [Tophat][tophat]       | [SnpEff][snpeff]          | [goleft][goleft]     |
 |                             |                        | [Subread featureCounts][featurecounts] |         |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ MultiQC Modules:
     FastQC: modules/fastqc.md
     FastQ Screen: modules/fastq_screen.md
     Skewer: modules/skewer.md
+    SortMeRNA: module/sortmerna.md
     Trimmomatic: modules/trimmomatic.md
   Aligners:
     Bismark: modules/bismark.md

--- a/docs/modules/sortmerna.md
+++ b/docs/modules/sortmerna.md
@@ -1,0 +1,11 @@
+---
+Name: SortMeRNA
+URL: http://bioinfo.lifl.fr/RNA/sortmerna/
+Description: >
+    SortMeRNA is a program tool for filtering, mapping and OTU-picking NGS reads
+    in metatranscriptomic and metagenomic data.
+---
+
+SortMeRNA is a program tool for filtering, mapping and OTU-picking NGS reads in metatranscriptomic and metagenomic data. The core algorithm is based on approximate seeds and allows for fast and sensitive analyses of nucleotide sequences. The main application of SortMeRNA is filtering ribosomal RNA from metatranscriptomic data.
+
+The MultiQC module parses the log files, which are created when `SortMeRNA` is run with the `--log` option.

--- a/docs/modules/sortmerna.md
+++ b/docs/modules/sortmerna.md
@@ -9,3 +9,10 @@ Description: >
 SortMeRNA is a program tool for filtering, mapping and OTU-picking NGS reads in metatranscriptomic and metagenomic data. The core algorithm is based on approximate seeds and allows for fast and sensitive analyses of nucleotide sequences. The main application of SortMeRNA is filtering ribosomal RNA from metatranscriptomic data.
 
 The MultiQC module parses the log files, which are created when `SortMeRNA` is run with the `--log` option.
+
+The default header in the 'General Statistics' table is '% rRNA'. Users can override this using the configuration option:
+
+```
+sortmerna:
+    tab_header: 'My database hits'
+```

--- a/multiqc/modules/sortmerna/__init__.py
+++ b/multiqc/modules/sortmerna/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+from .sortmerna import MultiqcModule
+

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+""" MultiQC module to parse output from SortMeRNA """
+
+from __future__ import print_function
+from collections import OrderedDict
+import json
+import logging
+import os
+import re
+
+from multiqc.modules.base_module import config, BaseMultiqcModule
+from multiqc import plots
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class MultiqcModule(BaseMultiqcModule):
+
+    def __init__(self):
+
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(name='SortMeRNA', anchor='sortmerna',
+        href='http://bioinfo.lifl.fr/RNA/sortmerna/',
+        info="is a program tool for filtering, mapping and OTU-picking NGS reads in metatranscriptomic and metagenomic data.")
+
+        # Parse logs
+        self.sortmerna = dict()
+        for f in self.find_log_files(config.sp['sortmerna'], filehandles=True):
+            self.parse_sortmerna(f)
+
+        if len(self.sortmerna) == 0:
+            log.debug("Could not find any SortMeRNA data in {}".format(config.analysis_dir))
+            raise UserWarning
+
+        log.info("Found {} logs".format(len(self.sortmerna)))
+        self.write_data_file(self.sortmerna, 'multiqc_sortmerna')
+        log.debug(self.sortmerna)
+        # Add rRNA rate to the general stats table
+        headers = OrderedDict()
+        headers['rRNA_pct'] = {
+            'title': '% rRNA',
+            'description': '% rRNA',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'scale': 'OrRd',
+            'format': '{:.1f}%'
+        }
+        self.general_stats_addcols(self.sortmerna, headers)
+
+        # Make barplot
+        self.intro += self.sortmerna_overall_barplot()
+        self.intro += self.sortmerna_detailed_barplot()
+
+    def parse_sortmerna(self, f):
+        s_name = None
+        post_results_start = False
+        post_database_start = False
+        db_number = 0
+        err = False
+
+        for l in f["f"]:
+            if "Reads file" in l:
+                s_name = os.path.basename(l.split(" ")[-1]).strip().split(".")[0]
+                self.sortmerna[s_name] = dict()
+            if "Results:" in l and not post_results_start:
+                post_results_start = True
+            if not post_results_start:
+                continue
+            if post_results_start and not post_database_start:
+                if "Total reads =" in l:
+                    m = re.search("\d+",l)
+                    if m:
+                        self.sortmerna[s_name]["total"] = int(m.group())
+                    else:
+                        err = True
+                elif "Total reads passing" in l:
+                    m = re.search("\d+",l)
+                    if m:
+                        self.sortmerna[s_name]["rRNA"] = int(m.group())
+                        self.sortmerna[s_name]["rRNA_pct"] = float(self.sortmerna[s_name]["rRNA"]) / float(self.sortmerna[s_name]["total"]) * 100
+                    else:
+                        err = True
+                elif "Total reads failing" in l:
+                    m = re.search("\d+",l)
+                    if m:
+                        self.sortmerna[s_name]["non_rRNA"] = int(m.group())
+                        self.sortmerna[s_name]["non_rRNA_pct"] = float(self.sortmerna[s_name]["non_rRNA"]) / float(self.sortmerna[s_name]["total"]) * 100
+                    else:
+                        err = True
+            if post_database_start:
+                if not l.strip():
+                    break
+                db_number = db_number + 1
+                m = re.search("    .*\t", l)
+                if m:
+                    db = m.group().strip()
+                    db = os.path.splitext(os.path.basename(db))[0]
+                    pct = float(re.search("\d+\.\d+%", l).group().replace("%",""))
+                    count = int(self.sortmerna[s_name]["total"]) * (pct / 100)
+                    self.sortmerna[s_name][db + "_pct"] = pct
+                    self.sortmerna[s_name][db + "_count"] = count
+                else:
+                    err = True
+            if "By database:" in l and not post_database_start:
+                post_database_start = True
+        if err:
+            log.warning("Error parsing data in: " + s_name)
+            self.sortmerna.pop(s_name, 'None')
+        s_name = None
+
+    def sortmerna_overall_barplot (self):
+        keys = OrderedDict()
+        keys["non_rRNA"] = { 'color': '#a6cee3', 'name': 'Other' }
+        keys["rRNA"] = { 'color': '#e31a1c', 'name': 'rRNA' }
+        pconfig = {
+            'id': 'SortMeRNA overall',
+            'title': 'SortMeRNA Other vs rRNA',
+            'ylab': 'Reads'
+        }
+        log.debug(keys)
+        return plots.bargraph.plot(self.sortmerna, keys, pconfig)
+
+    def sortmerna_detailed_barplot (self):
+        """ Make the HighCharts HTML to plot the sortmerna rates """
+
+        colors = ["#1f78b4", "#b2df8a", "#33a02c", "#fb9a99",
+                  "#e31a1c", "#fdbf6f", "#ff7f00", "#cab2d6",
+                  "#6a3d9a", "#ffff99", "#b15928"]
+
+        # Specify the order of the different possible categories
+        keys = OrderedDict()
+        metrics = set()
+        for sample in self.sortmerna:
+            for key in self.sortmerna[sample]:
+                if not key in ["total", "rRNA", "non_rRNA"] and not "_pct" in key:
+                    metrics.add(key)
+
+        col_index = 0
+        for key in metrics:
+            keys[key] = { 'color': colors[col_index], 'name': key.replace("_count","") }
+            col_index = col_index + 1
+        # Config for the plot
+        pconfig = {
+            'id': 'SortMeRNA detailed',
+            'title': 'SortMeRNA hits',
+            'ylab': 'Reads'
+        }
+
+        return plots.bargraph.plot(self.sortmerna, keys, pconfig)

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -34,6 +34,9 @@ class MultiqcModule(BaseMultiqcModule):
             log.debug("Could not find any SortMeRNA data in {}".format(config.analysis_dir))
             raise UserWarning
 
+        log.info("Found {} logs".format(len(self.sortmerna)))
+        self.write_data_file(self.sortmerna, 'multiqc_sortmerna')
+
         # Get custom table header, default to 'rRNA'
         tab_header = getattr(config, 'sortmerna', {}).get('seqname', '% rRNA')
 

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -193,3 +193,4 @@ module_order:
     - 'fastq_screen'
     - 'fastqc'
     - 'clusterflow'
+    - 'sortmerna'

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -199,12 +199,12 @@ slamdunk:
         contents: '# slamdunk tcperutr'
 snpeff:
     contents: 'SnpEff_version'
+sortmerna:
+    contents: 'Minimal SW score based on E-value'
 star:
     fn: '*Log.final.out'
 star_genecounts:
     fn: '*ReadsPerGene.out.tab'
-sortmerna:
-    contents: 'Command: sortmerna'
 tophat:
     fn: '*align_summary.txt'
 trimmomatic:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -203,6 +203,8 @@ star:
     fn: '*Log.final.out'
 star_genecounts:
     fn: '*ReadsPerGene.out.tab'
+sortmerna:
+    contents: 'Command: sortmerna'
 tophat:
     fn: '*align_summary.txt'
 trimmomatic:

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
             'slamdunk = multiqc.modules.slamdunk:MultiqcModule',
             'snpeff = multiqc.modules.snpeff:MultiqcModule',
             'star = multiqc.modules.star:MultiqcModule',
+            'sortmerna = multiqc.modules.sortmerna:MultiqcModule',
             'tophat = multiqc.modules.tophat:MultiqcModule',
             'trimmomatic = multiqc.modules.trimmomatic:MultiqcModule',
             'gatk = multiqc.modules.gatk:MultiqcModule',


### PR DESCRIPTION
SortMeRNA identifies rRNA containing reads in FASTQ files (although any custom file can be used to create a database). It is commonly used in metagenomics analyses and in general data processing to deplete rRNA or other contaminants (e.g.: PhiX)