### PR TITLE
Fix typos in the documentation

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -258,7 +258,7 @@ What most MultiQC modules do once they have found matching analysis files
 is to pass the matched file contents to another function, responsible
 for parsing the data from the file. How this parsing is done will depend
 on the format of the log file and the type of data being read. See below
-for a basic example, based loosly on the preseq module:
+for a basic example, based loosely on the preseq module:
 
 ```python
 class MultiqcModule(BaseMultiqcModule):
@@ -414,7 +414,7 @@ headers['name'] = {
     'shared_key': None              # See below for description
     'modify': None,                 # Lambda function to modify values
     'hidden': False,                # Set to True to hide the column on page load
-    'placement' : 1000.0,           # Alter the default ordering of coumns in the table
+    'placement' : 1000.0,           # Alter the default ordering of columns in the table
 }
 ```
 * `namespace`

--- a/docs/modules/jellyfish.md
+++ b/docs/modules/jellyfish.md
@@ -12,7 +12,7 @@ The MultiQC module for Jellyfish parses *only* `*_jf.hist` files. The general us
  - `gunzip -c file.fastq.gz | jellyfish count -o file.jf  -m ...`
  - `jellyfish histo -o file_jf.hist -f file.jf`
 
-In case a user wants to customise the mathcing pattern for jellyfish, then multiqc can be run with option `--cl_config "sp: { jellyfish: { fn: 'PATTERN' } }"` where `PATTERN` is the patern to be matched. For example:
+In case a user wants to customise the matching pattern for jellyfish, then multiqc can be run with the option `--cl_config "sp: { jellyfish: { fn: 'PATTERN' } }"` where `PATTERN` is the pattern to be matched. For example:
 
 ```
 multiqc . --cl_config "sp: { jellyfish: { fn: '*.hist' } }"

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -346,7 +346,7 @@ key should match the keys used in the data dictionary, but values can
 customise the output. If you want to specify the order of the columns, you
 must use an `OrderedDict`.
 
-Finally, a the function accepts a third parameter, a config dictionary.
+Finally, the function accepts a config dictionary as a third parameter.
 This can set global options for the table (eg. a title) and can also hold
 default values to customise the output of all table columns.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,13 +25,19 @@ section of the docs explains this in more detail.
 
 ### Big log files
 
-Another reason that log files can be skipped is if the log filesize is very large. For example, this could happen with very long concatenated standard out files. By default, MultiQC skips any file that is larger than 10MB to keep execution fast. The verbose log output (`-v` or `multiqc_data/multiqc.log`) will show you if files are being skipped with messages such as these:
+Another reason that log files can be skipped is if the log filesize is very
+large. For example, this could happen with very long concatenated standard out
+files. By default, MultiQC skips any file that is larger than 10MB to keep
+execution fast. The verbose log output (`-v` or `multiqc_data/multiqc.log`) will
+show you if files are being skipped with messages such as these:
 
 ```
 [DEBUG  ]  Ignoring file as too large: filename.txt
 ```
 
-You can configure the threshold and parse your files by changing the `log_filesize_limit` config option. For example, to parse files up to 2GB in size, add the following to your MultiQC config file:
+You can configure the threshold and parse your files by changing the
+`log_filesize_limit` config option. For example, to parse files up to 2GB in
+size, add the following to your MultiQC config file:
 
 ```yaml
 log_filesize_limit: 2000000000


### PR DESCRIPTION
Fixes a few minor typos, along with a bit of rephrasing and reformatting.