### PR TITLE
Downgrade networkx dependency to v1.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'requests',
         'simplejson',
         'spectra',
+        'networkx==1.*',
     ],
     entry_points = {
         'multiqc.modules.v1': [


### PR DESCRIPTION
`spectra` depends on `colormath` which requires `networkx` but incompatible with with v2: https://github.com/gtaylor/python-colormath/issues/73, which makes MultiQC installation fail (e.g. https://travis-ci.org/MultiQC/MultiQC_bcbio/jobs/266483333). This PR fixes that by downgrading `networkx` to 1.*.

Not sure why Travis can't catch that. I've activated travis for my fork - it's expectedly fails: https://travis-ci.org/vladsaveliev/MultiQC/jobs/266568649. Maybe some caching happens. What do you think about removing the `-q` flag in https://github.com/ewels/MultiQC/blob/master/.travis.yml#L9 which will help to see which versions of which libraries are installed?