### PR TITLE
Fix htseq module error when using htseq 0.8

### DIFF
--- a/multiqc/modules/htseq/htseq.py
+++ b/multiqc/modules/htseq/htseq.py
@@ -59,10 +59,10 @@ class MultiqcModule(BaseMultiqcModule):
         for l in f['f']:
             s = l.split("\t")
             if s[0] in keys:
-                parsed_data[s[0][2:]] = int(s[1])
+                parsed_data[s[0][2:]] = int(s[-1])
             else:
                 try:
-                    assigned_counts += int(s[1])
+                    assigned_counts += int(s[-1])
                 except (ValueError, IndexError):
                     pass
         if len(parsed_data) > 0:


### PR DESCRIPTION
Use last column of htseq-count table instead of 2nd column.
This should fix an issue that arises with htseq 0.8 when the new option "--additional-attr" is used. This new option adds a column, and thus the second column no longer contains the desired data