### PR TITLE
change sample name regexp in MarkDuplicates.py

### DIFF
--- a/multiqc/modules/picard/MarkDuplicates.py
+++ b/multiqc/modules/picard/MarkDuplicates.py
@@ -28,9 +28,9 @@ def parse_reports(self):
                 s_name = None
 
                 # Pull sample name from input
-                fn_search = re.search("INPUT=\[?([^\\s]+)\]?", l)
+                fn_search = re.search((r"INPUT=(\[([^\s]+)\]|([^\s]+))", l)
                 if fn_search:
-                    s_name = os.path.basename(fn_search.group(1))
+                    s_name = os.path.basename(fn_search.group(2) or fn_search.group(3))
                     s_name = self.clean_s_name(s_name, f['root'])
 
             if s_name is not None:


### PR DESCRIPTION
In the original regexp `INPUT=\[?([^\\s]+)\]?`, the last character `\]?` will never be matched due to the greedy operator `+` in `[^\\s]+`. So we will get sample name with trailing `]` character, which is inconsistent with name from other tools like FastQC.