### PR TITLE
resolved bug in special case max_x=0

### DIFF
--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -225,7 +225,7 @@ def report_sections(self):
     if len(self.qualimap_bamqc_coverage_hist) > 0:
         # Chew back on histogram to prevent long flat tail
         # (find a sensible max x - lose 1% of longest tail)
-        max_x = 0
+        max_x = 1
         total_bases_by_sample = dict()
         for s_name, d in self.qualimap_bamqc_coverage_hist.items():
             total_bases_by_sample[s_name] = sum(d.values())

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -225,7 +225,7 @@ def report_sections(self):
     if len(self.qualimap_bamqc_coverage_hist) > 0:
         # Chew back on histogram to prevent long flat tail
         # (find a sensible max x - lose 1% of longest tail)
-        max_x = 1
+        max_x = 0
         total_bases_by_sample = dict()
         for s_name, d in self.qualimap_bamqc_coverage_hist.items():
             total_bases_by_sample[s_name] = sum(d.values())
@@ -240,7 +240,7 @@ def report_sections(self):
         for s_name, hist in self.qualimap_bamqc_coverage_hist.items():
             total = total_bases_by_sample[s_name]
             # Make a range of depths that isn't stupidly huge for high coverage expts
-            depth_range = list(range(0, max_x + 1, math.ceil(float(max_x)/400.0)))
+            depth_range = list(range(0, max_x + 1, math.ceil(float(max_x)/400.0) if max_x > 0 else 1))
             # Check that we have our specified coverages in the list
             for c in self.covs:
                 if int(c) not in depth_range:


### PR DESCRIPTION
if `max_x=0` then this expression breaks:
```  depth_range = list(range(0, max_x + 1, math.ceil(float(max_x)/400.0)))```

because the step need to be greater than 0 (`math.ceil(float(max_x)/400.0)` evaluates to 0). 
This happens if the most occurring coverage is 0, that might happen if you align capture data against the whole genome.