### PR TITLE
Allow setting a default config which will persist across page reloads

### DIFF
--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -635,7 +635,6 @@ function mqc_save_config(name, clear, as_default){
         prev_config = JSON.parse(prev_config);
       } else {
         prev_config = {};
-        as_default = true;
       }
 
       // Update config obj with current config
@@ -703,6 +702,11 @@ function mqc_clear_default_config() {
       setTimeout(function () {
         $('#mqc-cleared-success').slideUp(function () { $(this).remove(); });
       }, 5000);
+    var name = $('#mqc_loadconfig_form select option:contains("default")').text();
+    console.log(name);
+    $('#mqc_loadconfig_form select option:contains("default")').remove();
+    name = name.replace(' [default]', '');
+    $('#mqc_loadconfig_form select').append('<option>'+name+'</option>').val(name);
     });
   } catch (e) {
     console.log('Could not access localStorage');
@@ -719,12 +723,13 @@ function populate_mqc_saveselect(){
     if(local_config !== null && local_config !== undefined){
       local_config = JSON.parse(local_config);
       for (var name in local_config){
-        $('#mqc_loadconfig_form select').append('<option>'+name+'</option>').val(name);
         if (local_config[name]['default']) {
           console.log('Loaded default config!');
           load_mqc_config(name);
           default_config = name;
+          name = name+' [default]';
         }
+        $('#mqc_loadconfig_form select').append('<option>'+name+'</option>').val(name);
       }
     }
   } catch(e){
@@ -737,7 +742,6 @@ function populate_mqc_saveselect(){
       '<a href="https://www.google.se/search?q=Block+third-party+cookies+and+site+data" target="_blank">change this browser setting</a>'+
       ' to save MultiQC report configs.</p>');
   }
-  $('#mqc_loadconfig_form select').val(default_config);
 }
 
 //////////////////////////////////////////////////////

--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -348,6 +348,11 @@ $(function () {
         mqc_save_config(name, false, true);
     }
   });
+    // Clear current config default
+  $('.mqc_config_clear_default').click(function(e){
+    e.preventDefault();
+    mqc_clear_default_config();
+  });
 
   // Filter text is changed
   $('.mqc_filters').on('blur', 'li input', function(){
@@ -615,7 +620,6 @@ function mqc_save_config(name, clear, as_default){
       // Update config obj with current config
       if(clear == true){
         delete prev_config[name];
-        // TODO: If deleted config was default, move default to possible remaining config
       } else {
         prev_config[name] = config;
         prev_config[name]['last_updated'] = Date();
@@ -645,8 +649,10 @@ function mqc_save_config(name, clear, as_default){
         }, 5000);
       });
     } else {
-      // Add to load select box and select it
-      $('#mqc_loadconfig_form select').prepend('<option>'+name+'</option>').val(name);
+      // Remove from load select box
+      $("#mqc_loadconfig_form select option:contains('"+name+"')").remove();
+      // Add new name to load select box and select it
+      $('#mqc_loadconfig_form select').prepend('<option>'+name+(as_default?' [default]':'')+'</option>').val(name+(as_default?' [default]':''));
       // Success message
       $('<p class="text-success" id="mqc-save-success">Settings saved.</p>').hide().insertBefore($('#mqc_saveconfig_form')).slideDown(function(){
         setTimeout(function(){
@@ -655,6 +661,31 @@ function mqc_save_config(name, clear, as_default){
       });
     }
   } catch(e){ console.log('Error updating localstorage: '+e); }
+}
+
+// Clear current default configuration
+function mqc_clear_default_config() {
+  try {
+    var config = localStorage.getItem("mqc_config");
+    if (!config) {
+      return;
+    } else {
+      config = JSON.parse(config);
+    }
+    for (var c in config) {
+      if (config.hasOwnProperty(c)) {
+        config[c]['default'] = false;
+      }
+    }
+    localStorage.setItem("mqc_config", JSON.stringify(config));
+    $('<p class="text-danger" id="mqc-cleared-success">Unset default.</p>').hide().insertBefore($('#mqc_loadconfig_form .actions')).slideDown(function () {
+      setTimeout(function () {
+        $('#mqc-cleared-success').slideUp(function () { $(this).remove(); });
+      }, 5000);
+    });
+  } catch (e) {
+    console.log('Could not access localStorage');
+  }
 }
 
 //////////////////////////////////////////////////////

--- a/multiqc/templates/default/toolbox.html
+++ b/multiqc/templates/default/toolbox.html
@@ -238,6 +238,7 @@ of the report.
         <div class="form-group actions">
           <button type="submit" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-floppy-open"></span> Load</button>
           <button class="mqc_config_clear btn btn-sm btn-default"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+          <button class="mqc_config_set_default btn btn-sm btn-default"><span class="glyphicon glyphicon-save"></span> Set as default</button>
         </div>
       </form>
     </div>

--- a/multiqc/templates/default/toolbox.html
+++ b/multiqc/templates/default/toolbox.html
@@ -238,7 +238,8 @@ of the report.
         <div class="form-group actions">
           <button type="submit" class="btn btn-sm btn-default"><span class="glyphicon glyphicon-floppy-open"></span> Load</button>
           <button class="mqc_config_clear btn btn-sm btn-default"><span class="glyphicon glyphicon-trash"></span> Delete</button>
-          <button class="mqc_config_set_default btn btn-sm btn-default"><span class="glyphicon glyphicon-save"></span> Set as default</button>
+          <button class="mqc_config_set_default btn btn-sm btn-default"><span class="glyphicon glyphicon-floppy-saved"></span> Set default</button>
+          <button class="mqc_config_clear_default btn btn-sm btn-default"><span class="glyphicon glyphicon-floppy-remove"></span> Clear default</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
This PR adds two buttons to the config tab in the toolbox.
They allow to set a config as default. This will label the config with '[default]' and load it each time the page is opened.
It also allows to unset the current default config.

It uses the localstorage to save the config which means it will be lost when cookies are cleared.