### PR TITLE
Safer networkx version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'requests',
         'simplejson',
         'spectra',
-        'networkx==1.*',
+        'networkx<2',
     ],
     entry_points = {
         'multiqc.modules.v1': [


### PR DESCRIPTION
Let's make it `<2` to avoid installation errors with old setuptools. Anyways we don't care about older versions for other packages, so why worry here. But just to make sure, I tests against networkx<1 and it works smoothly.