### PR TITLE
Initial Base Recalibrator section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
   - multiqc data -f -v --flat -e star -x ngi -s -z -c ../multiqc_config_example.yaml
   - multiqc -m star -o tests/multiqc_report_dev -t default_dev -k json --file-list data/special_cases/file_list.txt
   - multiqc -f empty_dir
+  - multiqc -f data/modules/gatk/BaseRecalibrator/recal_data.table

--- a/docs/modules/gatk.md
+++ b/docs/modules/gatk.md
@@ -10,7 +10,17 @@ a wide variety of tools with a primary focus on variant discovery and genotyping
 Its powerful processing engine and high-performance computing features make it capable
 of taking on projects of any size.
 
-Supported tools: `VariantEval`
+Supported tools: 
+- `BaseRecalibrator`
+- `VariantEval`
+
+#### BaseRecalibrator
+[BaseRecalibrator](https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_gatk_tools_walkers_bqsr_BaseRecalibrator.php)
+is a tool for detecting systematic errors in read base quality scores of aligned high-throughput
+sequencing reads. It outputs a base quality score recalibration table that can be used in 
+conjunction with the 
+[PrintReads](https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_gatk_tools_walkers_readutils_PrintReads.php)
+tool to recalibrate base quality scores.
 
 ### VariantEval
 [VariantEval](https://www.broadinstitute.org/gatk/gatkdocs/org_broadinstitute_gatk_tools_walkers_varianteval_VariantEval.php)

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -4,11 +4,19 @@
 """ MultiQC submodule to parse output from GATK BaseRecalibrator """
 
 import logging
-from collections import OrderedDict, defaultdict
+from enum import IntEnum
 from multiqc.plots import linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
+
+
+class RecalTableType(IntEnum):
+    pre_recalibration = 0
+    post_recalibration = 1
+
+    def human_readable(self):
+        return self.name.capitalize().replace('_', '-')
 
 
 class BaseRecalibratorMixin():
@@ -22,28 +30,35 @@ class BaseRecalibratorMixin():
             '#:GATKTable:RecalTable1:': 'recal_table_1',
             '#:GATKTable:RecalTable2:': 'recal_table_2',
         }
-        samples_kept = set()
-        self.gatk_base_recalibrator = {table_name: {} for table_name in
-                                       report_table_headers.values()}
+        samples_kept = {rt_type: set() for rt_type in RecalTableType}
+        self.gatk_base_recalibrator = {recal_type:
+                                           {table_name: {}
+                                            for table_name
+                                            in report_table_headers.values()}
+                                       for recal_type in RecalTableType}
+
         for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
             parsed_data = self.parse_report(f['f'].readlines(), report_table_headers)
+            rt_type = determine_recal_table_type(parsed_data)
             if len(parsed_data) > 0:
-                if f['s_name'] in samples_kept:
+                if f['s_name'] in samples_kept[rt_type]:
                     log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))
-                samples_kept.add(f['s_name'])
+                else:
+                    samples_kept[rt_type].add(f['s_name'])
 
                 self.add_data_source(f, section='base_recalibrator')
                 for table_name, sample_tables in parsed_data.items():
-                    self.gatk_base_recalibrator[table_name][f['s_name']] = sample_tables
+                    self.gatk_base_recalibrator[rt_type][table_name][
+                        f['s_name']] = sample_tables
 
         # Filter to strip out ignored sample names
-        self.gatk_base_recalibrator = {
-            table_name: self.ignore_samples(sample_tables)
-            for table_name, sample_tables
-            in self.gatk_base_recalibrator.items()
-        }
+        for rt_type in RecalTableType:
+            for table_name, sample_tables in self.gatk_base_recalibrator[rt_type].items():
+                self.gatk_base_recalibrator[rt_type][table_name] = self.ignore_samples(
+                    sample_tables)
 
-        n_reports_found = len(samples_kept)
+        n_reports_found = sum([len(samples_kept[rt_type]) for rt_type in RecalTableType])
+
         if n_reports_found > 0:
             log.info("Found {} BaseRecalibrator reports".format(n_reports_found))
 
@@ -54,11 +69,39 @@ class BaseRecalibratorMixin():
     def add_quality_score_vs_no_of_observations_section(self):
         """ Add a section for the quality score vs number of observations line plot """
 
-        sample_tables = self.gatk_base_recalibrator['quality_quantization_map']
-        sample_data = {
-            sample: {int(x): int(y) for x, y in zip(table['QualityScore'], table['Count'])}
-            for sample, table in sample_tables.items()
-        }
+        sample_data = []
+        data_labels = []
+        for rt_type in RecalTableType:
+            sample_tables = self.gatk_base_recalibrator[rt_type]['quality_quantization_map']
+
+            sample_data.append({
+                sample: {int(x): int(y) for x, y in zip(table['QualityScore'], table['Count'])}
+                for sample, table in sample_tables.items()
+            })
+
+            sample_y_sums = {
+                sample: sum(int(y) for y in table['Count'])
+                for sample, table
+                in sample_tables.items()
+            }
+
+            sample_data.append({
+                sample: {
+                    int(x): float(y) / sample_y_sums[sample]
+                    for x, y in zip(table['QualityScore'], table['Count'])
+                }
+                for sample, table in sample_tables.items()
+            })
+
+            flat_proportions = [float(y) / sample_y_sums[sample]
+                                for sample, table in sample_tables.items()
+                                for y in table['Count']]
+            prop_ymax = max(flat_proportions)
+            data_labels.append({'name': "{} Count".format(rt_type.human_readable()),
+                                'ylab': 'Count'})
+            data_labels.append({'ymax': prop_ymax,
+                                'name': "{} Percent".format(rt_type.human_readable()),
+                                'ylab': 'Percent'})
 
         plot = linegraph.plot(
             sample_data,
@@ -67,9 +110,8 @@ class BaseRecalibratorMixin():
                 'id': 'gatk-base-recalibrator-quality-score-vs-number-of-observations',
                 'xlab': 'Observed Quality Score',
                 'ylab': 'Count',
-                'yDecimals': False,
                 'xDecimals': False,
-                'tt_label': '{point.x}: {point.y:.0f}'
+                'data_labels': data_labels,
             })
 
         # Reported vs empirical quality scores
@@ -88,3 +130,11 @@ class BaseRecalibratorMixin():
             ),
             plot=plot,
         )
+
+
+def determine_recal_table_type(parsed_data):
+    arguments = dict(zip(parsed_data['arguments']['Argument'], parsed_data['arguments']['Value']))
+    if arguments['recalibration_report'] == 'null':
+        return RecalTableType.pre_recalibration
+    else:
+        return RecalTableType.post_recalibration

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -73,6 +73,8 @@ class BaseRecalibratorMixin():
         data_labels = []
         for rt_type in RecalTableType:
             sample_tables = self.gatk_base_recalibrator[rt_type]['quality_quantization_map']
+            if len(sample_tables) == 0:
+                continue
 
             sample_data.append({
                 sample: {int(x): int(y) for x, y in zip(table['QualityScore'], table['Count'])}

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -63,6 +63,8 @@ class BaseRecalibratorMixin():
         plot = linegraph.plot(
             sample_data,
             pconfig={
+                'title': "Observed Quality Score Counts",
+                'id': 'gatk-base-recalibrator-quality-score-vs-number-of-observations',
                 'xlab': 'Observed Quality Score',
                 'ylab': 'Count',
                 'yDecimals': False,

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -73,8 +73,6 @@ class BaseRecalibratorMixin():
         data_labels = []
         for rt_type in RecalTableType:
             sample_tables = self.gatk_base_recalibrator[rt_type]['quality_quantization_map']
-            if len(sample_tables) == 0:
-                continue
 
             sample_data.append({
                 sample: {int(x): int(y) for x, y in zip(table['QualityScore'], table['Count'])}

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -5,7 +5,7 @@
 
 import logging
 from collections import OrderedDict, defaultdict
-from multiqc.plots import bargraph, table, linegraph
+from multiqc.plots import linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -80,7 +80,7 @@ class BaseRecalibratorMixin():
                 'after base quality score recalibration (BQSR). Applying BQSR should broaden the '
                 'distribution of base quality scores.'
             ),
-            helptext= (
+            helptext=(
                 'For more information see <a href=https://gatkforums.broadinstitute.org/gatk/discussion/44/base-quality-score-recalibration-bqsr>'
                 'the Broad\'s description of BQSR</a>.'
             ),

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -81,8 +81,10 @@ class BaseRecalibratorMixin():
                 'distribution of base quality scores.'
             ),
             helptext=(
-                'For more information see <a href=https://gatkforums.broadinstitute.org/gatk/discussion/44/base-quality-score-recalibration-bqsr>'
-                'the Broad\'s description of BQSR</a>.'
+                'For more information see '
+                '[the Broad\'s description of BQSR]'
+                '(https://gatkforums.broadinstitute.org/gatk/discussion/44/base-quality-score-recalibration-bqsr)'
+                '.'
             ),
             plot=plot,
         )

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" MultiQC submodule to parse output from GATK BaseRecalibrator """
+
+import logging
+from collections import OrderedDict, defaultdict
+from multiqc.plots import bargraph, table, linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+class BaseRecalibratorMixin():
+    def parse_gatk_base_recalibrator(self):
+        """ Find GATK BaseRecalibrator logs and parse their data """
+
+        self.gatk_base_recalibrator = dict()
+        for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
+            parsed_data = self.parse_report(
+                f['f'],
+                {
+                    '#:GATKTable:Arguments:Recalibration argument collection values used in this run': 'arguments',
+                    '#:GATKTable:Quantized:Quality quantization map': 'quality_quantization_map',
+                    '#:GATKTable:RecalTable0:': 'recal_table_0',
+                    '#:GATKTable:RecalTable1:': 'recal_table_1',
+                    '#:GATKTable:RecalTable2:': 'recal_table_2',
+                }
+            )
+            if len(parsed_data) > 0:
+                if f['s_name'] in self.gatk_base_recalibrator:
+                    log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))
+                self.add_data_source(f, section='base_recalibrator')
+                self.gatk_base_recalibrator[f['s_name']] = parsed_data
+
+        # Filter to strip out ignored sample names
+        self.gatk_base_recalibrator = self.ignore_samples(self.gatk_base_recalibrator)
+
+        if len(self.gatk_base_recalibrator) > 0:
+            # Write parsed report data to a file (restructure first)
+            self.write_data_file(self.gatk_base_recalibrator, 'multiqc_gatk_base_recalibrator')
+
+            # Reported vs empirical quality scores
+            self.add_section(
+                name='Reported vs Empirical Quality Scores',
+                anchor='gatk-reported-vs-empirical-quality-scores',
+                plot=quality_score_vs_no_of_observations(self.gatk_base_recalibrator)
+            )
+
+        # Return the number of logs that were found
+        return len(self.gatk_base_recalibrator)
+
+
+def quality_score_vs_no_of_observations(data):
+    """ Return HTML for the quality score vs number of observations line plot """
+
+    table = data['quality_quantization_map']
+    xy = {x: y for x, y in zip(table['QualityScore'], table['Count'])}
+    return linegraph.plot({'sample_1': xy})

--- a/multiqc/modules/gatk/gatk.py
+++ b/multiqc/modules/gatk/gatk.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """ MultiQC module to parse output from GATK """
 from __future__ import print_function
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import logging
 
 from multiqc import config
@@ -10,12 +10,13 @@ from multiqc.modules.base_module import BaseMultiqcModule
 # Import the GATK submodules
 # import varianteval
 from .varianteval import VariantEvalMixin
+from .base_recalibrator import BaseRecalibratorMixin
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
 
-class MultiqcModule(BaseMultiqcModule, VariantEvalMixin):
+class MultiqcModule(BaseMultiqcModule, BaseRecalibratorMixin, VariantEvalMixin):
     """ GATK has a number of different commands and outputs.
     This MultiQC module supports some but not all. The code for
     each script is split into its own file and adds a section to
@@ -25,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule, VariantEvalMixin):
 
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
-            name='GATK',  anchor='gatk', target='GATK',
+            name='GATK', anchor='gatk', target='GATK',
             href='https://www.broadinstitute.org/gatk/',
             info=(" is a toolkit offering a wide variety of tools with a "
                   "primary focus on variant discovery and genotyping."))
@@ -47,3 +48,51 @@ class MultiqcModule(BaseMultiqcModule, VariantEvalMixin):
 
         # Add to the General Stats table (has to be called once per MultiQC module)
         self.general_stats_addcols(self.general_stats_data, self.general_stats_headers)
+
+    def parse_report(self, f, table_names):
+        """ Parse a GATK report https://software.broadinstitute.org/gatk/documentation/article.php?id=1244
+
+        Only GATTable entries are parsed.  Tables are returned as a dict of tables.
+        Each table is a dict of arrays, where names correspond to column names, and arrays
+        correspond to column values.
+
+        Args:
+            f (file handle): a file handle to a GATK report.
+            table_names (dict): a dict with keys that are GATK report table names
+                (e.g. "#:GATKTable:Quantized:Quality quantization map"), and values that are the
+                keys in the returned dict.
+
+        Returns:
+            {
+                table_1:
+                    {
+                        col_1: [ val_1, val_2, ... ]
+                        col_2: [ val_1, val_2, ... ]
+                        ...
+                    }
+                table_2:
+                    ...
+            }
+        """
+
+        data = dict()
+        while True:
+            line = f.readline()
+            if line == '':
+                break
+            line = line.rstrip()
+            if line in table_names.keys():
+                data[table_names[line]] = self.parse_gatk_report_table(f)
+        return data
+
+    def parse_gatk_report_table(self, f):
+        data = defaultdict(list)
+        headers = f.readline().rstrip().split()
+        while True:
+            line = f.readline()
+            line = line.rstrip()
+            if line == '':
+                break
+            for index, value in enumerate(line.split()):
+                data[headers[index]].append(value)
+        return data

--- a/multiqc/modules/gatk/gatk.py
+++ b/multiqc/modules/gatk/gatk.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """ MultiQC module to parse output from GATK """
 from __future__ import print_function
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 import logging
 
 from multiqc import config
@@ -34,15 +34,14 @@ class MultiqcModule(BaseMultiqcModule, BaseRecalibratorMixin, VariantEvalMixin):
         # Set up class objects to hold parsed data
         self.general_stats_headers = OrderedDict()
         self.general_stats_data = dict()
-        n = dict()
 
         # Call submodule functions
-        n['varianteval'] = self.parse_gatk_varianteval()
-        if n['varianteval'] > 0:
-            log.info("Found {} VariantEval reports".format(n['varianteval']))
+        n_reports_found = 0
+        n_reports_found += self.parse_gatk_base_recalibrator()
+        n_reports_found += self.parse_gatk_varianteval()
 
         # Exit if we didn't find anything
-        if sum(n.values()) == 0:
+        if n_reports_found == 0:
             log.debug("Could not find any reports in {}".format(config.analysis_dir))
             raise UserWarning
 
@@ -86,8 +85,8 @@ class MultiqcModule(BaseMultiqcModule, BaseRecalibratorMixin, VariantEvalMixin):
         return data
 
     def parse_gatk_report_table(self, f):
-        data = defaultdict(list)
         headers = f.readline().rstrip().split()
+        data = OrderedDict([(h, []) for h in headers])
         while True:
             line = f.readline()
             line = line.rstrip()

--- a/multiqc/modules/gatk/varianteval.py
+++ b/multiqc/modules/gatk/varianteval.py
@@ -27,7 +27,9 @@ class VariantEvalMixin():
         # Filter to strip out ignored sample names
         self.gatk_varianteval = self.ignore_samples(self.gatk_varianteval)
 
-        if len(self.gatk_varianteval) > 0:
+        n_reports_found = len(self.gatk_varianteval)
+        if n_reports_found > 0:
+            log.info("Found {} VariantEval reports".format(n_reports_found))
 
             # Write parsed report data to a file (restructure first)
             self.write_data_file(self.gatk_varianteval, 'multiqc_gatk_varianteval')
@@ -73,9 +75,7 @@ class VariantEvalMixin():
                 plot = comp_overlap_table(self.gatk_varianteval)
             )
 
-
-        # Return the number of logs that were found
-        return len(self.gatk_varianteval)
+        return n_reports_found
 
 
 def parse_single_report(f):

--- a/multiqc/modules/gatk/varianteval.py
+++ b/multiqc/modules/gatk/varianteval.py
@@ -80,6 +80,7 @@ class VariantEvalMixin():
 
 def parse_single_report(f):
     """ Parse a gatk varianteval varianteval """
+    # Fixme: Separate GATKReport parsing and data subsetting. A GATKReport parser now available from the GATK MultiqcModel.
 
     data = dict()
     in_CompOverlap = False

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -71,6 +71,9 @@ flexbar:
 gatk/varianteval:
     contents: '#:GATKTable:TiTvVariantEvaluator'
     shared: true
+gatk/base_recalibrator:
+    contents: '#:GATKTable:Arguments:Recalibration argument collection values used in this run'
+    num_lines: 3
 goleft_indexcov/roc:
     fn: '*-indexcov.roc'
 goleft_indexcov/ped:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -72,7 +72,7 @@ gatk/varianteval:
     contents: '#:GATKTable:TiTvVariantEvaluator'
     shared: true
 gatk/base_recalibrator:
-    contents: '#:GATKTable:Arguments:Recalibration argument collection values used in this run'
+    contents: '#:GATKTable:Arguments:Recalibration'
     num_lines: 3
 goleft_indexcov/roc:
     fn: '*-indexcov.roc'

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'simplejson',
         'spectra',
         'networkx==1.*',
+        'enum34',
     ],
     entry_points = {
         'multiqc.modules.v1': [


### PR DESCRIPTION
This PR adds a mixin class for parsing GATK BaseRecalibrator recalibration tables.  

At this point there is only one plot that summarizes the observed quality scores, but more to follow.

This PR also moves the logging of the number of records found by each mixin class to the class itself so that verbose mode shows the origin of the log messages correctly. That is, this:
```
[2017-08-17 12:12:04,741] multiqc.modules.gatk.base_recalibrator             [INFO   ]  Found 1 BaseRecalibrator reports
[2017-08-17 12:12:04,759] multiqc.modules.gatk.varianteval                   [INFO   ]  Found 3 VariantEval reports
```

instead of this:

```
[2017-08-17 12:02:09,612] multiqc.modules.gatk.gatk                          [INFO   ]  Found 1 BaseRecalibrator reports
[2017-08-17 12:02:09,629] multiqc.modules.gatk.gatk                          [INFO   ]  Found 3 VariantEval reports
```


