### PR TITLE
Search refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,27 @@ Version 1.0! Bumping the major version number for a couple of reasons:
    compatibility for plugins. As such, semantic versioning suggests a change in
    major version number.
 
-Most people who run MultiQC just use the core installation.
-If this is the case for you, then you have nothing to worry about. The changes
-mentioned above will only apply to plugins and external code bases.
-To see what changes need to applied to your custom plugin code, please see
-the [MultiQC docs](http://multiqc.info/docs/#v1.0-updates).
+For most people, you shouldn't have any problems upgrading. There are two
+scenarios where you may need to make changes with this update:
+
+1. You have custom file search patterns
+  * These have been flattened. For example, change the following:
+```yaml
+fastqc:
+    data:
+        fn: 'fastqc_data.txt'
+    zip:
+        fn: '*_fastqc.zip'
+```
+  to this:
+```yaml
+fastqc/data:
+    fn: 'fastqc_data.txt'
+fastqc/zip:
+    fn: '*_fastqc.zip'
+```
+2. You have custom plugins / modules / external code
+  * To see what changes need to applied to your custom plugin code, please see the [MultiQC docs](http://multiqc.info/docs/#v1.0-updates).
 
 #### Module updates:
 * [**BUSCO**](http://busco.ezlab.org/) - new module!
@@ -55,6 +71,9 @@ the [MultiQC docs](http://multiqc.info/docs/#v1.0-updates).
 
 #### Core MultiQC updates:
 * Change in module structure and import statements (see [details](http://multiqc.info/docs/#v1.0-updates)).
+* Module file search has been rewritten (see above changes to configs)
+  * Significant improvement in search speed
+  * More options for modules to find their logs (see the [docs](http://multiqc.info/docs/#step-1-find-log-files))
 * New config option to change numeric multiplier in General Stats
   * For example, if reports have few reads, can show `Thousands of Reads` instead of `Millions of Reads`
   * Set config options `read_count_multiplier`, `read_count_prefix` and `read_count_desc`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ fastqc/zip:
 * Change in module structure and import statements (see [details](http://multiqc.info/docs/#v1.0-updates)).
 * Module file search has been rewritten (see above changes to configs)
   * Significant improvement in search speed (test dataset runs in approximately half the time)
-  * More options for modules to find their logs, eg. filename regexes (see the [docs](http://multiqc.info/docs/#step-1-find-log-files))
+  * More options for modules to find their logs, eg. filename and contents matching regexes (see the [docs](http://multiqc.info/docs/#step-1-find-log-files))
 * New config option to change numeric multiplier in General Stats
   * For example, if reports have few reads, can show `Thousands of Reads` instead of `Millions of Reads`
   * Set config options `read_count_multiplier`, `read_count_prefix` and `read_count_desc`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ fastqc/data:
 fastqc/zip:
     fn: '*_fastqc.zip'
 ```
+  * See the [documentation](http://multiqc.info/docs/#step-1-find-log-files) for instructions on how to write the new file search syntax.
+  * See [`search_patterns.yaml`](multiqc/utils/search_patterns.yaml) for examples.
 2. You have custom plugins / modules / external code
   * To see what changes need to applied to your custom plugin code, please see the [MultiQC docs](http://multiqc.info/docs/#v1.0-updates).
 
@@ -72,8 +74,8 @@ fastqc/zip:
 #### Core MultiQC updates:
 * Change in module structure and import statements (see [details](http://multiqc.info/docs/#v1.0-updates)).
 * Module file search has been rewritten (see above changes to configs)
-  * Significant improvement in search speed
-  * More options for modules to find their logs (see the [docs](http://multiqc.info/docs/#step-1-find-log-files))
+  * Significant improvement in search speed (test dataset runs in approximately half the time)
+  * More options for modules to find their logs, eg. filename regexes (see the [docs](http://multiqc.info/docs/#step-1-find-log-files))
 * New config option to change numeric multiplier in General Stats
   * For example, if reports have few reads, can show `Thousands of Reads` instead of `Millions of Reads`
   * Set config options `read_count_multiplier`, `read_count_prefix` and `read_count_desc`

--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -261,19 +261,17 @@ should be parsed.
 
 As described in the above [_Data as part of MultiQC config_](#data-as-part-of-multiqc-config) section,
 this configuration should be held within a section called `custom_data` with a section-specific id.
-The only difference is that no `data` subsection should be present and the `sp` key _must_ be present.
+The only difference is that no `data` subsection is given and a search pattern for the given id must
+be supplied.
 
-The `sp` key tells MultiQC how to find files. This should have `fn` and/or `contents` under it, as
-described in the [Module search patterns](http://multiqc.info/docs/#module-search-patterns) section
-of the docs.
+Search patterns are added [as with any other module](http://multiqc.info/docs/#module-search-patterns).
+Ensure that the search pattern key is the same as your `custom_data` section ID.
 
 For example:
 ```yaml
 # Other MultiQC config stuff here
 custom_data:
     example_files:
-        sp:
-            fn: 'example_files_*'
         file_format: 'tsv'
         section_name: 'Coverage Decay'
         description: 'This plot comes from files acommpanied by a mutliqc_config.yaml file for configuration'
@@ -284,6 +282,9 @@ custom_data:
             ylab: 'X Coverage'
             ymax: 100
             ymin: 0
+sp:
+    example_files:
+        fn: 'example_files_*'
 ```
 A data file within the MultiQC search directories could then simply look like this:
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -165,7 +165,10 @@ or more search criteria. The following keys can be used:
 * `fn_re`
   * A regex filename pattern
 * `contents`
-  * A string to match within the file contents
+  * A string to match within the file contents (checked line by line)
+* `contents_re`
+  * A regex to match within the file contents (checked line by line)
+  * NB: Regex must match entire line (add `.*` to start and end of pattern to avoid this)
 * `num_lines`
   * The number of lines to search through for the `contents` string. Default: all lines.
 * `shared`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -167,35 +167,32 @@ myothermod:
     contents: This is myprogram v1.3
 ```
 
-Note that if you want to find multiple log files, you can nest these
-dictionaries (though they must end with either `fn` or `contents`).
-For example, see the `FastQC` module:
+Note that if you want to find multiple log files, the convention is
+to use the module name and a forward slash separator _(this helps
+backwards-compatibility)_:
 ```yaml
-fastqc:
-    data:
-        fn: fastqc_data.txt
-    zip:
-        fn: _fastqc.zip
+fastqc/data:
+    fn: fastqc_data.txt
+fastqc/zip:
+    fn: _fastqc.zip
 ```
 
-You can supply a list of strings if needed, eg. the `bismark` module:
+You can also supply a list of strings if needed, eg. the `bismark` module:
 ```yaml
-bismark:
-    align:
-        fn:
-            - _PE_report.txt
-            - _SE_report.txt
+bismark/align:
+    fn:
+        - _PE_report.txt
+        - _SE_report.txt
 ```
 
 The value of adding these strings here is that they can be overwritten
 by users in their own config files. This is helpful as people have weird
 and wonderful processing pipelines with their own file naming conventions.
 
-Once your strings are added, you can call them in your module with the
-`config.sp['mymod']`. Next, use the base function `self.find_log_files()`
-to look for your files like this:
+Once your strings are added, you can find files in your module with the
+base function `self.find_log_files()`, using the key you set in the YAML:
 ```python
-self.find_log_files(config.sp['mymod'], filehandles=False)
+self.find_log_files('mymod', filehandles=False)
 ```
 
 This will recursively search the analysis directories looking for a matching
@@ -209,7 +206,7 @@ This function yields a dictionary with various information about matching
 files. The `f` key contains the contents of matching files by default.
 ```python
 # Find all files for mymod
-for f in self.find_log_files(config.sp['mymod']):
+for f in self.find_log_files('mymod'):
     print f['f']        # File contents
     print f['s_name']   # Sample name (from cleaned fn)
     print f['root']     # Directory file was in
@@ -221,7 +218,7 @@ instead:
 ```python
 # Find all files which contain the string 'My Statistic:'
 # Return a filehandle instead of the file contents
-for f in self.find_log_files(config.sp['mymod'], filehandles=True):
+for f in self.find_log_files('mymod', filehandles=True):
     line = f['f'].readline()  # f['f'] is now a filehandle instead of contents
 ```
 
@@ -237,7 +234,7 @@ class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # [...]
         self.mod_data = dict()
-        for f in self.find_log_files(config.sp['mymod']):
+        for f in self.find_log_files('mymod'):
             self.mod_data[f['s_name']] = self.parse_logs(f['f'])
 
     def parse_logs(self, f):
@@ -301,7 +298,7 @@ is typically written immediately after the above warning.
 If you've used the `self.find_log_files` function, writing to the sources file
 is as simple as passing the log file variable to the `self.add_data_source` function:
 ```python
-for f in self.find_log_files(config.sp['mymod']):
+for f in self.find_log_files('mymod'):
     self.add_data_source(f)
 ```
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -157,19 +157,37 @@ First, add your default patterns to:
 MULTIQC_ROOT/multiqc/utils/search_patterns.yaml
 ```
 
-You should see the patterns for all other modules to give you an idea,
-but you want a yaml key with the name of your module, then either `fn`
-or `contents` for strings to match against filenames or file contents:
+Each search has a yaml key (typically the name of your module), with one
+or more search criteria. The following keys can be used:
+
+* `fn`
+  * A glob filename pattern, used with the Python [`fnmatch`](https://docs.python.org/2/library/fnmatch.html) function
+* `fn_re`
+  * A regex filename pattern
+* `contents`
+  * A string to match within the file contents
+* `num_lines`
+  * The number of lines to search through for the `contents` string. Default: all lines.
+* `shared`
+  * By default, once a file has been assigned to a module it is not searched again. Specify `shared: true` when your file can be shared between multiple tools (for example, part of a `stdout` stream).
+* `max_filesize`
+  * Files larger than the `log_filesize_limit` config key (default: 10MB) are skipped. If you know your files will be smaller than this and need to search by contents, you can specify this value (in bytes) to skip any files smaller than this limit.
+
+Please try to use `num_lines` and `max_filesize` where possible as they will speed up
+MultiQC execution time.
+
+For example, two typical modules could specify search patterns as follows:
+
 ```yaml
 mymod:
-    fn: _myprogram.txt
+    fn: '_myprogram.txt'
 myothermod:
-    contents: This is myprogram v1.3
+    contents: 'This is myprogram v1.3'
 ```
 
-Note that if you want to find multiple log files, the convention is
-to use the module name and a forward slash separator _(this helps
-backwards-compatibility)_:
+Note that if you want to find multiple different log files for a single module,
+the convention is to use the module name and a forward slash separator _(this changed
+in the v1.0 release and the slashes help backwards-compatibility)_:
 ```yaml
 fastqc/data:
     fn: fastqc_data.txt
@@ -177,50 +195,58 @@ fastqc/zip:
     fn: _fastqc.zip
 ```
 
-You can also supply a list of strings if needed, eg. the `bismark` module:
+You can also supply a list of different patterns for a single log file type if needed.
+If any of the patterns are matched, the file will be returned:
 ```yaml
-bismark/align:
-    fn:
-        - _PE_report.txt
-        - _SE_report.txt
+mymod:
+    - fn: 'mylog.txt'
+    - fn: 'different_fn.out'
 ```
 
-The value of adding these strings here is that they can be overwritten
-by users in their own config files. This is helpful as people have weird
-and wonderful processing pipelines with their own file naming conventions.
+You can use _AND_ logic by specifying keys within a single list item. For example:
+```yaml
+mymod:
+    fn: 'mylog.txt'
+    contents: 'mystring'
+myothermod:
+    - fn: 'different_fn.out'
+      contents: 'This is myprogram v1.3'
+    - fn: 'another.txt'
+      contents: 'What are these files anyway?'
+```
+Here, a file must have the filename `mylog.txt` _and_ contain the string `mystring`.
+
+Remember that users can overwrite these defaults in their own config files.
+This is helpful as people have weird and wonderful processing pipelines with
+their own conventions.
 
 Once your strings are added, you can find files in your module with the
 base function `self.find_log_files()`, using the key you set in the YAML:
 ```python
-self.find_log_files('mymod', filehandles=False)
+self.find_log_files('mymod')
 ```
 
-This will recursively search the analysis directories looking for a matching
-file name (if the `fn` key is there) or a text string held within a file
-(if the `contents` key is there). Contents matching is only done on files
-smaller than `config.log_filesize_limit` (default 1MB).
-Note that both `fn` and `contents` can be used in combination
-if required - files will be returned if anything matches (`OR` not `AND`).
-
-This function yields a dictionary with various information about matching
-files. The `f` key contains the contents of matching files by default.
+This function yields a dictionary with various information about each matching
+file. The `f` key contains the contents of the matching file:
 ```python
 # Find all files for mymod
-for f in self.find_log_files('mymod'):
-    print f['f']        # File contents
-    print f['s_name']   # Sample name (from cleaned fn)
-    print f['root']     # Directory file was in
-    print f['fn']       # Filename
+for myfile in self.find_log_files('mymod'):
+    print( myfile['f'] )       # File contents
+    print( myfile['s_name'] )  # Sample name (from cleaned filename)
+    print( myfile['fn'] )      # Filename
+    print( myfile['root'] )    # Directory file was in
 ```
 
 If `filehandles=True` is specified, the `f` key contains a file handle
 instead:
 ```python
-# Find all files which contain the string 'My Statistic:'
-# Return a filehandle instead of the file contents
 for f in self.find_log_files('mymod', filehandles=True):
-    line = f['f'].readline()  # f['f'] is now a filehandle instead of contents
+    # f['f'] is now a filehandle instead of contents
+    for l in f['f']:
+        print( l )
 ```
+This is good if the file is large, as Python doesn't read the entire
+file into memory in one go.
 
 ## Step 2 - Parse data from the input files
 What most MultiQC modules do once they have found matching analysis files

--- a/multiqc/modules/bamtools/stats.py
+++ b/multiqc/modules/bamtools/stats.py
@@ -44,7 +44,7 @@ def parse_reports(self):
     }
 
     # Go through files and parse data using regexes
-    for f in self.find_log_files(config.sp['bamtools']['stats']):
+    for f in self.find_log_files('bamtools/stats'):
         d = dict()
         for k, r in regexes.items():
             r_search = re.search(r, f['f'], re.MULTILINE)

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -4,7 +4,6 @@
 
 from __future__ import print_function
 from collections import OrderedDict
-import fnmatch
 import io
 import logging
 import os
@@ -44,73 +43,33 @@ class BaseMultiqcModule(object):
                  As yield is used, the results can be iterated over without loading all files at once
         """
 
-        # Get the search patterns
-        if isinstance(sp_key, dict):
-            patterns = sp_key
-        else:
-            patterns = config.sp.get(sp_key, {})
+        # # Get the search patterns
+        # if isinstance(sp_key, dict):
+        #     patterns = sp_key
+        # else:
+        #     patterns = config.sp.get(sp_key, {})
 
-        # Get the search parameters
-        fn_match = None
-        contents_match = None
-        if 'fn' in patterns:
-            fn_match = patterns['fn']
-        if 'contents' in patterns:
-            contents_match = patterns['contents']
-        if fn_match == None and contents_match == None:
-            logger.warning("No file patterns specified for {}".format(self.name))
+        if not isinstance(sp_key, str):
+            logger.warn("Depreciated: Please use new style for find_log_files()")
             return
 
-        # Loop through files, yield results if we find something
-        for f in report.files:
-
-            # Set up vars
-            root = f['root']
-            fn = f['fn']
-
+        for f in report.files[sp_key]:
             # Make a sample name from the filename
-            s_name = self.clean_s_name(fn, root)
-
-            # Make search strings into lists if a string is given
-            if type(fn_match) is str:
-                fn_match = [fn_match]
-            if type(contents_match) is str:
-                contents_match = [contents_match]
-
-            # Search for file names ending in a certain string
-            fn_matched = False
-            if fn_match is not None:
-                for m in fn_match:
-                    if fnmatch.fnmatch(fn, m):
-                        fn_matched = True
-                        if not filehandles and not filecontents:
-                            yield {'s_name': s_name, 'root': root, 'fn': fn}
-
-            if fn_matched or contents_match is not None:
+            f['s_name'] = self.clean_s_name(f['fn'], f['root'])
+            if filehandles or filecontents:
                 try:
-                    with io.open (os.path.join(root,fn), "r", encoding='utf-8') as f:
-
-                        # Search this file for our string of interest
-                        returnfile = False
-                        if contents_match is not None and fn_matched is False:
-                            for line in f:
-                                for m in contents_match:
-                                    if m in line:
-                                        returnfile = True
-                                        break
-                            f.seek(0)
-                        else:
-                            returnfile = True
-
-                        if returnfile:
-                            if filehandles:
-                                yield {'s_name': s_name, 'f': f, 'root': root, 'fn': fn}
-                            elif filecontents:
-                                yield {'s_name': s_name, 'f': f.read(), 'root': root, 'fn': fn}
-
+                    with io.open (os.path.join(f['root'],f['fn']), "r", encoding='utf-8') as fh:
+                        if filehandles:
+                            f['f'] = fh
+                        elif filecontents:
+                            f['f'] = fh.read()
+                            yield f # Yield inside the with, so file still open
                 except (IOError, OSError, ValueError, UnicodeDecodeError):
                     if config.report_readerrors:
-                        logger.debug("Couldn't read file when looking for output: {}".format(fn))
+                        logger.debug("Couldn't open filehandle when returning file: {}".format(f['fn']))
+                        f['f'] = None
+            else:
+                yield f
 
     def add_section(self, name=None, anchor=None, description='', helptext='', plot='', content='', autoformat=True):
         """ Add a section to the module report output """

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -41,8 +41,21 @@ class BaseMultiqcModule(object):
                  As yield is used, the results can be iterated over without loading all files at once
         """
 
-        if not isinstance(sp_key, str):
-            logger.warn("Depreciated: Please use new style for find_log_files()")
+        # Old, depreciated syntax support
+        # Can also be used by Custom Content
+        if isinstance(sp_key, dict):
+            report.files[self.name] = list()
+            for sf in report.searchfiles:
+                if report.search_file(sp_key, {'fn': sf[0], 'root': sf[1]}):
+                    report.files[self.name].append({'fn': sf[0], 'root': sf[1]})
+            sp_key = self.name
+            logwarn = "Depreciation Warning: {} - Please use new style for find_log_files()".format(self.name)
+            if len(report.files[self.name]) > 0:
+                logger.warn(logwarn)
+            else:
+                logger.debug(logwarn)
+        elif not isinstance(sp_key, str):
+            logger.warn("Did not understand find_log_files() search key")
             return
 
         for f in report.files[sp_key]:

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -32,22 +32,14 @@ class BaseMultiqcModule(object):
 
     def find_log_files(self, sp_key, filecontents=True, filehandles=False):
         """
-        Search the analysis directory for log files of interest. Can take either a filename
-        suffix or a search string to return only log files that contain relevant info.
-        :param patterns: Dict with keys 'fn' or 'contents' (or both). Keys can contain
-        string or a list of strings. 'fn' matches filenames, 'contents' matches file contents.
-        NB: Both searches return file if *any* of the supplied strings are matched.
+        Return matches log files of interest.
+        :param sp_key: Search pattern key specified in config
         :param filehandles: Set to true to return a file handle instead of slurped file contents
-        :return: Yields a set with two items - a sample name generated from the filename
-                 and either the file contents or file handle for the current matched file.
+        :return: Yields a dict with filename (fn), root directory (root), cleaned sample name
+                 generated from the filename (s_name) and either the file contents or file handle
+                 for the current matched file (f).
                  As yield is used, the results can be iterated over without loading all files at once
         """
-
-        # # Get the search patterns
-        # if isinstance(sp_key, dict):
-        #     patterns = sp_key
-        # else:
-        #     patterns = config.sp.get(sp_key, {})
 
         if not isinstance(sp_key, str):
             logger.warn("Depreciated: Please use new style for find_log_files()")

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -41,8 +41,7 @@ class BaseMultiqcModule(object):
                  As yield is used, the results can be iterated over without loading all files at once
         """
 
-        # Old, depreciated syntax support
-        # Can also be used by Custom Content
+        # Old, depreciated syntax support. Likely to be removed in a future version.
         if isinstance(sp_key, dict):
             report.files[self.name] = list()
             for sf in report.searchfiles:
@@ -66,9 +65,10 @@ class BaseMultiqcModule(object):
                     with io.open (os.path.join(f['root'],f['fn']), "r", encoding='utf-8') as fh:
                         if filehandles:
                             f['f'] = fh
+                            yield f
                         elif filecontents:
                             f['f'] = fh.read()
-                            yield f # Yield inside the with, so file still open
+                            yield f
                 except (IOError, OSError, ValueError, UnicodeDecodeError):
                     if config.report_readerrors:
                         logger.debug("Couldn't open filehandle when returning file: {}".format(f['fn']))

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -31,7 +31,7 @@ class BaseMultiqcModule(object):
         self.intro = '<p>{} {}</p>{}'.format( mname, info, extra )
         self.sections = list()
 
-    def find_log_files(self, patterns, filecontents=True, filehandles=False):
+    def find_log_files(self, sp_key, filecontents=True, filehandles=False):
         """
         Search the analysis directory for log files of interest. Can take either a filename
         suffix or a search string to return only log files that contain relevant info.
@@ -43,6 +43,12 @@ class BaseMultiqcModule(object):
                  and either the file contents or file handle for the current matched file.
                  As yield is used, the results can be iterated over without loading all files at once
         """
+
+        # Get the search patterns
+        if isinstance(sp_key, dict):
+            patterns = sp_key
+        else:
+            patterns = config.sp.get(sp_key, {})
 
         # Get the search parameters
         fn_match = None

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -26,7 +26,7 @@ class StatsReportMixin():
         self.bcftools_stats = dict()
         self.bcftools_stats_indels = dict()
         depth_data = dict()
-        for f in self.find_log_files(config.sp['bcftools']['stats']):
+        for f in self.find_log_files('bcftools/stats'):
             s_names = list()
             for line in f['f'].splitlines():
                 s = line.split("\t")

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -80,10 +80,9 @@ class MultiqcModule(BaseMultiqcModule):
             'meth': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}},
             'cov': {'CpG_R1' : {}, 'CHG_R1' : {}, 'CHH_R1' : {}, 'CpG_R2' : {}, 'CHG_R2' : {}, 'CHH_R2' : {}}
         }
-        sp = config.sp['bismark']
 
         # Find and parse bismark alignment reports
-        for f in self.find_log_files(sp['align']):
+        for f in self.find_log_files('bismark/align'):
             parsed_data = self.parse_bismark_report(f['f'], regexes['alignment'])
             if parsed_data is not None:
                 # Calculate percent_aligned - doubles as a good check that stuff has worked
@@ -98,7 +97,7 @@ class MultiqcModule(BaseMultiqcModule):
                     self.bismark_data['alignment'][f['s_name']] = parsed_data
 
         # Find and parse bismark deduplication reports
-        for f in self.find_log_files(sp['dedup']):
+        for f in self.find_log_files('bismark/dedup'):
             parsed_data = self.parse_bismark_report(f['f'], regexes['dedup'])
             if parsed_data is not None:
                 if f['s_name'] in self.bismark_data['dedup']:
@@ -107,7 +106,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['dedup'][f['s_name']] = parsed_data
 
         # Find and parse bismark methylation extractor reports
-        for f in self.find_log_files(sp['meth_extract']):
+        for f in self.find_log_files('bismark/meth_extract'):
             parsed_data = self.parse_bismark_report(f['f'], regexes['methextract'])
             s_name = f['s_name']
             if parsed_data is not None:
@@ -117,12 +116,12 @@ class MultiqcModule(BaseMultiqcModule):
                 self.bismark_data['methextract'][s_name] = parsed_data
 
         # Find and parse M-bias plot data
-        for f in self.find_log_files(sp['m_bias'], filehandles=True):
+        for f in self.find_log_files('bismark/m_bias', filehandles=True):
             self.parse_bismark_mbias(f)
             self.add_data_source(f, section='m_bias')
 
         # Find and parse bam2nuc reports
-        for f in self.find_log_files(sp['bam2nuc'], filehandles=True):
+        for f in self.find_log_files('bismark/bam2nuc', filehandles=True):
             self.parse_bismark_bam2nuc(f)
             self.add_data_source(f, section='bam2nuc')
 

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -37,7 +37,7 @@ class MultiqcModule(BaseMultiqcModule):
             'bowtie.right_kept_reads.m2g_um_seg1.log',
             'bowtie.right_kept_reads.m2g_um_seg2.log'
         ]
-        for f in self.find_log_files(config.sp['bowtie']):
+        for f in self.find_log_files('bowtie'):
             if f['fn'] in fn_ignore:
                 log.debug('Skipping file because looks like tophat log: {}/{}'.format(f['root'], f['fn']))
                 continue

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.bowtie2_data = dict()
         self.num_se = 0
         self.num_pe = 0
-        for f in self.find_log_files(config.sp['bowtie2'], filehandles=True):
+        for f in self.find_log_files('bowtie2', filehandles=True):
             # Check that this isn't actually Bismark using bowtie
             if f['f'].read().find('bisulfite', 0) < 0:
                 f['f'].seek(0)

--- a/multiqc/modules/busco/busco.py
+++ b/multiqc/modules/busco/busco.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any BUSCO reports
         self.busco_data = dict()
-        for f in self.find_log_files(config.sp['busco']):
+        for f in self.find_log_files('busco'):
             self.parse_busco_log(f)
 
         if len(self.busco_data) == 0:

--- a/multiqc/modules/clusterflow/clusterflow.py
+++ b/multiqc/modules/clusterflow/clusterflow.py
@@ -33,10 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
         self.clusterflow_commands = dict()
         self.clusterflow_runfiles = dict()
 
-        for f in self.find_log_files(config.sp['clusterflow']['logs'], filehandles=True):
+        for f in self.find_log_files('clusterflow/logs', filehandles=True):
             self.parse_clusterflow_logs(f)
             self.add_data_source(f, 'log')
-        for f in self.find_log_files(config.sp['clusterflow']['runfiles'], filehandles=True):
+        for f in self.find_log_files('clusterflow/runfiles', filehandles=True):
             parsed_data = self.parse_clusterflow_runfiles(f)
             if parsed_data is not None:
                 self.clusterflow_runfiles[f['s_name']] = parsed_data

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -108,7 +108,7 @@ def custom_module_classes():
                     s_name = m_config.get('sample_name')
                 else:
                     c_id = k
-                    m_config = cust_mods[c_id]['config']
+                    m_config = dict(cust_mods[c_id]['config'])
 
                 # Guess sample name if not given
                 if s_name is None:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -406,7 +406,7 @@ def _parse_txt(f, conf):
 
     # Single sample line / bar graph - first row has two columns
     if len(d[0]) == 2:
-        # Line graph - row, num : num
+        # Line graph - num : num
         if (conf.get('plot_type') is None and type(d[0][0]) == float and type(d[0][1]) == float):
             conf['plot_type'] = 'linegraph'
         # Bar graph - str : num

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -48,15 +48,17 @@ def custom_module_classes():
         if 'data' in f:
             cust_mods[c_id]['data'].update( f['data'] )
             cust_mods[c_id]['config'].update( { k:v for k, v in f.items() if k is not 'data' } )
+            cust_mods[c_id]['config']['id'] = cust_mods[c_id]['config'].get('id', c_id)
             continue
 
         # Custom Content ID has search patterns in the config
         if c_id in report.files:
             cust_mods[c_id]['config'] = f
+            cust_mods[c_id]['config']['id'] = cust_mods[c_id]['config'].get('id', c_id)
             search_patterns.append(c_id)
             continue
 
-        # We should have had sometihng by now
+        # We should have had something by now
         log.warn("Found section '{}' in config for under custom_data, but no data or search patterns.".format(c_id))
 
     # Now go through each of the file search patterns
@@ -103,12 +105,15 @@ def custom_module_classes():
                 s_name = None
                 if m_config is not None:
                     c_id = m_config.get('id', k)
-                    cust_mods[c_id]['config'].update( m_config )
-                    m_config = cust_mods[c_id]['config']
+                    # Update the base config with anything parsed from the file
+                    b_config = cust_mods.get(c_id, {}).get('config', {})
+                    b_config.update( m_config )
+                    # Now set the module config to the merged dict
+                    m_config = dict(b_config)
                     s_name = m_config.get('sample_name')
                 else:
                     c_id = k
-                    m_config = dict(cust_mods[c_id]['config'])
+                    m_config = cust_mods.get(c_id, {}).get('config', {})
 
                 # Guess sample name if not given
                 if s_name is None:

--- a/multiqc/modules/cutadapt/cutadapt.py
+++ b/multiqc/modules/cutadapt/cutadapt.py
@@ -36,7 +36,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.cutadapt_length_exp = dict()
         self.cutadapt_length_obsexp = dict()
 
-        for f in self.find_log_files(config.sp['cutadapt'], filehandles=True):
+        for f in self.find_log_files('cutadapt', filehandles=True):
             self.parse_cutadapt_logs(f)
 
         if len(self.cutadapt_data) == 0:

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any FastQ Screen reports
         self.fq_screen_data = dict()
         self.num_orgs = 0
-        for f in self.find_log_files(config.sp['fastq_screen'], filehandles=True):
+        for f in self.find_log_files('fastq_screen', filehandles=True):
             parsed_data = self.parse_fqscreen(f['f'])
             if parsed_data is not None:
                 if f['s_name'] in self.fq_screen_data:

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -39,12 +39,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.fastqc_data = dict()
 
         # Find and parse unzipped FastQC reports
-        for f in self.find_log_files(config.sp['fastqc']['data']):
+        for f in self.find_log_files('fastqc/data'):
             s_name = self.clean_s_name(os.path.basename(f['root']), os.path.dirname(f['root']))
             self.parse_fastqc_report(f['f'], s_name, f)
 
         # Find and parse zipped FastQC reports
-        for f in self.find_log_files(config.sp['fastqc']['zip'], filecontents=False):
+        for f in self.find_log_files('fastqc/zip', filecontents=False):
             s_name = f['fn']
             if s_name.endswith('_fastqc.zip'):
                 s_name = s_name[:-11]
@@ -424,7 +424,7 @@ class MultiqcModule(BaseMultiqcModule):
         theoretical_gc = None
         theoretical_gc_raw = None
         theoretical_gc_name = None
-        for f in self.find_log_files(config.sp['fastqc']['theoretical_gc']):
+        for f in self.find_log_files('fastqc/theoretical_gc'):
             if theoretical_gc_raw is not None:
                 log.warn("Multiple FastQC Theoretical GC Content files found, now using {}".format(f['fn']))
             theoretical_gc_raw = f['f']

--- a/multiqc/modules/featureCounts/feature_counts.py
+++ b/multiqc/modules/featureCounts/feature_counts.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any featureCounts reports
         self.featurecounts_data = dict()
         self.featurecounts_keys = list()
-        for f in self.find_log_files(config.sp['featurecounts']):
+        for f in self.find_log_files('featurecounts'):
             self.parse_featurecounts_report(f)
 
         if len(self.featurecounts_data) == 0:

--- a/multiqc/modules/gatk/varianteval.py
+++ b/multiqc/modules/gatk/varianteval.py
@@ -17,7 +17,7 @@ class VariantEvalMixin():
         """ Find GATK varianteval logs and parse their data """
 
         self.gatk_varianteval = dict()
-        for f in self.find_log_files(config.sp['gatk']['varianteval'], filehandles=True):
+        for f in self.find_log_files('gatk/varianteval', filehandles=True):
             parsed_data = parse_single_report(f['f'])
             if len(parsed_data) > 0:
                 if f['s_name'] in self.gatk_varianteval:

--- a/multiqc/modules/goleft_indexcov/goleft_indexcov.py
+++ b/multiqc/modules/goleft_indexcov/goleft_indexcov.py
@@ -52,7 +52,7 @@ class MultiqcModule(BaseMultiqcModule):
         drops off more quickly. This indicates a higher fraction of low coverage regions.'
         max_chroms = 50
         data = collections.defaultdict(lambda: collections.defaultdict(dict))
-        for fn in self.find_log_files(config.sp["goleft_indexcov"]["roc"], filehandles=True):
+        for fn in self.find_log_files('goleft_indexcov/roc', filehandles=True):
             header = fn['f'].readline()
             sample_names = [self.clean_s_name(x, fn["root"]) for x in header.strip().split()[2:]]
             for parts in (l.rstrip().split() for l in fn['f']):
@@ -104,7 +104,7 @@ class MultiqcModule(BaseMultiqcModule):
         for more details.'
 
         data = {}
-        for fn in self.find_log_files(config.sp["goleft_indexcov"]["ped"], filehandles=True):
+        for fn in self.find_log_files('goleft_indexcov/ped', filehandles=True):
             header = fn['f'].readline()[1:].strip().split("\t")
             for sample_parts in (l.split("\t") for l in fn['f']):
                 cur = dict(zip(header, sample_parts))

--- a/multiqc/modules/hicup/hicup.py
+++ b/multiqc/modules/hicup/hicup.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any HiCUP summary reports
         self.hicup_data = dict()
-        for f in self.find_log_files(config.sp['hicup']):
+        for f in self.find_log_files('hicup'):
             self.parse_hicup_logs(f)
 
         if len(self.hicup_data) == 0:

--- a/multiqc/modules/htseq/htseq.py
+++ b/multiqc/modules/htseq/htseq.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any HTSeq Count reports
         self.htseq_data = dict()
         self.htseq_keys = list()
-        for f in self.find_log_files(config.sp['htseq'], filehandles=True):
+        for f in self.find_log_files('htseq', filehandles=True):
             parsed_data = self.parse_htseq_report(f)
             if parsed_data is not None:
                 self.htseq_data[f['s_name']] = parsed_data

--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Kallisto reports
         self.kallisto_data = dict()
-        for f in self.find_log_files(config.sp['kallisto'], filehandles=True):
+        for f in self.find_log_files('kallisto', filehandles=True):
             self.parse_kallisto_log(f)
 
         if len(self.kallisto_data) == 0:

--- a/multiqc/modules/methylQA/methylQA.py
+++ b/multiqc/modules/methylQA/methylQA.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.methylqa_data = dict()
         self.methylqa_coverage_counts = dict()
         self.methylqa_coverage_percentages = dict()
-        for f in self.find_log_files(config.sp['methylQA']):
+        for f in self.find_log_files('methylQA'):
             self.parse_methylqa_logs(f)
 
         if len(self.methylqa_data) == 0:

--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -31,7 +31,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.peddy_length_exp = dict()
         self.peddy_length_obsexp = dict()
 
-        for f in self.find_log_files(config.sp['peddy']['summary_table']):
+        for f in self.find_log_files('peddy/summary_table'):
             parsed_data = self.parse_peddy_summary(f)
             if parsed_data is not None:
                 for s_name in parsed_data:
@@ -42,7 +42,8 @@ class MultiqcModule(BaseMultiqcModule):
                         self.peddy_data[s_name] = parsed_data[s_name]
 
         for pattern in ['het_check', 'ped_check', 'sex_check']:
-            for f in self.find_log_files(config.sp['peddy'][pattern]):
+            sp_key = 'peddy/{}'.format(pattern)
+            for f in self.find_log_files(sp_key):
                 parsed_data = self.parse_peddy_csv(f)
                 if parsed_data is not None:
                     for s_name in parsed_data:

--- a/multiqc/modules/picard/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/picard/AlignmentSummaryMetrics.py
@@ -20,7 +20,7 @@ def parse_reports(self):
     self.picard_alignment_metrics = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['alignment_metrics'], filehandles=True):
+    for f in self.find_log_files('picard/alignment_metrics', filehandles=True):
         parsed_data = dict()
         s_name = None
         keys = None

--- a/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
+++ b/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
@@ -91,10 +91,7 @@ def parse_reports(self):
     self.picard_baseDistributionByCycle_samplestats = dict()
 
     # Go through logs and find Metrics
-    base_dist_files = self.find_log_files(
-        config.sp['picard']['basedistributionbycycle'],
-        filehandles=True
-    )
+    base_dist_files = self.find_log_files('picard/basedistributionbycycle', filehandles=True)
 
     for f in base_dist_files:
         try:

--- a/multiqc/modules/picard/GcBiasMetrics.py
+++ b/multiqc/modules/picard/GcBiasMetrics.py
@@ -22,7 +22,7 @@ def parse_reports(self):
     self.picard_GCbiasSummary_data = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['gcbias'], filehandles=True):
+    for f in self.find_log_files('picard/gcbias', filehandles=True):
         s_name = None
         gc_col = None
         cov_col = None

--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -62,7 +62,7 @@ def parse_reports(self):
     self.picard_HsMetrics_data = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['hsmetrics'], filehandles=True):
+    for f in self.find_log_files('picard/hsmetrics', filehandles=True):
         parsed_data = dict()
         s_name = None
         keys = None

--- a/multiqc/modules/picard/InsertSizeMetrics.py
+++ b/multiqc/modules/picard/InsertSizeMetrics.py
@@ -23,7 +23,7 @@ def parse_reports(self):
     self.picard_insertSize_samplestats = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['insertsize'], filehandles=True):
+    for f in self.find_log_files('picard/insertsize', filehandles=True):
         s_name = None
         in_hist = False
         for l in f['f']:

--- a/multiqc/modules/picard/MarkDuplicates.py
+++ b/multiqc/modules/picard/MarkDuplicates.py
@@ -21,7 +21,7 @@ def parse_reports(self):
     self.picard_dupMetrics_data = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['markdups'], filehandles=True):
+    for f in self.find_log_files('picard/markdups', filehandles=True):
         s_name = None
         for l in f['f']:
             # New log starting

--- a/multiqc/modules/picard/OxoGMetrics.py
+++ b/multiqc/modules/picard/OxoGMetrics.py
@@ -20,7 +20,7 @@ def parse_reports(self):
     self.picard_OxoGMetrics_data = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['oxogmetrics'], filehandles=True):
+    for f in self.find_log_files('picard/oxogmetrics', filehandles=True):
         # We use lists to make sure that we don't overwrite when no data will be parsed
         parsed_data = list()
         sample_names = list()

--- a/multiqc/modules/picard/RnaSeqMetrics.py
+++ b/multiqc/modules/picard/RnaSeqMetrics.py
@@ -22,7 +22,7 @@ def parse_reports(self):
     self.picard_RnaSeqMetrics_histogram = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['rnaseqmetrics'], filehandles=True):
+    for f in self.find_log_files('picard/rnaseqmetrics', filehandles=True):
         s_name = None
         in_hist = False
         for l in f['f']:

--- a/multiqc/modules/picard/RrbsSummaryMetrics.py
+++ b/multiqc/modules/picard/RrbsSummaryMetrics.py
@@ -20,7 +20,7 @@ def parse_reports(self):
     self.picard_rrbs_metrics = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['rrbs_metrics'], filehandles=True):
+    for f in self.find_log_files('picard/rrbs_metrics', filehandles=True):
         parsed_data = dict()
         s_name = None
         keys = None

--- a/multiqc/modules/picard/WgsMetrics.py
+++ b/multiqc/modules/picard/WgsMetrics.py
@@ -23,7 +23,7 @@ def parse_reports(self):
     self.picard_wgsmetrics_samplestats = dict()
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(config.sp['picard']['wgs_metrics'], filehandles=True):
+    for f in self.find_log_files('picard/wgs_metrics', filehandles=True):
         s_name = None
         in_hist = False
         for l in f['f']:

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any Preseq reports
         self.preseq_data = dict()
         self.total_max = 0
-        for f in self.find_log_files(config.sp['preseq']):
+        for f in self.find_log_files('preseq'):
             parsed_data = self.parse_preseq_logs(f)
             if parsed_data is not None:
                 if f['s_name'] in self.preseq_data:

--- a/multiqc/modules/prokka/prokka.py
+++ b/multiqc/modules/prokka/prokka.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse logs
         self.prokka = dict()
-        for f in self.find_log_files(config.sp['prokka'], filehandles=True):
+        for f in self.find_log_files('prokka', filehandles=True):
             self.parse_prokka(f)
 
         if len(self.prokka) == 0:

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -16,8 +16,6 @@ log = logging.getLogger(__name__)
 def parse_reports(self):
     """ Find Qualimap BamQC reports and parse their data """
 
-    sp = config.sp['qualimap']['bamqc']
-
     try:
         covs = config.qualimap_config['general_stats_coverage']
         assert type(covs) == list
@@ -32,23 +30,23 @@ def parse_reports(self):
 
     # General stats - genome_results.txt
     self.qualimap_bamqc_genome_results = dict()
-    for f in self.find_log_files(sp['genome_results']):
+    for f in self.find_log_files('qualimap/bamqc/genome_results'):
         parse_genome_results(self, f)
 
     # Coverage - coverage_histogram.txt
     self.qualimap_bamqc_coverage_hist = dict()
-    for f in self.find_log_files(sp['coverage'], filehandles=True):
+    for f in self.find_log_files('qualimap/bamqc/coverage', filehandles=True):
         parse_coverage(self, f)
 
     # Insert size - insert_size_histogram.txt
     self.qualimap_bamqc_insert_size_hist = dict()
-    for f in self.find_log_files(sp['insert_size'], filehandles=True):
+    for f in self.find_log_files('qualimap/bamqc/insert_size', filehandles=True):
         parse_insert_size(self, f)
 
     # GC distribution - mapped_reads_gc-content_distribution.txt
     self.qualimap_bamqc_gc_content_dist = dict()
     self.qualimap_bamqc_gc_by_species = dict()  # {'HUMAN': data_dict, 'MOUSE': data_dict}
-    for f in self.find_log_files(sp['gc_dist'], filehandles=True):
+    for f in self.find_log_files('qualimap/bamqc/gc_dist', filehandles=True):
         parse_gc_dist(self, f)
 
     # Make the plots for the report

--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 def parse_reports(self):
     """ Find Qualimap RNASeq reports and parse their data """
 
-    sp = config.sp['qualimap']['rnaseq']
     self.qualimap_rnaseq_genome_results = dict()
     regexes = {
         'reads_aligned': r"read(?:s| pairs) aligned\s*=\s*([\d,]+)",
@@ -31,7 +30,7 @@ def parse_reports(self):
         'reads_aligned_intergenic': r"intergenic\s*=\s*([\d,]+)",
         'reads_aligned_overlapping_exon': r"overlapping exon\s*=\s*([\d,]+)",
     }
-    for f in self.find_log_files(sp['rnaseq_results']):
+    for f in self.find_log_files('qualimap/rnaseq/rnaseq_results'):
         d = dict()
 
         # Get the sample name
@@ -78,7 +77,7 @@ def parse_reports(self):
 
     #### Coverage profile
     self.qualimap_rnaseq_cov_hist = dict()
-    for f in self.find_log_files(sp['coverage'], filehandles=True):
+    for f in self.find_log_files('qualimap/rnaseq/coverage', filehandles=True):
         s_name = self.get_s_name(f)
         d = dict()
         for l in f['f']:

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any QUAST reports
         self.quast_data = dict()
-        for f in self.find_log_files(config.sp['quast']):
+        for f in self.find_log_files('quast'):
             self.parse_quast_log(f)
 
         if len(self.quast_data) == 0:

--- a/multiqc/modules/rna_seqc/rna_seqc.py
+++ b/multiqc/modules/rna_seqc/rna_seqc.py
@@ -24,20 +24,20 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse metrics information.
         self.rna_seqc_metrics = dict()
-        for f in self.find_log_files(config.sp['rna_seqc']['metrics']):
+        for f in self.find_log_files('rna_seqc/metrics'):
             self.parse_metrics(f)
 
         # Parse normalised coverage information.
         self.rna_seqc_norm_high_cov = dict()
         self.rna_seqc_norm_medium_cov = dict()
         self.rna_seqc_norm_low_cov = dict()
-        for f in self.find_log_files(config.sp['rna_seqc']['coverage']):
+        for f in self.find_log_files('rna_seqc/coverage'):
             self.parse_coverage(f)
 
         # Parse correlation matrices
         self.rna_seqc_pearson = None
         self.rna_seqc_spearman = None
-        for f in self.find_log_files(config.sp['rna_seqc']['correlation']):
+        for f in self.find_log_files('rna_seqc/correlation'):
             self.parse_correlation(f)
 
         num_found = max( len(self.rna_seqc_metrics), len(self.rna_seqc_norm_high_cov),

--- a/multiqc/modules/rseqc/bam_stat.py
+++ b/multiqc/modules/rseqc/bam_stat.py
@@ -41,7 +41,7 @@ def parse_reports(self):
     is_paired_end=False
 
     # Go through files and parse data using regexes
-    for f in self.find_log_files(config.sp['rseqc']['bam_stat']):
+    for f in self.find_log_files('rseqc/bam_stat'):
         d = dict()
         for k, r in regexes.items():
             r_search = re.search(r, f['f'], re.MULTILINE)

--- a/multiqc/modules/rseqc/gene_body_coverage.py
+++ b/multiqc/modules/rseqc/gene_body_coverage.py
@@ -24,7 +24,7 @@ def parse_reports(self):
     # and add these to the general stats table?
 
     # Go through files and parse data
-    for f in self.find_log_files(config.sp['rseqc']['gene_body_coverage']):
+    for f in self.find_log_files('rseqc/gene_body_coverage'):
 
         # RSeQC >= v2.4
         if f['f'].startswith('Percentile'):

--- a/multiqc/modules/rseqc/infer_experiment.py
+++ b/multiqc/modules/rseqc/infer_experiment.py
@@ -28,7 +28,7 @@ def parse_reports(self):
     }
 
     # Go through files and parse data using regexes
-    for f in self.find_log_files(config.sp['rseqc']['infer_experiment']):
+    for f in self.find_log_files('rseqc/infer_experiment'):
         d = dict()
         for k, r in regexes.items():
             r_search = re.search(r, f['f'], re.MULTILINE)

--- a/multiqc/modules/rseqc/inner_distance.py
+++ b/multiqc/modules/rseqc/inner_distance.py
@@ -21,7 +21,7 @@ def parse_reports(self):
     self.inner_distance_pct = dict()
 
     # Go through files and parse data
-    for f in self.find_log_files(config.sp['rseqc']['inner_distance']):
+    for f in self.find_log_files('rseqc/inner_distance'):
         if f['s_name'] in self.inner_distance:
             log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))
         self.add_data_source(f, section='inner_distance')

--- a/multiqc/modules/rseqc/junction_annotation.py
+++ b/multiqc/modules/rseqc/junction_annotation.py
@@ -31,7 +31,7 @@ def parse_reports(self):
     }
 
     # Go through files and parse data using regexes
-    for f in self.find_log_files(config.sp['rseqc']['junction_annotation']):
+    for f in self.find_log_files('rseqc/junction_annotation'):
         d = dict()
         for k, r in regexes.items():
             r_search = re.search(r, f['f'], re.MULTILINE)

--- a/multiqc/modules/rseqc/junction_saturation.py
+++ b/multiqc/modules/rseqc/junction_saturation.py
@@ -26,7 +26,7 @@ def parse_reports(self):
     self.junction_saturation_novel_pct = dict()
 
     # Go through files and parse data
-    for f in self.find_log_files(config.sp['rseqc']['junction_saturation']):
+    for f in self.find_log_files('rseqc/junction_saturation'):
         parsed = dict()
         for l in f['f'].splitlines():
             r = re.search(r"^([xyzw])=c\(([\d,]+)\)$", l)

--- a/multiqc/modules/rseqc/read_distribution.py
+++ b/multiqc/modules/rseqc/read_distribution.py
@@ -38,7 +38,7 @@ def parse_reports(self):
     }
 
     # Go through files and parse data using regexes
-    for f in self.find_log_files(config.sp['rseqc']['read_distribution']):
+    for f in self.find_log_files('rseqc/read_distribution'):
         d = dict()
         for k, r in first_regexes.items():
             r_search = re.search(r, f['f'], re.MULTILINE)

--- a/multiqc/modules/rseqc/read_duplication.py
+++ b/multiqc/modules/rseqc/read_duplication.py
@@ -20,7 +20,7 @@ def parse_reports(self):
     self.read_dups = dict()
 
     # Go through files and parse data
-    for f in self.find_log_files(config.sp['rseqc']['read_duplication_pos']):
+    for f in self.find_log_files('rseqc/read_duplication_pos'):
         if f['f'].startswith('Occurrence	UniqReadNumber'):
             if f['s_name'] in self.read_dups:
                 log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))

--- a/multiqc/modules/rseqc/read_gc.py
+++ b/multiqc/modules/rseqc/read_gc.py
@@ -21,7 +21,7 @@ def parse_reports(self):
     self.read_gc_pct = dict()
 
     # Go through files and parse data
-    for f in self.find_log_files(config.sp['rseqc']['read_gc']):
+    for f in self.find_log_files('rseqc/read_gc'):
 
         if f['f'].startswith('GC%	read_count'):
             gc = list()

--- a/multiqc/modules/salmon/salmon.py
+++ b/multiqc/modules/salmon/salmon.py
@@ -26,14 +26,14 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse meta information. JSON win!
         self.salmon_meta = dict()
-        for f in self.find_log_files(config.sp['salmon']['meta']):
+        for f in self.find_log_files('salmon/meta'):
             # Get the s_name from the parent directory
             s_name = os.path.basename( os.path.dirname(f['root']) )
             s_name = self.clean_s_name(s_name, f['root'])
             self.salmon_meta[s_name] = json.loads(f['f'])
         # Parse Fragment Length Distribution logs
         self.salmon_fld = dict()
-        for f in self.find_log_files(config.sp['salmon']['fld']):
+        for f in self.find_log_files('salmon/fld'):
             # Get the s_name from the parent directory
             if os.path.basename(f['root']) == 'libParams':
                 s_name = os.path.basename( os.path.dirname(f['root']) )

--- a/multiqc/modules/samblaster/samblaster.py
+++ b/multiqc/modules/samblaster/samblaster.py
@@ -25,7 +25,7 @@ class MultiqcModule(BaseMultiqcModule):
                                             info="is a tool to mark duplicates and extract discordant and split reads from sam files.")
 
         self.samblaster_data = dict()
-        for f in self.find_log_files(config.sp['samblaster'], filehandles=True):
+        for f in self.find_log_files('samblaster', filehandles=True):
             self.parse_samblaster(f)
         if len(self.samblaster_data) == 0:
             log.debug("Could not find any data in {}".format(config.analysis_dir))

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -19,7 +19,7 @@ class FlagstatReportMixin():
         """ Find Samtools flagstat logs and parse their data """
 
         self.samtools_flagstat = dict()
-        for f in self.find_log_files(config.sp['samtools']['flagstat']):
+        for f in self.find_log_files('samtools/flagstat'):
             parsed_data = parse_single_report(f['f'])
             if len(parsed_data) > 0:
                 if f['s_name'] in self.samtools_flagstat:

--- a/multiqc/modules/samtools/idxstats.py
+++ b/multiqc/modules/samtools/idxstats.py
@@ -18,7 +18,7 @@ class IdxstatsReportMixin():
         """ Find Samtools idxstats logs and parse their data """
 
         self.samtools_idxstats = dict()
-        for f in self.find_log_files(config.sp['samtools']['idxstats']):
+        for f in self.find_log_files('samtools/idxstats'):
             parsed_data = parse_single_report(f['f'])
             if len(parsed_data) > 0:
                 if f['s_name'] in self.samtools_idxstats:

--- a/multiqc/modules/samtools/rmdup.py
+++ b/multiqc/modules/samtools/rmdup.py
@@ -18,7 +18,7 @@ class RmdupReportMixin():
         """ Find Samtools rmdup logs and parse their data """
 
         self.samtools_rmdup = dict()
-        for f in self.find_log_files(config.sp['samtools']['rmdup'], filehandles=True):
+        for f in self.find_log_files('samtools/rmdup', filehandles=True):
             # Example below:
             # [bam_rmdupse_core] 26602816 / 103563641 = 0.2569 in library '   '
             dups_regex = "\[bam_rmdups?e?_core\] (\d+) / (\d+) = (\d+\.\d+) in library '(.*)'"

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -19,7 +19,7 @@ class StatsReportMixin():
         """ Find Samtools stats logs and parse their data """
 
         self.samtools_stats = dict()
-        for f in self.find_log_files(config.sp['samtools']['stats']):
+        for f in self.find_log_files('samtools/stats'):
             parsed_data = dict()
             for line in f['f'].splitlines():
                 if not line.startswith("SN"):

--- a/multiqc/modules/skewer/skewer.py
+++ b/multiqc/modules/skewer/skewer.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.skewer_data = dict()
         self.skewer_readlen_dist = dict()
 
-        for f in self.find_log_files(config.sp['skewer'], filehandles=True):
+        for f in self.find_log_files('skewer', filehandles=True):
             self.parse_skewer_log(f)
 
         if len(self.skewer_data) == 0:

--- a/multiqc/modules/slamdunk/slamdunk.py
+++ b/multiqc/modules/slamdunk/slamdunk.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Summary Reports
         self.slamdunk_data = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['summary'], filehandles = True):
+        for f in self.find_log_files('slamdunk/summary', filehandles = True):
             self.parseSummary(f)
         if len(self.slamdunk_data) > 0:
             self.slamdunkGeneralStatsTable()
@@ -45,7 +45,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # PCA Plots
         self.PCA_data = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['PCA'], filehandles = True):
+        for f in self.find_log_files('slamdunk/PCA', filehandles = True):
             self.parsePCA(f)
         if len(self.PCA_data) > 0:
             self.slamdunkPCAPlot()
@@ -54,7 +54,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # UTR Rate reports
         self.utrates_data = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['utrrates'], filehandles = True):
+        for f in self.find_log_files('slamdunk/utrrates', filehandles = True):
             self.parseUtrRates(f)
         if len(self.utrates_data) > 0:
             self.write_data_file(self.utrates_data, 'multiqc_slamdunk_utrrates')
@@ -65,7 +65,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Read rate reports
         self.rates_data_plus = dict()
         self.rates_data_minus = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['rates'], filehandles = True):
+        for f in self.find_log_files('slamdunk/rates', filehandles = True):
             self.parseSlamdunkRates(f)
         if len(self.rates_data_plus) > 0:
             self.write_data_file(self.rates_data_plus, 'multiqc_slamdunk_readrates_plus')
@@ -79,7 +79,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.nontc_per_readpos_minus = dict()
         self.tc_per_readpos_plus = dict()
         self.tc_per_readpos_minus = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['tcperreadpos'], filehandles = True):
+        for f in self.find_log_files('slamdunk/tcperreadpos', filehandles = True):
             self.parseSlamdunkTCPerReadpos(f)
         if len(self.tc_per_readpos_plus) > 0:
             self.write_data_file(self.tc_per_readpos_plus, 'multiqc_slamdunk_tcperreadpos_plus')
@@ -95,7 +95,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.nontc_per_utrpos_minus = dict()
         self.tc_per_utrpos_plus = dict()
         self.tc_per_utrpos_minus = dict()
-        for f in self.find_log_files(config.sp['slamdunk']['tcperutrpos'], filehandles = True):
+        for f in self.find_log_files('slamdunk/tcperutrpos', filehandles = True):
             self.parseSlamdunkTCPerUtrpos(f)
         if len(self.nontc_per_utrpos_plus) > 0:
             self.write_data_file(self.tc_per_utrpos_plus, 'multiqc_slamdunk_tcperutrpos_plus')

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.snpeff_section_totals = dict()
         self.snpeff_qualities = dict()
 
-        for f in self.find_log_files(config.sp['snpeff'], filehandles=True):
+        for f in self.find_log_files('snpeff', filehandles=True):
             self.parse_snpeff_log(f)
 
         if len(self.snpeff_data) == 0:

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse logs
         self.sortmerna = dict()
-        for f in self.find_log_files(config.sp['sortmerna'], filehandles=True):
+        for f in self.find_log_files('sortmerna', filehandles=True):
             self.parse_sortmerna(f)
 
         if len(self.sortmerna) == 0:

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any STAR reports
         self.star_data = dict()
-        for f in self.find_log_files(config.sp['star']):
+        for f in self.find_log_files('star'):
             parsed_data = self.parse_star_report(f['f'])
             if parsed_data is not None:
                 s_name = f['s_name']
@@ -41,7 +41,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.star_genecounts_unstranded = dict()
         self.star_genecounts_first_strand = dict()
         self.star_genecounts_second_strand = dict()
-        for f in self.find_log_files(config.sp['star_genecounts'], filehandles=True):
+        for f in self.find_log_files('star_genecounts', filehandles=True):
             parsed_data = self.parse_star_genecount_report(f)
             if parsed_data is not None:
                 s_name = f['s_name']

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any Tophat reports
         self.tophat_data = dict()
-        for f in self.find_log_files(config.sp['tophat']):
+        for f in self.find_log_files('tophat'):
             parsed_data = self.parse_tophat_log(f['f'])
             if parsed_data is not None:
                 if f['s_name'] == "align_summary.txt":

--- a/multiqc/modules/trimmomatic/trimmomatic.py
+++ b/multiqc/modules/trimmomatic/trimmomatic.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse logs
         self.trimmomatic = dict()
-        for f in self.find_log_files(config.sp['trimmomatic'], filehandles=True):
+        for f in self.find_log_files('trimmomatic', filehandles=True):
             self.parse_trimmomatic(f)
 
         if len(self.trimmomatic) == 0:

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -121,15 +121,15 @@ def mqc_load_config(yaml_config):
                     if c == 'sp':
                         # Merge filename patterns instead of replacing
                         sp.update(v)
-                        logger.debug("Added to filename patterns: {}".format(sp))
+                        logger.debug("Added to filename patterns: {}".format(v))
                     elif c == 'extra_fn_clean_exts':
                         # Prepend to filename cleaning patterns instead of replacing
                         fn_clean_exts[0:0] = v
-                        logger.debug("Added to filename clean extensions. Now looking for: {}".format(fn_clean_exts))
+                        logger.debug("Added to filename clean extensions: {}".format(v))
                     elif c == 'extra_fn_clean_trim':
                         # Prepend to filename cleaning patterns instead of replacing
                         fn_clean_trim[0:0] = v
-                        logger.debug("Added to filename clean trimmings. Now looking for: {}".format(fn_clean_trim))
+                        logger.debug("Added to filename clean trimmings: {}".format(v))
                     else:
                         logger.debug("New config '{}': {}".format(c, v))
                         globals()[c] = v

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -160,7 +160,7 @@ module_order:
     - 'qualimap'
     - 'preseq'
     - 'quast'
-    - 'rna-seqc'
+    - 'rna_seqc'
     - 'rseqc'
     - 'busco'
     - 'goleft_indexcov'

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -54,7 +54,6 @@ fn_ignore_paths:
 no_version_check: false
 log_filesize_limit: 10000000
 report_readerrors: false
-report_imgskips: false
 skip_generalstats: false
 data_format_extensions:
     tsv: 'txt'

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -189,7 +189,7 @@ module_order:
     - 'cutadapt'
     - 'trimmomatic'
     - 'skewer'
+    - 'sortmerna'
     - 'fastq_screen'
     - 'fastqc'
     - 'clusterflow'
-    - 'sortmerna'

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -11,6 +11,7 @@ import io
 import json
 import mimetypes
 import os
+import re
 import yaml
 
 from multiqc import config
@@ -34,11 +35,34 @@ num_hc_plots = 0
 num_mpl_plots = 0
 saved_raw_data = dict()
 
-# Make a list of files to search
-files = list()
+# Make a dict of discovered files for each seach key
+files = dict()
 def get_filelist():
 
+    # Prep search patterns
+    spatterns = [{},{},{},{}]
+    for key, sps in config.sp.items():
+        files[key] = list()
+        if not isinstance(sps, list):
+            sps = [sps]
+        # Split search patterns according to speed of execution.
+        if any([x for x in sps if 'contents' in x]):
+            if any([x for x in sps if 'num_lines' in x]):
+                spatterns[1][key] = sps
+            elif any([x for x in sps if 'max_filesize' in x]):
+                spatterns[2][key] = sps
+            else:
+                spatterns[3][key] = sps
+        else:
+            spatterns[0][key] = sps
+
     def add_file(fn, root):
+        """
+        Function applied to each file found when walking the analysis
+        directories. Runs through all search patterns and returns True
+        if a match is found.
+        """
+        f = {'fn': fn, 'root': root}
 
         # Check that this is a file and not a pipe or anything weird
         if not os.path.isfile(os.path.join(root, fn)):
@@ -50,35 +74,88 @@ def get_filelist():
             logger.debug("Ignoring file as matched an ignore pattern: {}".format(fn))
             return None
 
-        # Use mimetypes to exclude binary files where possible
-        (ftype, encoding) = mimetypes.guess_type(os.path.join(root, fn))
-        if encoding is not None:
-            logger.debug("Ignoring file as is encoded: {}".format(fn))
-            return None
-        if ftype is not None and ftype.startswith('image'):
-            if config.report_imgskips:
-                logger.debug("Ignoring file as has filetype '{}': {}".format(ftype, fn))
-            return None
-
-        # Limit search to files under 5MB to avoid 30GB FastQ files etc.
+        # Limit search to small files, to avoid 30GB FastQ files etc.
         try:
-            filesize = os.path.getsize(os.path.join(root,fn))
+            f['filesize'] = os.path.getsize(os.path.join(root,fn))
         except (IOError, OSError, ValueError, UnicodeDecodeError):
             logger.debug("Couldn't read file when checking filesize: {}".format(fn))
         else:
-            if filesize > config.log_filesize_limit:
-                logger.debug("Ignoring file as too large: {}".format(fn))
-                return None
+            if f['filesize'] > config.log_filesize_limit:
+                return False
 
-        # Looks good! Remember this file
-        files.append({
-            'root': root,
-            'fn': fn
-        })
+        # Test file for each search pattern
+        for patterns in spatterns:
+            for key, sps in patterns.items():
+                for sp in sps:
+                    if search_file (sp, f):
+                        # Looks good! Remember this file
+                        files[key].append(f)
+                        # Don't keep searching this file for other modules
+                        if not sp.get('shared', False):
+                            return
+                        # Don't look at other patterns for this module
+                        else:
+                            break
+
+    def search_file (pattern, f):
+        """
+        Function to searach a single file for a single search pattern.
+        """
+        fn_matched = False
+        contents_matched = False
+
+        # Use mimetypes to exclude binary files where possible
+        (ftype, encoding) = mimetypes.guess_type(os.path.join(f['root'], f['fn']))
+        if encoding is not None:
+            return False
+        if ftype is not None and ftype.startswith('image'):
+            return False
+
+        # Search pattern specific filesize limit
+        if pattern.get('max_filesize') is not None and 'filesize' in f:
+            if f['filesize'] > pattern.get('max_filesize'):
+                return False
+
+        # Search by file name (glob)
+        if pattern.get('fn') is not None:
+            if fnmatch.fnmatch(f['fn'], pattern['fn']):
+                fn_matched = True
+                if pattern.get('contents') is None:
+                    return True
+
+        # Search by file name (regex)
+        if pattern.get('fn_re') is not None:
+            if re.match( pattern['fn_re'], f['fn']):
+                fn_matched = True
+                if pattern.get('contents') is None:
+                    return True
+
+        # Search by file contents
+        if pattern.get('contents') is not None:
+            try:
+                with io.open (os.path.join(root,fn), "r", encoding='utf-8') as f:
+                    l = 1
+                    for line in f:
+                        if pattern['contents'] in line:
+                            contents_matched = True
+                            if pattern.get('fn') is None and pattern.get('fn_re') is None:
+                                return True
+                            break
+                        if pattern.get('num_lines') and l >= pattern.get('num_lines'):
+                            break
+                        l += 1
+            except (IOError, OSError, ValueError, UnicodeDecodeError):
+                if config.report_readerrors:
+                    logger.debug("Couldn't read file when looking for output: {}".format(fn))
+                    return False
+
+        return fn_matched and contents_matched
 
     # Go through the analysis directories
     for path in config.analysis_dir:
-        if os.path.isdir(path):
+        if os.path.isfile(path):
+            add_file({'fn': os.path.basename(path), 'root': os.path.dirname(path)})
+        elif os.path.isdir(path):
             for root, dirnames, filenames in os.walk(path, followlinks=True, topdown=True):
                 bname = os.path.basename(root)
 
@@ -109,9 +186,6 @@ def get_filelist():
                 # Search filenames in this directory
                 for fn in filenames:
                     add_file(fn, root)
-
-        elif os.path.isfile(path):
-            add_file(os.path.basename(path), os.path.dirname(path))
 
 
 def data_sources_tofile ():

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -6,6 +6,7 @@ helper functions to generate markup for report. """
 
 from __future__ import print_function
 from collections import defaultdict, OrderedDict
+import click
 import fnmatch
 import io
 import json
@@ -151,10 +152,11 @@ def get_filelist():
 
         return fn_matched and contents_matched
 
-    # Go through the analysis directories
+    # Go through the analysis directories and get file list
+    sfiles = []
     for path in config.analysis_dir:
         if os.path.isfile(path):
-            add_file({'fn': os.path.basename(path), 'root': os.path.dirname(path)})
+            sfiles.append([os.path.basename(path), os.path.dirname(path)])
         elif os.path.isdir(path):
             for root, dirnames, filenames in os.walk(path, followlinks=True, topdown=True):
                 bname = os.path.basename(root)
@@ -182,10 +184,13 @@ def get_filelist():
                 if len(p_matches) > 0:
                     logger.debug("Ignoring directory as matched fn_ignore_paths: {}".format(root))
                     continue
-
                 # Search filenames in this directory
                 for fn in filenames:
-                    add_file(fn, root)
+                    sfiles.append([fn, root])
+    # Search through collected files
+    with click.progressbar(sfiles, label="Searching {} files..".format(len(sfiles))) as searchfiles:
+        for sf in searchfiles:
+            add_file(sf[0], sf[1])
 
 
 def data_sources_tofile ():

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -37,6 +37,7 @@ num_mpl_plots = 0
 saved_raw_data = dict()
 
 # Make a dict of discovered files for each seach key
+searchfiles = list()
 files = dict()
 def get_filelist():
 
@@ -134,7 +135,7 @@ def get_filelist():
         # Search by file contents
         if pattern.get('contents') is not None:
             try:
-                with io.open (os.path.join(root,fn), "r", encoding='utf-8') as f:
+                with io.open (os.path.join(f['root'],f['fn']), "r", encoding='utf-8') as f:
                     l = 1
                     for line in f:
                         if pattern['contents'] in line:
@@ -153,10 +154,9 @@ def get_filelist():
         return fn_matched and contents_matched
 
     # Go through the analysis directories and get file list
-    sfiles = []
     for path in config.analysis_dir:
         if os.path.isfile(path):
-            sfiles.append([os.path.basename(path), os.path.dirname(path)])
+            searchfiles.append([os.path.basename(path), os.path.dirname(path)])
         elif os.path.isdir(path):
             for root, dirnames, filenames in os.walk(path, followlinks=True, topdown=True):
                 bname = os.path.basename(root)
@@ -186,10 +186,10 @@ def get_filelist():
                     continue
                 # Search filenames in this directory
                 for fn in filenames:
-                    sfiles.append([fn, root])
+                    searchfiles.append([fn, root])
     # Search through collected files
-    with click.progressbar(sfiles, label="Searching {} files..".format(len(sfiles))) as searchfiles:
-        for sf in searchfiles:
+    with click.progressbar(searchfiles, label="Searching {} files..".format(len(searchfiles))) as sfiles:
+        for sf in sfiles:
             add_file(sf[0], sf[1])
 
 

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -18,22 +18,17 @@ bismark/bam2nuc:
     fn: '*.nucleotide_stats.txt'
 bowtie:
     contents: '# reads processed:'
+    shared: true
 bowtie2:
     contents: 'reads; of these:'
+    shared: true
 busco:
     fn: 'short_summary_*'
 custom_content:
-    fn:
-        - '*_mqc.yaml'
-        - '*_mqc.yml'
-        - '*_mqc.json'
-        - '*_mqc.txt'
-        - '*_mqc.csv'
-        - '*_mqc.tsv'
-        - '*_mqc.log'
-        - '*_mqc.out'
+    fn_re: '.+_mqc\.(yaml|yml|json|txt|csv|tsv|log|out)'
 clusterflow/logs:
     fn: '*_clusterFlow.txt'
+    shared: true
 clusterflow/runfiles:
     fn: '*.run'
 cutadapt:
@@ -73,34 +68,45 @@ peddy/sex_check:
     fn: '*.sex_check.csv'
 picard/alignment_metrics:
     contents: 'picard.analysis.AlignmentSummaryMetrics'
+    shared: true
 picard/basedistributionbycycle:
     contents: 'picard.analysis.BaseDistributionByCycleMetrics'
+    shared: true
 picard/gcbias:
-    contents:
-        - 'picard.analysis.GcBiasDetailMetrics'
-        - 'picard.analysis.GcBiasSummaryMetrics'
+    - contents: 'picard.analysis.GcBiasDetailMetrics'
+      shared: true
+    - contents: 'picard.analysis.GcBiasSummaryMetrics'
+      shared: true
 picard/hsmetrics:
     contents: 'picard.analysis.directed.HsMetrics'
+    shared: true
 picard/insertsize:
     contents: 'picard.analysis.InsertSizeMetrics'
+    shared: true
 picard/markdups:
     contents: 'picard.sam.DuplicationMetrics'
+    shared: true
 picard/oxogmetrics:
     contents: 'picard.analysis.CollectOxoGMetrics'
+    shared: true
 picard/rnaseqmetrics:
-    contents:
-        - 'picard.analysis.CollectRnaSeqMetrics'
-        - 'picard.analysis.Collectrnaseqmetrics'
+    - contents: 'picard.analysis.CollectRnaSeqMetrics'
+      shared: true
+    - contents: 'picard.analysis.Collectrnaseqmetrics'
+      shared: true
 picard/rrbs_metrics:
     contents: 'picard.analysis.RrbsSummaryMetrics'
+    shared: true
 picard/wgs_metrics:
     contents: 'picard.analysis.CollectWgsMetrics$WgsMetrics'
+    shared: true
 preseq:
-    contents:
-        - 'EXPECTED_DISTINCT'
-        - 'distinct_reads'
+    - contents: 'EXPECTED_DISTINCT'
+    - contents: 'distinct_reads'
 prokka:
     fn: '*.txt'
+    contents: 'contigs:'
+    num_lines: 2
 qualimap/bamqc/genome_results:
     fn: 'genome_results.txt'
 qualimap/bamqc/coverage:
@@ -120,14 +126,9 @@ quast:
 rna_seqc/metrics:
     fn: 'metrics.tsv'
 rna_seqc/coverage:
-    fn:
-        - 'meanCoverageNorm_high.txt'
-        - 'meanCoverageNorm_medium.txt'
-        - 'meanCoverageNorm_low.txt'
+    fn_re: 'meanCoverageNorm_(high|medium|low)\.txt'
 rna_seqc/correlation:
-    fn:
-        - 'corrMatrixPearson.txt'
-        - 'corrMatrixSpearman.txt'
+    fn_re: 'corrMatrix(Pearson|Spearman)\.txt'
 rseqc/bam_stat:
     contents: 'Proper-paired reads map to different chrom:'
 rseqc/gene_body_coverage:
@@ -145,8 +146,8 @@ rseqc/read_distribution:
 rseqc/read_duplication_pos:
     fn: '*.pos.DupRate.xls'
 rseqc/infer_experiment:
-    fn: '*infer_experiment.txt'
-    contents: 'Fraction of reads explained by'
+    - fn: '*infer_experiment.txt'
+    - contents: 'Fraction of reads explained by'
 salmon/meta:
     fn: 'meta_info.json'
 salmon/fld:
@@ -165,16 +166,22 @@ skewer:
     contents: 'maximum error ratio allowed (-r):'
 slamdunk/summary:
     contents: '# slamdunk summary'
+    num_lines: 1
 slamdunk/PCA:
     contents: '# slamdunk PCA'
+    num_lines: 1
 slamdunk/rates:
     contents: '# slamdunk rates'
+    num_lines: 1
 slamdunk/utrrates:
     contents: '# slamdunk utrrates'
+    num_lines: 1
 slamdunk/tcperreadpos:
     contents: '# slamdunk tcperreadpos'
+    num_lines: 1
 slamdunk/tcperutrpos:
     contents: '# slamdunk tcperutr'
+    num_lines: 1
 snpeff:
     contents: 'SnpEff_version'
 sortmerna:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -93,10 +93,8 @@ picard/oxogmetrics:
     contents: 'picard.analysis.CollectOxoGMetrics'
     shared: true
 picard/rnaseqmetrics:
-    - contents: 'picard.analysis.CollectRnaSeqMetrics'
-      shared: true
-    - contents: 'picard.analysis.Collectrnaseqmetrics'
-      shared: true
+    contents_re: '.*picard\.analysis\.Collect[Rr]na[Ss]eq[Mm]etrics.*'
+    shared: true
 picard/rrbs_metrics:
     contents: 'picard.analysis.RrbsSummaryMetrics'
     shared: true

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -2,25 +2,20 @@
 # Default configurations for how modules can find their log files.
 # Loaded by the config module so that these patterns can be overwritten in user config files.
 
-bamtools:
-    stats:
-      contents: 'Stats for BAM file(s):'
-bcftools:
-    stats:
-        contents: 'This file was produced by bcftools stats'
-bismark:
-    align:
-        fn: '*_[SP]E_report.txt'
-        # contents: Writing a C -> T converted version of the input file
-    dedup:
-        fn: '*.deduplication_report.txt'
-    meth_extract:
-        fn: '*_splitting_report.txt'
-        # contents: Bismark Extractor Version
-    m_bias:
-        fn: '*M-bias.txt'
-    bam2nuc:
-        fn: '*.nucleotide_stats.txt'
+bamtools/stats:
+    contents: 'Stats for BAM file(s):'
+bcftools/stats:
+    contents: 'This file was produced by bcftools stats'
+bismark/align:
+    fn: '*_[SP]E_report.txt'
+bismark/dedup:
+    fn: '*.deduplication_report.txt'
+bismark/meth_extract:
+    fn: '*_splitting_report.txt'
+bismark/m_bias:
+    fn: '*M-bias.txt'
+bismark/bam2nuc:
+    fn: '*.nucleotide_stats.txt'
 bowtie:
     contents: '# reads processed:'
 bowtie2:
@@ -37,34 +32,29 @@ custom_content:
         - '*_mqc.tsv'
         - '*_mqc.log'
         - '*_mqc.out'
-clusterflow:
-    logs:
-        fn: '*_clusterFlow.txt'
-    runfiles:
-        fn: '*.run'
+clusterflow/logs:
+    fn: '*_clusterFlow.txt'
+clusterflow/runfiles:
+    fn: '*.run'
 cutadapt:
     contents: 'This is cutadapt'
     # contents: 'cutadapt version' # Use this instead if using very old versions of cutadapt (eg. v1.2)
 fastq_screen:
     fn: '*_screen.txt'
-fastqc:
-    data:
-        fn: 'fastqc_data.txt'
-    zip:
-        fn: '*_fastqc.zip'
-    theoretical_gc:
-        fn: '*fastqc_theoretical_gc*'
+fastqc/data:
+    fn: 'fastqc_data.txt'
+fastqc/zip:
+    fn: '*_fastqc.zip'
+fastqc/theoretical_gc:
+    fn: '*fastqc_theoretical_gc*'
 featurecounts:
     fn: '*.summary'
-gatk:
-    varianteval:
-        contents: '#:GATKReport'
-goleft_indexcov:
-    roc:
-        fn: '*-indexcov.roc'
-    ped:
-        fn: '*-indexcov.ped'
-picard:
+gatk/varianteval:
+    contents: '#:GATKReport'
+goleft_indexcov/roc:
+    fn: '*-indexcov.roc'
+goleft_indexcov/ped:
+    fn: '*-indexcov.ped'
 htseq:
     contents: '__too_low_aQual'
 hicup:
@@ -73,130 +63,118 @@ kallisto:
     contents: '[quant] finding pseudoalignments for the reads'
 methylQA:
     fn: '*.report'
-peddy:
-    summary_table:
-        fn: '*.peddy.ped'
-    het_check:
-        fn: '*.het_check.csv'
-    ped_check:
-        fn: '*.ped_check.csv'
-    sex_check:
-        fn: '*.sex_check.csv'
-picard:
-    alignment_metrics:
-        contents: 'picard.analysis.AlignmentSummaryMetrics'
-    basedistributionbycycle:
-        contents: 'picard.analysis.BaseDistributionByCycleMetrics'
-    gcbias:
-        contents:
-          - 'picard.analysis.GcBiasDetailMetrics'
-          - 'picard.analysis.GcBiasSummaryMetrics'
-    hsmetrics:
-        contents: 'picard.analysis.directed.HsMetrics'
-    insertsize:
-        contents: 'picard.analysis.InsertSizeMetrics'
-    markdups:
-        contents: 'picard.sam.DuplicationMetrics'
-    oxogmetrics:
-        contents: 'picard.analysis.CollectOxoGMetrics'
-    rnaseqmetrics:
-        contents:
-          - 'picard.analysis.CollectRnaSeqMetrics'
-          - 'picard.analysis.Collectrnaseqmetrics'
-    rrbs_metrics:
-        contents: 'picard.analysis.RrbsSummaryMetrics'
-    wgs_metrics:
-        contents: 'picard.analysis.CollectWgsMetrics$WgsMetrics'
+peddy/summary_table:
+    fn: '*.peddy.ped'
+peddy/het_check:
+    fn: '*.het_check.csv'
+peddy/ped_check:
+    fn: '*.ped_check.csv'
+peddy/sex_check:
+    fn: '*.sex_check.csv'
+picard/alignment_metrics:
+    contents: 'picard.analysis.AlignmentSummaryMetrics'
+picard/basedistributionbycycle:
+    contents: 'picard.analysis.BaseDistributionByCycleMetrics'
+picard/gcbias:
+    contents:
+        - 'picard.analysis.GcBiasDetailMetrics'
+        - 'picard.analysis.GcBiasSummaryMetrics'
+picard/hsmetrics:
+    contents: 'picard.analysis.directed.HsMetrics'
+picard/insertsize:
+    contents: 'picard.analysis.InsertSizeMetrics'
+picard/markdups:
+    contents: 'picard.sam.DuplicationMetrics'
+picard/oxogmetrics:
+    contents: 'picard.analysis.CollectOxoGMetrics'
+picard/rnaseqmetrics:
+    contents:
+        - 'picard.analysis.CollectRnaSeqMetrics'
+        - 'picard.analysis.Collectrnaseqmetrics'
+picard/rrbs_metrics:
+    contents: 'picard.analysis.RrbsSummaryMetrics'
+picard/wgs_metrics:
+    contents: 'picard.analysis.CollectWgsMetrics$WgsMetrics'
 preseq:
     contents:
         - 'EXPECTED_DISTINCT'
         - 'distinct_reads'
-    # contents: 'TOTAL_READS	EXPECTED_DISTINCT'
-    # contents: 'TOTAL_BASES	EXPECTED_DISTINCT'
 prokka:
     fn: '*.txt'
-qualimap:
-    bamqc:
-        genome_results:
-            fn: 'genome_results.txt'
-        coverage:
-            fn: 'coverage_histogram.txt'
-        insert_size:
-            fn: 'insert_size_histogram.txt'
-        genome_fraction:
-            fn: 'genome_fraction_coverage.txt'
-        gc_dist:
-            fn: 'mapped_reads_gc-content_distribution.txt'
-    rnaseq:
-        rnaseq_results:
-            fn: 'rnaseq_qc_results.txt'
-        coverage:
-            fn: 'coverage_profile_along_genes_(total).txt'
+qualimap/bamqc/genome_results:
+    fn: 'genome_results.txt'
+qualimap/bamqc/coverage:
+    fn: 'coverage_histogram.txt'
+qualimap/bamqc/insert_size:
+    fn: 'insert_size_histogram.txt'
+qualimap/bamqc/genome_fraction:
+    fn: 'genome_fraction_coverage.txt'
+qualimap/bamqc/gc_dist:
+    fn: 'mapped_reads_gc-content_distribution.txt'
+qualimap/rnaseq/rnaseq_results:
+    fn: 'rnaseq_qc_results.txt'
+qualimap/rnaseq/coverage:
+    fn: 'coverage_profile_along_genes_(total).txt'
 quast:
     fn: 'report.tsv'
-rna_seqc:
-    metrics:
-        fn: 'metrics.tsv'
-    coverage:
-        fn:
-            - 'meanCoverageNorm_high.txt'
-            - 'meanCoverageNorm_medium.txt'
-            - 'meanCoverageNorm_low.txt'
-    correlation:
-        fn:
-            - 'corrMatrixPearson.txt'
-            - 'corrMatrixSpearman.txt'
-rseqc:
-    bam_stat:
-        contents: 'Proper-paired reads map to different chrom:'
-    gene_body_coverage:
-        fn: '*.geneBodyCoverage.txt'
-    inner_distance:
-        fn: '*.inner_distance_freq.txt'
-    junction_annotation:
-        contents: 'Partial Novel Splicing Junctions:'
-    junction_saturation:
-        fn: '*.junctionSaturation_plot.r'
-    read_gc:
-        fn: '*.GC.xls'
-    read_distribution:
-        contents: 'Group               Total_bases         Tag_count           Tags/Kb'
-    read_duplication_pos:
-        fn: '*.pos.DupRate.xls'
-    infer_experiment:
-        fn: '*infer_experiment.txt'
-        contents: 'Fraction of reads explained by'
-salmon:
-    meta:
-        fn: 'meta_info.json'
-    fld:
-        fn: 'flenDist.txt'
+rna_seqc/metrics:
+    fn: 'metrics.tsv'
+rna_seqc/coverage:
+    fn:
+        - 'meanCoverageNorm_high.txt'
+        - 'meanCoverageNorm_medium.txt'
+        - 'meanCoverageNorm_low.txt'
+rna_seqc/correlation:
+    fn:
+        - 'corrMatrixPearson.txt'
+        - 'corrMatrixSpearman.txt'
+rseqc/bam_stat:
+    contents: 'Proper-paired reads map to different chrom:'
+rseqc/gene_body_coverage:
+    fn: '*.geneBodyCoverage.txt'
+rseqc/inner_distance:
+    fn: '*.inner_distance_freq.txt'
+rseqc/junction_annotation:
+    contents: 'Partial Novel Splicing Junctions:'
+rseqc/junction_saturation:
+    fn: '*.junctionSaturation_plot.r'
+rseqc/read_gc:
+    fn: '*.GC.xls'
+rseqc/read_distribution:
+    contents: 'Group               Total_bases         Tag_count           Tags/Kb'
+rseqc/read_duplication_pos:
+    fn: '*.pos.DupRate.xls'
+rseqc/infer_experiment:
+    fn: '*infer_experiment.txt'
+    contents: 'Fraction of reads explained by'
+salmon/meta:
+    fn: 'meta_info.json'
+salmon/fld:
+    fn: 'flenDist.txt'
 samblaster:
     contents: 'samblaster: Version'
-samtools:
-    stats:
-        contents: 'This file was produced by samtools stats'
-    flagstat:
-        contents: 'in total (QC-passed reads + QC-failed reads)'
-    idxstats:
-        fn: '*idxstat*'
-    rmdup:
-        contents: '[bam_rmdup'
+samtools/stats:
+    contents: 'This file was produced by samtools stats'
+samtools/flagstat:
+    contents: 'in total (QC-passed reads + QC-failed reads)'
+samtools/idxstats:
+    fn: '*idxstat*'
+samtools/rmdup:
+    contents: '[bam_rmdup'
 skewer:
     contents: 'maximum error ratio allowed (-r):'
-slamdunk:
-    summary:
-        contents: '# slamdunk summary'
-    PCA:
-        contents: '# slamdunk PCA'
-    rates:
-        contents: '# slamdunk rates'
-    utrrates:
-        contents: '# slamdunk utrrates'
-    tcperreadpos:
-        contents: '# slamdunk tcperreadpos'
-    tcperutrpos:
-        contents: '# slamdunk tcperutr'
+slamdunk/summary:
+    contents: '# slamdunk summary'
+slamdunk/PCA:
+    contents: '# slamdunk PCA'
+slamdunk/rates:
+    contents: '# slamdunk rates'
+slamdunk/utrrates:
+    contents: '# slamdunk utrrates'
+slamdunk/tcperreadpos:
+    contents: '# slamdunk tcperreadpos'
+slamdunk/tcperutrpos:
+    contents: '# slamdunk tcperutr'
 snpeff:
     contents: 'SnpEff_version'
 sortmerna:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -34,6 +34,7 @@ clusterflow/runfiles:
 cutadapt:
     contents: 'This is cutadapt'
     # contents: 'cutadapt version' # Use this instead if using very old versions of cutadapt (eg. v1.2)
+    shared: true
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -4,8 +4,10 @@
 
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
+    shared: true
 bcftools/stats:
     contents: 'This file was produced by bcftools stats'
+    shared: true
 bismark/align:
     fn: '*_[SP]E_report.txt'
 bismark/dedup:
@@ -47,6 +49,7 @@ featurecounts:
     fn: '*.summary'
 gatk/varianteval:
     contents: '#:GATKReport'
+    shared: true
 goleft_indexcov/roc:
     fn: '*-indexcov.roc'
 goleft_indexcov/ped:
@@ -57,6 +60,7 @@ hicup:
     fn: 'HiCUP_summary_report*'
 kallisto:
     contents: '[quant] finding pseudoalignments for the reads'
+    shared: true
 methylQA:
     fn: '*.report'
 peddy/summary_table:
@@ -74,10 +78,8 @@ picard/basedistributionbycycle:
     contents: 'picard.analysis.BaseDistributionByCycleMetrics'
     shared: true
 picard/gcbias:
-    - contents: 'picard.analysis.GcBiasDetailMetrics'
-      shared: true
-    - contents: 'picard.analysis.GcBiasSummaryMetrics'
-      shared: true
+    contents: 'picard.analysis.GcBias'
+    shared: true
 picard/hsmetrics:
     contents: 'picard.analysis.directed.HsMetrics'
     shared: true
@@ -103,9 +105,10 @@ picard/wgs_metrics:
     shared: true
 preseq:
     - contents: 'EXPECTED_DISTINCT'
+      max_filesize: 500000
     - contents: 'distinct_reads'
+      max_filesize: 500000
 prokka:
-    fn: '*.txt'
     contents: 'contigs:'
     num_lines: 2
 qualimap/bamqc/genome_results:
@@ -132,39 +135,48 @@ rna_seqc/correlation:
     fn_re: 'corrMatrix(Pearson|Spearman)\.txt'
 rseqc/bam_stat:
     contents: 'Proper-paired reads map to different chrom:'
+    max_filesize: 500000
 rseqc/gene_body_coverage:
     fn: '*.geneBodyCoverage.txt'
 rseqc/inner_distance:
     fn: '*.inner_distance_freq.txt'
 rseqc/junction_annotation:
     contents: 'Partial Novel Splicing Junctions:'
+    max_filesize: 500000
 rseqc/junction_saturation:
     fn: '*.junctionSaturation_plot.r'
 rseqc/read_gc:
     fn: '*.GC.xls'
 rseqc/read_distribution:
     contents: 'Group               Total_bases         Tag_count           Tags/Kb'
+    max_filesize: 500000
 rseqc/read_duplication_pos:
     fn: '*.pos.DupRate.xls'
 rseqc/infer_experiment:
     - fn: '*infer_experiment.txt'
     - contents: 'Fraction of reads explained by'
+      max_filesize: 500000
 salmon/meta:
     fn: 'meta_info.json'
 salmon/fld:
     fn: 'flenDist.txt'
 samblaster:
     contents: 'samblaster: Version'
+    shared: true
 samtools/stats:
     contents: 'This file was produced by samtools stats'
+    shared: true
 samtools/flagstat:
     contents: 'in total (QC-passed reads + QC-failed reads)'
+    shared: true
 samtools/idxstats:
     fn: '*idxstat*'
 samtools/rmdup:
     contents: '[bam_rmdup'
+    shared: true
 skewer:
     contents: 'maximum error ratio allowed (-r):'
+    shared: true
 slamdunk/summary:
     contents: '# slamdunk summary'
     num_lines: 1
@@ -185,8 +197,10 @@ slamdunk/tcperutrpos:
     num_lines: 1
 snpeff:
     contents: 'SnpEff_version'
+    max_filesize: 1000000
 sortmerna:
     contents: 'Minimal SW score based on E-value'
+    shared: true
 star:
     fn: '*Log.final.out'
 star_genecounts:
@@ -195,3 +209,4 @@ tophat:
     fn: '*align_summary.txt'
 trimmomatic:
     contents: 'Trimmomatic'
+    shared: true

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -232,12 +232,13 @@ plots_flat, plots_interactive, make_pdf, config_file, verbose, quiet, **kwargs):
     if file_list:
         if len(analysis_dir) > 1:
             raise ValueError("If --file-list is giving, analysis_dir should have only one plain text file.")
-        config.analysis_dir = ()
+        config.analysis_dir = []
         with (open(analysis_dir[0])) as in_handle:
             for line in in_handle:
                 if os.path.exists(line.strip()):
-                    config.analysis_dir += (os.path.abspath(line.strip()),)
-        if len(config.analysis_dir) == 0:
+                    path = os.path.abspath(line.strip())
+                    report.searchfiles.append([os.path.basename(path), os.path.dirname(path)])
+        if len(report.searchfiles) == 0:
             logger.error("No files were added from {} using --file-list option.".format(analysis_dir[0]))
             logger.error("Please, check that {} contains correct file paths.".format(analysis_dir[0]))
             raise ValueError("Any files to be searched.")


### PR DESCRIPTION
A rewrite of how the file search mechanism works. Roughly speaking, the process was / is:

* Before:
    * MultiQC generates a list of files when it begins (skipping v. large files etc)
    * Each module runs through the list looking for its files
    * Modules supply a config dictionary to the search function
    * Snazzy new progress bar whilst doing the first search
* Now:
    * MultiQC searches files for each module search pattern when it begins
    * Each module supplies it's search key (instead of a config dict) and is given back the matching files, without doing a second search
    * Backwards compatibility is currently maintained for plugins etc. that supply search dicts, though with a warning.

Because MultiQC was searching the full file list very many times before (once for each module), it could be quite slow when run with lots of files. This refactoring appears to speed up execution time by around 25-50%. Not bad really! Speed up will be most noticeable when running with lots of files which are all matched by modules by filename. Modules with these search patterns are run first and the files removed from the search list.

All feedback welcome!

Phil