### PR TITLE
Quast: processs metaquast runs properly

### DIFF
--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -239,7 +239,6 @@ class MultiqcModule(BaseMultiqcModule):
         """ Make a bar plot showing the number and length of contigs for each assembly """
 
         # Prep the data
-        import re
         data = dict()
         categories = []
         for s_name, d in self.quast_data.items():

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -50,6 +50,11 @@ thousandsSep_format: null
 
 fn_ignore_dirs:
     - 'multiqc_data'
+    - 'icarus_viewers'       # quast
+    - 'runs_per_reference'   # quast
+    - 'not_aligned'          # quast
+    - 'contigs_reports'      # quast
+
 fn_ignore_paths:
     - '*/work/??/??????????????????????????????' # Nextflow work directories - always same hash lengths
 sample_names_ignore: []
@@ -155,10 +160,13 @@ fn_ignore_files:
     - '*.fastq.gz'
     - '*.fq'
     - '*.fastq'
+    - '*.fa'
     - '*.gtf'
     - '*.bed'
     - '*.vcf'
     - '*.txt.gz'
+    - '*.pdf'
+    - '*.html'
 
 # Favourite modules that should appear at the top in preference
 # This is in addition to those below. These appear above _all_ other


### PR DESCRIPTION
Fixing https://github.com/ewels/MultiQC/issues/487

In order to support outputs from metagenomic quast runs properly, we first need to determine if we are faced with a regular or a metaquast run. The basic directory structures for those are as follows:

Regular quast run (single genome), in MultiQC we want to parse `quast.tsv`:
```
quast.log
report.tsv
```
Metaquast run (multiple reference genomes), in MultiQC we want to parse `combined_reference/report.tsv`:
```
combined_reference/
   quast.log
   report.tsv
metaquast.log
runs_per_reference/
   reference1/
      quast.log
      report.tsv
   reference2/
      quast.log
      report.tsv
   ...
not_aligned/
   quast.log
   report.tsv
```

So the trick is to make MultiQC avoid treating all those per-reference subdirectories as full quast inputs. The only way I figured is to target `metaquast.log`, and then point to `dirname(join('combined_reference', 'report.tsv')` avoiding the standard file search mechanism. Only if `metaquast.log` is not found, go and search for all occurences of 'report.tsv' and process as a regular quast. I'm not sure how to distinguish between `report.tsv` and `combined_reference/report.tsv` using `find_log_files` only.

I'm also adding test data into https://github.com/ewels/MultiQC_TestData 