### PR TITLE
Bcl2fastq

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ Code contributions from:
 [@t-neumann](https://github.com/t-neumann),
 [@ahvigil](https://github.com/ahvigil),
 [@bschiffthaler](https://github.com/bschiffthaler),
-[@jrderuiter](https://github.com/jrderuiter)
-[@iimog](https://github.com/iimog)
+[@jrderuiter](https://github.com/jrderuiter),
+[@iimog](https://github.com/iimog),
 [@rlegendre](https://github.com/rlegendre)
 and many others. Thanks for your support!
 

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -103,15 +103,14 @@ class MultiqcModule(BaseMultiqcModule):
                 "undetermined": self.bcl2fastq_data[runId][lane]["samples"]["undetermined"]["total"]
                 }
                 for sample in self.bcl2fastq_data[runId][lane]["samples"].keys():
-                    uniqSampleName = self.prepend_runid(runId, sample)
-                    if not uniqSampleName in self.bcl2fastq_bysample:
-                        self.bcl2fastq_bysample[uniqSampleName] = {"total": 0, "perfectIndex": 0}
-                    self.bcl2fastq_bysample[uniqSampleName]["total"] += self.bcl2fastq_data[runId][lane]["samples"][sample]["total"]
-                    self.bcl2fastq_bysample[uniqSampleName]["perfectIndex"] += self.bcl2fastq_data[runId][lane]["samples"][sample]["perfectIndex"]
+                    if not sample in self.bcl2fastq_bysample:
+                        self.bcl2fastq_bysample[sample] = {"total": 0, "perfectIndex": 0}
+                    self.bcl2fastq_bysample[sample]["total"] += self.bcl2fastq_data[runId][lane]["samples"][sample]["total"]
+                    self.bcl2fastq_bysample[sample]["perfectIndex"] += self.bcl2fastq_data[runId][lane]["samples"][sample]["perfectIndex"]
                     if sample != "undetermined":
-                        if not uniqSampleName in self.source_files:
-                            self.source_files[uniqSampleName] = []
-                        self.source_files[uniqSampleName].append(self.bcl2fastq_data[runId][lane]["samples"][sample]["filename"])
+                        if not sample in self.source_files:
+                            self.source_files[sample] = []
+                        self.source_files[sample].append(self.bcl2fastq_data[runId][lane]["samples"][sample]["filename"])
 
     def add_general_stats(self):
         data = {key: {"total": self.bcl2fastq_bysample[key]["total"], "perfectPercent": '{0:.1f}'.format(float(100.0*self.bcl2fastq_bysample[key]["perfectIndex"]/self.bcl2fastq_bysample[key]["total"]))} for key in self.bcl2fastq_bysample.keys()}

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -83,6 +83,8 @@ class MultiqcModule(BaseMultiqcModule):
             run_data[lane] = {"total": 0, "perfectIndex": 0, "samples": dict()}
             for demuxResult in conversionResult["DemuxResults"]:
                 sample = demuxResult["SampleName"]
+                if sample in run_data[lane]["samples"]:
+                    log.debug("Duplicate runId/lane/sample combination found! Overwriting: {}, {}".format(self.prepend_runid(runId, lane),sample))
                 run_data[lane]["samples"][sample] = {"total": 0, "perfectIndex": 0, "filename": os.path.join(myfile['root'],myfile["fn"])}
                 run_data[lane]["total"] += demuxResult["NumberReads"]
                 run_data[lane]["samples"][sample]["total"] += demuxResult["NumberReads"]


### PR DESCRIPTION
As discussed in #527 I added some changes to the behavior of the bcl2fastq module:
 - Samples are no longer prefixed with the run ID (so same samples from different runs are combined)
 - Yield Q30 is added to the main results table
 - Yield Q30 is added to the data files (both by sample and by lane)

The rest of the suggestions is not yet implemented. I will be busy in the next weeks as I try to finish my thesis. I'm happy to continue work on this module afterwards. However, if anyone wants to take over development of this module, please feel free.

It might make sense to add another configuration option `base_count_multiplier` for yield Q30 (just like the existing `read_count_multiplier`.