### PR TITLE
fix fastq_screen module

### DIFF
--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -139,7 +139,7 @@ class MultiqcModule(BaseMultiqcModule):
                 thisdata = list()
                 if len(categories) > 0:
                     getCats = False
-                for org in self.fq_screen_data[s]:
+                for org in sorted(self.fq_screen_data[s]):
                     if org == 'total_reads':
                         continue
                     try:

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Section 1 - Alignment Profiles
         # Posh plot only works for around 20 samples, 8 organisms.
-        if len(self.fq_screen_data) * self.num_orgs <= 160 and not config.plots_force_flat and not getattr(config, 'fastqscreen_simpleplot', False):
+        if len(self.fq_screen_data) * self.num_orgs <= 160 and not config.plots_force_flat and not getattr(config, 'fastqscreen_simpleplot', True):
             self.add_section( content = self.fqscreen_plot() )
         # Use simpler plot that works with many samples
         else:


### PR DESCRIPTION
Hi @ewels -

1) The `fastq_screen` module was not sorting the organism dict keys, resulting in random order of the bars in the non-simple-plot version.
2) While troubleshooting that, I set `fastqscreen_simpleplot: true` in the config as indicated in the docs, but it wasn't forcing the simple plot.

Luckily the fixes are super easy, both fixed in this PR.

Thanks for such a great tool!

