### PR TITLE
Simplify the `general_stats_addcols` example

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -377,7 +377,7 @@ data = {
         'second_col': '66.3%'
     }
 }
-self.general_stats_addcols(data, headers)
+self.general_stats_addcols(data)
 ```
 
 To give more informative table headers and configure things like


### PR DESCRIPTION
Drops passing the `header` argument since it is not defined or discussed up to this point in the documentation (it is coming in the following section). The example here works fine without specifying the header explicitly.