### PR TITLE
Add a deepTools module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ string beginning with the name of your module, anything you like after the first
 * [**RSEM**](https://deweylab.github.io/RSEM/) - new module!
     * Parse .cnt file comming from rsem-calculate-expression and plot read repartitions (Unalignable, Unique, Multi ...)
     * Module written by [@noirot]
+* [**deepTools**](https://github.com/fidelram/deepTools) - new module!
+    * Parse text output from `bamPEFragmentSize`, `estimateReadFiltering`, `plotCoverage`, `plotEnrichment`, and `plotFingerprint`
+    * Module written by [@dpryan79]
 
 #### Module updates:
 * **AfterQC**

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ MultiQC Modules:
     BUSCO: modules/busco.md
     Conpair: modules/conpair.md
     Disambiguate: modules/disambiguate.md
+    deepTools: modules/deeptools.md
     featureCounts: modules/featureCounts.md
     GATK: modules/gatk.md
     goleft_indexcov: modules/goleft_indexcov.md

--- a/docs/modules/deeptools.md
+++ b/docs/modules/deeptools.md
@@ -7,4 +7,14 @@ Description: >
 
 deepTools addresses the challenge of handling the large amounts of data that are now routinely generated from DNA sequencing centers. deepTools contains useful modules to process the mapped reads data for multiple quality checks, creating **normalized coverage files** in standard bedGraph and bigWig file formats, that allow comparison between different files (for example, treatment and control). Finally, using such normalized and standardized files, deepTools can create many publication-ready **visualizations** to identify enrichments and for functional annotations of the genome.
 
-The MultiQC module for deepTools parses a number of the text files that deepTools can produce.
+The MultiQC module for deepTools parses a number of the text files that deepTools can produce. In particular, the following are supported:
+
+ - `bamPEFragmentSize --table`
+ - `estimateReadFiltering`
+ - `plotCoverage ---outRawCounts` (as well as the content written normally to the console)
+ - `plotEnrichment --outRawCounts`
+ - `plotFingerprint --outQualityMetrics --outRawCounts`
+
+Please be aware that some tools (namely, `plotFingerprint --outRawCounts`) are only supported as of deepTools version 2.6. Also for this type of file, you may need to increase the maximum file size supported by MultiQC (`log_filesize_limit` in the MultiQC configuration file). You can find details regarding the configuration file location [here](http://multiqc.info/docs/#configuring-multiqc).
+
+Note that sample names are parsed from the text files themselves, they are not derived from file names.

--- a/docs/modules/deeptools.md
+++ b/docs/modules/deeptools.md
@@ -1,0 +1,10 @@
+---
+Name: deepTools
+URL: http://deeptools.readthedocs.io
+Description: >
+    Tools to process and analyze deep sequencing data.
+---
+
+deepTools addresses the challenge of handling the large amounts of data that are now routinely generated from DNA sequencing centers. deepTools contains useful modules to process the mapped reads data for multiple quality checks, creating **normalized coverage files** in standard bedGraph and bigWig file formats, that allow comparison between different files (for example, treatment and control). Finally, using such normalized and standardized files, deepTools can create many publication-ready **visualizations** to identify enrichments and for functional annotations of the genome.
+
+The MultiQC module for deepTools parses a number of the text files that deepTools can produce.

--- a/docs/modules/deeptools.md
+++ b/docs/modules/deeptools.md
@@ -15,6 +15,6 @@ The MultiQC module for deepTools parses a number of the text files that deepTool
  - `plotEnrichment --outRawCounts`
  - `plotFingerprint --outQualityMetrics --outRawCounts`
 
-Please be aware that some tools (namely, `plotFingerprint --outRawCounts`) are only supported as of deepTools version 2.6. Also for this type of file, you may need to increase the maximum file size supported by MultiQC (`log_filesize_limit` in the MultiQC configuration file). You can find details regarding the configuration file location [here](http://multiqc.info/docs/#configuring-multiqc).
+Please be aware that some tools (namely, `plotFingerprint --outRawCounts` and `plotCoverage --outRawCounts`) are only supported as of deepTools version 2.6. For earlier output from `plotCoverage --outRawCounts`, you can use `#'chr'	'start'	'end'	` in `utils/search_patterns.yaml` (see [here](http://multiqc.info/docs/#module-search-patterns) for more details). Also for these types of files, you may need to increase the maximum file size supported by MultiQC (`log_filesize_limit` in the MultiQC configuration file). You can find details regarding the configuration file location [here](http://multiqc.info/docs/#configuring-multiqc).
 
 Note that sample names are parsed from the text files themselves, they are not derived from file names.

--- a/multiqc/modules/deeptools/__init__.py
+++ b/multiqc/modules/deeptools/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .deeptools import MultiqcModule

--- a/multiqc/modules/deeptools/bamPEFragmentSize.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSize.py
@@ -17,7 +17,7 @@ class bamPEFragmentSizeMixin():
         """Find bamPEFragmentSize output. Only the output from --table is supported."""
         self.deeptools_bamPEFragmentSize = dict()
         for f in self.find_log_files('deeptools/bamPEFragmentSize'):
-            parsed_data = self.parseBamPEFile(f['f'], f['fn'])
+            parsed_data = self.parseBamPEFile(f)
             for k, v in parsed_data.items():
                 if k in self.deeptools_bamPEFragmentSize:
                     log.warning("Replacing duplicate sample {}.".format(k))
@@ -28,146 +28,111 @@ class bamPEFragmentSizeMixin():
         if len(self.deeptools_bamPEFragmentSize) > 0:
             headersSE = OrderedDict()
             headersSE["Reads Sampled"] = {'title': 'Reads Sampled'}
-            headersSE["Read Length Minimum"] = {'title': 'Read Len. Min.', 'description': 'Minimum read length'}
-            headersSE["Read Length 1st Quartile"] = {'title': 'Read Len. 1st Qu.', 'description': '1st quartile read length'}
-            headersSE["Read Length Mean"] = {'title': 'Read Len. Mean', 'description': 'Mean read length'}
-            headersSE["Read Length Median"] = {'title': 'Read Len. Median', 'description': 'Median read length'}
-            headersSE["Read Length 3rd Quartile"] = {'title': 'Read Len. 3rd Qu.', 'description': '3rd quartile read length'}
-            headersSE["Read Length Maximum"] = {'title': 'Read Len. Max.', 'description': 'Maximum read length'}
-            headersSE["Read Length Std. Dev."] = {'title': 'Read Len. Std. Dev.', 'description': 'read length standard deviation'}
-            headersSE["Read Length Med. Abs. Dev."] = {'title': 'Read Len. MAD', 'description': 'read length median absolute deviation'}
-            self.add_section(name="bamPEFragmentSize (read length metrics)",
+            headersSE["Read Len. Min."] = {'title': 'Read Len. Min.', 'description': 'Minimum read length'}
+            headersSE["Read Len. 1st. Qu."] = {'title': 'Read Len. 1st Qu.', 'description': '1st quartile read length'}
+            headersSE["Read Len. Mean"] = {'title': 'Read Len. Mean', 'description': 'Mean read length'}
+            headersSE["Read Len. Median"] = {'title': 'Read Len. Median', 'description': 'Median read length'}
+            headersSE["Read Len. 3rd Qu."] = {'title': 'Read Len. 3rd Qu.', 'description': '3rd quartile read length'}
+            headersSE["Read Len. Max"] = {'title': 'Read Len. Max.', 'description': 'Maximum read length'}
+            headersSE["Read Len. Std."] = {'title': 'Read Len. Std. Dev.', 'description': 'read length standard deviation'}
+            headersSE["Read Med. Abs. Dev."] = {'title': 'Read Len. MAD', 'description': 'read length median absolute deviation'}
+            config = {'namespace': 'deepTools bamPEFragmentSize'}
+            self.add_section(name="Read lengths",
                              anchor="bamPEFragmentSize",
-                             plot=table.plot(self.deeptools_bamPEFragmentSize, headersSE))
+                             plot=table.plot(self.deeptools_bamPEFragmentSize, headersSE, config))
 
             headersPE = OrderedDict()
-            headersPE["Fragments Sampled"] = {'title': 'Fragments Sampled'}
-            headersPE["Fragment Length Minimum"] = {'title': 'Fragment Len. Min.', 'description': 'Minimum read length'}
-            headersPE["Fragment Length 1st Quartile"] = {'title': 'Fragment Len. 1st Qu.', 'description': '1st quartile read length'}
-            headersPE["Fragment Length Mean"] = {'title': 'Fragment Len. Mean', 'description': 'Mean read length'}
-            headersPE["Fragment Length Median"] = {'title': 'Fragment Len. Median', 'description': 'Median read length'}
-            headersPE["Fragment Length 3rd Quartile"] = {'title': 'Fragment Len. 3rd Qu.', 'description': '3rd quartile read length'}
-            headersPE["Fragment Length Maximum"] = {'title': 'Fragment Len. Max.', 'description': 'Maximum read length'}
-            headersPE["Fragment Length Std. Dev."] = {'title': 'Fragment Len. Std. Dev.', 'description': 'read length standard deviation'}
-            headersPE["Fragment Length Med. Abs. Dev."] = {'title': 'Fragment Len. MAD', 'description': 'read length median absolute deviation'}
+            headersPE["Frag. Sampled"] = {'title': 'Fragments Sampled'}
+            headersPE["Frag. Len. Min."] = {'title': 'Fragment Len. Min.', 'description': 'Minimum fragment length'}
+            headersPE["Frag. Len. 1st. Qu."] = {'title': 'Fragment Len. 1st Qu.', 'description': '1st quartile fragment length'}
+            headersPE["Frag. Len. Mean"] = {'title': 'Fragment Len. Mean', 'description': 'Mean fragment length'}
+            headersPE["Frag. Len. Median"] = {'title': 'Fragment Len. Median', 'description': 'Median fragment length'}
+            headersPE["Frag. Len. 3rd Qu."] = {'title': 'Fragment Len. 3rd Qu.', 'description': '3rd quartile fragment length'}
+            headersPE["Frag. Len. Max"] = {'title': 'Fragment Len. Max.', 'description': 'Maximum fragment length'}
+            headersPE["Frag. Len. Std."] = {'title': 'Fragment Len. Std. Dev.', 'description': 'Fragment length standard deviation'}
+            headersPE["Frag. Med. Abs. Dev."] = {'title': 'Fragment Len. MAD', 'description': 'Fragment length median absolute deviation'}
 
             # Are there any PE datasets?
             PE = False
             for k, v in self.deeptools_bamPEFragmentSize.items():
-                if 'Fragment Length Minimum' in v:
+                if 'Frag. Len. Min.' in v:
                     PE = True
                     break
             if PE:
-                self.add_section(name="bamPEFragmentSize (fragment length metrics)",
+                self.add_section(name="Fragment lengths",
                                  anchor="bamPEFragmentSize",
-                                 plot=table.plot(self.deeptools_bamPEFragmentSize, headersPE))
+                                 plot=table.plot(self.deeptools_bamPEFragmentSize, headersPE, config))
 
             # Read length plot
             config = {'data_labels': [dict(name="Read length distribution", title="Read length distribution", ylab="Read length (bases)"),
                                       dict(name="Fragment length distribution", title="Fragment length distribution", ylab="Fragment length (bases)")],
+                      'id': 'bamPEFragmentSize',
+                      'title': 'Read/Fragment length distribution',
+                      'namespace': 'deepTools bamPEFragmentSize',
                       'ylab': "Read length (bases)",
                       'xlab': "Percentile"}
             SE = dict()
             PE = dict()
             for k, v in self.deeptools_bamPEFragmentSize.items():
-                SE[k] = {0: v['Read Length Minimum'],
-                         10: v['R10'],
-                         20: v['R20'],
-                         25: v['Read Length 1st Quartile'],
-                         30: v['R30'],
-                         40: v['R40'],
-                         50: v['Read Length Median'],
-                         60: v['R60'],
-                         70: v['R70'],
-                         75: v['Read Length 3rd Quartile'],
-                         80: v['R80'],
-                         90: v['R90'],
-                         99: v['R99'],
-                         100: v['Read Length Maximum']}
-                if 'Fragment Length Minimum' not in v:
+                SE[k] = {0: v['Read Len. Min.'],
+                         10: v['Read Len. 10%'],
+                         20: v['Read Len. 20%'],
+                         25: v['Read Len. 1st. Qu.'],
+                         30: v['Read Len. 30%'],
+                         40: v['Read Len. 40%'],
+                         50: v['Read Len. Median'],
+                         60: v['Read Len. 60%'],
+                         70: v['Read Len. 70%'],
+                         75: v['Read Len. 3rd Qu.'],
+                         80: v['Read Len. 80%'],
+                         90: v['Read Len. 90%'],
+                         99: v['Read Len. 99%'],
+                         100: v['Read Len. Max']}
+                if 'Frag. Len. Min.' not in v:
                     continue
-                PE[k] = {0: v['Fragment Length Minimum'],
-                         10: v['F10'],
-                         20: v['F20'],
-                         25: v['Fragment Length 1st Quartile'],
-                         30: v['F30'],
-                         40: v['F40'],
-                         50: v['Fragment Length Median'],
-                         60: v['F60'],
-                         70: v['F70'],
-                         75: v['Fragment Length 3rd Quartile'],
-                         80: v['F80'],
-                         90: v['F90'],
-                         99: v['F99'],
-                         100: v['Fragment Length Maximum']}
-            self.add_section(name="bamPEFragmentSize (read/fragment length distribution)",
+                PE[k] = {0: v['Frag. Len. Min.'],
+                         10: v['Frag. Len. 10%'],
+                         20: v['Frag. Len. 20%'],
+                         25: v['Frag. Len. 1st. Qu.'],
+                         30: v['Frag. Len. 30%'],
+                         40: v['Frag. Len. 40%'],
+                         50: v['Frag. Len. Median'],
+                         60: v['Frag. Len. 60%'],
+                         70: v['Frag. Len. 70%'],
+                         75: v['Frag. Len. 3rd Qu.'],
+                         80: v['Frag. Len. 80%'],
+                         90: v['Frag. Len. 90%'],
+                         99: v['Frag. Len. 99%'],
+                         100: v['Frag. Len. Max']}
+            self.add_section(name="Read/fragment length distribution",
                              anchor="bamPEFragmentSize",
                              plot=linegraph.plot([SE, PE], config))
 
         return len(self.deeptools_bamPEFragmentSize)
 
-    def parseBamPEFile(self, f, fname):
+    def parseBamPEFile(self, f):
         d = {}
-        firstLine = True
-        for line in f.splitlines():
-            if firstLine:
-                firstLine = False
-                continue
-            cols = line.strip().split("\t")
+        headers = None
+        for line in f['f'].splitlines():
+            cols = line.rstrip().split("\t")
+            if headers is None:
+                headers = cols
+            else:
+                s_name = None
+                for idx, h in enumerate(headers):
+                    if idx == 0:
+                        s_name = self.clean_s_name(cols[0], f['root'])
+                        if s_name in d:
+                            log.debug("Replacing duplicate sample {}.".format(s_name))
+                        d[s_name] = OrderedDict()
+                    else:
+                        if idx < 19 and cols[1] == "0":
+                            # Don't store fragment metrics for SE datasets, they're just 0.
+                            continue
+                        try:
+                            # Most values are ac
+                            d[s_name][h] = int(cols[idx])
+                        except ValueError:
+                            d[s_name][h] = float(cols[idx])
 
-            if len(cols) != 37:
-                # This is not really the output from bamPEFragmentSize!
-                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(fname))
-                return dict()
-
-            if cols[0] in d:
-                log.warning("Replacing duplicate sample {}.".format(cols[0]))
-            d[cols[0]] = dict()
-
-            try:
-                d[cols[0]]["Reads Sampled"] = int(cols[19])
-                d[cols[0]]["Read Length Minimum"] = float(cols[20])
-                d[cols[0]]["Read Length 1st Quartile"] = float(cols[21])
-                d[cols[0]]["Read Length Mean"] = float(cols[22])
-                d[cols[0]]["Read Length Median"] = float(cols[23])
-                d[cols[0]]["Read Length 3rd Quartile"] = float(cols[24])
-                d[cols[0]]["Read Length Maximum"] = float(cols[25])
-                d[cols[0]]["Read Length Std. Dev."] = float(cols[26])
-                d[cols[0]]["Read Length Med. Abs. Dev."] = float(cols[27])
-
-                # Not in the table
-                d[cols[0]]["R10"] = float(cols[28])
-                d[cols[0]]["R20"] = float(cols[29])
-                d[cols[0]]["R30"] = float(cols[30])
-                d[cols[0]]["R40"] = float(cols[31])
-                d[cols[0]]["R60"] = float(cols[32])
-                d[cols[0]]["R70"] = float(cols[33])
-                d[cols[0]]["R80"] = float(cols[34])
-                d[cols[0]]["R90"] = float(cols[35])
-                d[cols[0]]["R99"] = float(cols[36])
-                if cols[1] != "0":
-                    d[cols[0]]["Fragments Sampled"] = int(cols[1])
-                    d[cols[0]]["Fragment Length Minimum"] = float(cols[2])
-                    d[cols[0]]["Fragment Length 1st Quartile"] = float(cols[3])
-                    d[cols[0]]["Fragment Length Mean"] = float(cols[4])
-                    d[cols[0]]["Fragment Length Median"] = float(cols[5])
-                    d[cols[0]]["Fragment Length 3rd Quartile"] = float(cols[6])
-                    d[cols[0]]["Fragment Length Maximum"] = float(cols[7])
-                    d[cols[0]]["Fragment Length Std. Dev."] = float(cols[8])
-                    d[cols[0]]["Fragment Length Med. Abs. Dev."] = float(cols[9])
-
-                    # Not in the table
-                    d[cols[0]]["F10"] = float(cols[10])
-                    d[cols[0]]["F20"] = float(cols[11])
-                    d[cols[0]]["F30"] = float(cols[12])
-                    d[cols[0]]["F40"] = float(cols[13])
-                    d[cols[0]]["F60"] = float(cols[14])
-                    d[cols[0]]["F70"] = float(cols[15])
-                    d[cols[0]]["F80"] = float(cols[16])
-                    d[cols[0]]["F90"] = float(cols[17])
-                    d[cols[0]]["F99"] = float(cols[18])
-            except:
-                # Obviously this isn't really the output from bamPEFragmentSize
-                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(fname))
-                return dict()
         return d

--- a/multiqc/modules/deeptools/bamPEFragmentSize.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSize.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from deepTools bamPEFragmentSize """
+
+import logging
+import re
+from collections import OrderedDict
+
+from multiqc import config
+from multiqc.plots import table, linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class bamPEFragmentSizeMixin():
+    def parse_bamPEFragmentSize(self):
+        """Find bamPEFragmentSize output. Only the output from --table is supported."""
+        self.deeptools_bamPEFragmentSize = dict()
+        for f in self.find_log_files('deeptools/bamPEFragmentSize'):
+            parsed_data = self.parseFile(f['f'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_bamPEFragmentSize:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_bamPEFragmentSize[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='bamPEFragmentSize')
+        if len(self.deeptools_bamPEFragmentSize) > 0:
+            headersSE = OrderedDict()
+            headersSE["Reads Sampled"] = {'title': 'Reads Sampled'}
+            headersSE["Read Length Minimum"] = {'title': 'Read Len. Min.', 'description': 'Minimum read length'}
+            headersSE["Read Length 1st Quartile"] = {'title': 'Read Len. 1st Qu.', 'description': '1st quartile read length'}
+            headersSE["Read Length Mean"] = {'title': 'Read Len. Mean', 'description': 'Mean read length'}
+            headersSE["Read Length Median"] = {'title': 'Read Len. Median', 'description': 'Median read length'}
+            headersSE["Read Length 3rd Quartile"] = {'title': 'Read Len. 3rd Qu.', 'description': '3rd quartile read length'}
+            headersSE["Read Length Maximum"] = {'title': 'Read Len. Max.', 'description': 'Maximum read length'}
+            headersSE["Read Length Std. Dev."] = {'title': 'Read Len. Std. Dev.', 'description': 'read length standard deviation'}
+            headersSE["Read Length Med. Abs. Dev."] = {'title': 'Read Len. MAD', 'description': 'read length median absolute deviation'}
+            self.add_section(name="bamPEFragmentSize (read length metrics)",
+                             anchor="bamPEFragmentSize",
+                             plot=table.plot(self.deeptools_bamPEFragmentSize, headersSE))
+
+            headersPE = OrderedDict()
+            headersPE["Fragments Sampled"] = {'title': 'Fragments Sampled'}
+            headersPE["Fragment Length Minimum"] = {'title': 'Fragment Len. Min.', 'description': 'Minimum read length'}
+            headersPE["Fragment Length 1st Quartile"] = {'title': 'Fragment Len. 1st Qu.', 'description': '1st quartile read length'}
+            headersPE["Fragment Length Mean"] = {'title': 'Fragment Len. Mean', 'description': 'Mean read length'}
+            headersPE["Fragment Length Median"] = {'title': 'Fragment Len. Median', 'description': 'Median read length'}
+            headersPE["Fragment Length 3rd Quartile"] = {'title': 'Fragment Len. 3rd Qu.', 'description': '3rd quartile read length'}
+            headersPE["Fragment Length Maximum"] = {'title': 'Fragment Len. Max.', 'description': 'Maximum read length'}
+            headersPE["Fragment Length Std. Dev."] = {'title': 'Fragment Len. Std. Dev.', 'description': 'read length standard deviation'}
+            headersPE["Fragment Length Med. Abs. Dev."] = {'title': 'Fragment Len. MAD', 'description': 'read length median absolute deviation'}
+
+            # Are there any PE datasets?
+            PE = False
+            for k, v in self.deeptools_bamPEFragmentSize.items():
+                if 'Fragment Length Minimum' in v:
+                    PE = True
+                    break
+            if PE:
+                self.add_section(name="bamPEFragmentSize (fragment length metrics)",
+                                 anchor="bamPEFragmentSize",
+                                 plot=table.plot(self.deeptools_bamPEFragmentSize, headersPE))
+
+            # Read length plot
+            config = {'data_labels': [dict(name="Read length distribution", title="Read length distribution", ylab="Read length (bases)"),
+                                      dict(name="Fragment length distribution", title="Fragment length distribution", ylab="Fragment length (bases)")],
+                      'ylab': "Read length (bases)",
+                      'xlab': "Percentile"}
+            SE = dict()
+            PE = dict()
+            for k, v in self.deeptools_bamPEFragmentSize.items():
+                SE[k] = {0: v['Read Length Minimum'],
+                         10: v['R10'],
+                         20: v['R20'],
+                         25: v['Read Length 1st Quartile'],
+                         30: v['R30'],
+                         40: v['R40'],
+                         50: v['Read Length Median'],
+                         60: v['R60'],
+                         70: v['R70'],
+                         75: v['Read Length 3rd Quartile'],
+                         80: v['R80'],
+                         90: v['R90'],
+                         99: v['R99'],
+                         100: v['Read Length Maximum']}
+                if 'Fragment Length Minimum' not in v:
+                    continue
+                PE[k] = {0: v['Fragment Length Minimum'],
+                         10: v['F10'],
+                         20: v['F20'],
+                         25: v['Fragment Length 1st Quartile'],
+                         30: v['F30'],
+                         40: v['F40'],
+                         50: v['Fragment Length Median'],
+                         60: v['F60'],
+                         70: v['F70'],
+                         75: v['Fragment Length 3rd Quartile'],
+                         80: v['F80'],
+                         90: v['F90'],
+                         99: v['F99'],
+                         100: v['Fragment Length Maximum']}
+            self.add_section(name="bamPEFragmentSize (read/fragment length distribution)",
+                             anchor="bamPEFragmentSize",
+                             plot=linegraph.plot([SE, PE], config))
+
+        return len(self.deeptools_bamPEFragmentSize)
+
+    def parseFile(self, f):
+        d = {}
+        firstLine = True
+        for line in f.splitlines():
+            if firstLine:
+                firstLine = False
+                continue
+            cols = line.strip().split("\t")
+
+            if len(cols) != 37:
+                # This is not really the output from bamPEFragmentSize!
+                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(f.name))
+                return dict()
+
+            if cols[0] in d:
+                log.warning("Replacing duplicate sample {}.".format(cols[0]))
+            d[cols[0]] = dict()
+
+            try:
+                d[cols[0]]["Reads Sampled"] = int(cols[19])
+                d[cols[0]]["Read Length Minimum"] = float(cols[20])
+                d[cols[0]]["Read Length 1st Quartile"] = float(cols[21])
+                d[cols[0]]["Read Length Mean"] = float(cols[22])
+                d[cols[0]]["Read Length Median"] = float(cols[23])
+                d[cols[0]]["Read Length 3rd Quartile"] = float(cols[24])
+                d[cols[0]]["Read Length Maximum"] = float(cols[25])
+                d[cols[0]]["Read Length Std. Dev."] = float(cols[26])
+                d[cols[0]]["Read Length Med. Abs. Dev."] = float(cols[27])
+
+                # Not in the table
+                d[cols[0]]["R10"] = float(cols[28])
+                d[cols[0]]["R20"] = float(cols[29])
+                d[cols[0]]["R30"] = float(cols[30])
+                d[cols[0]]["R40"] = float(cols[31])
+                d[cols[0]]["R60"] = float(cols[32])
+                d[cols[0]]["R70"] = float(cols[33])
+                d[cols[0]]["R80"] = float(cols[34])
+                d[cols[0]]["R90"] = float(cols[35])
+                d[cols[0]]["R99"] = float(cols[36])
+                if cols[1] != "0":
+                    d[cols[0]]["Fragments Sampled"] = int(cols[1])
+                    d[cols[0]]["Fragment Length Minimum"] = float(cols[2])
+                    d[cols[0]]["Fragment Length 1st Quartile"] = float(cols[3])
+                    d[cols[0]]["Fragment Length Mean"] = float(cols[4])
+                    d[cols[0]]["Fragment Length Median"] = float(cols[5])
+                    d[cols[0]]["Fragment Length 3rd Quartile"] = float(cols[6])
+                    d[cols[0]]["Fragment Length Maximum"] = float(cols[7])
+                    d[cols[0]]["Fragment Length Std. Dev."] = float(cols[8])
+                    d[cols[0]]["Fragment Length Med. Abs. Dev."] = float(cols[9])
+
+                    # Not in the table
+                    d[cols[0]]["F10"] = float(cols[10])
+                    d[cols[0]]["F20"] = float(cols[11])
+                    d[cols[0]]["F30"] = float(cols[12])
+                    d[cols[0]]["F40"] = float(cols[13])
+                    d[cols[0]]["F60"] = float(cols[14])
+                    d[cols[0]]["F70"] = float(cols[15])
+                    d[cols[0]]["F80"] = float(cols[16])
+                    d[cols[0]]["F90"] = float(cols[17])
+                    d[cols[0]]["F99"] = float(cols[18])
+            except:
+                # Obviously this isn't really the output from bamPEFragmentSize
+                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(f.name))
+                return dict()
+        return d

--- a/multiqc/modules/deeptools/bamPEFragmentSize.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSize.py
@@ -17,7 +17,7 @@ class bamPEFragmentSizeMixin():
         """Find bamPEFragmentSize output. Only the output from --table is supported."""
         self.deeptools_bamPEFragmentSize = dict()
         for f in self.find_log_files('deeptools/bamPEFragmentSize'):
-            parsed_data = self.parseFile(f['f'])
+            parsed_data = self.parseBamPEFile(f['f'], f['fn'])
             for k, v in parsed_data.items():
                 if k in self.deeptools_bamPEFragmentSize:
                     log.warning("Replacing duplicate sample {}.".format(k))
@@ -106,7 +106,7 @@ class bamPEFragmentSizeMixin():
 
         return len(self.deeptools_bamPEFragmentSize)
 
-    def parseFile(self, f):
+    def parseBamPEFile(self, f, fname):
         d = {}
         firstLine = True
         for line in f.splitlines():
@@ -117,7 +117,7 @@ class bamPEFragmentSizeMixin():
 
             if len(cols) != 37:
                 # This is not really the output from bamPEFragmentSize!
-                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(f.name))
+                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(fname))
                 return dict()
 
             if cols[0] in d:
@@ -168,6 +168,6 @@ class bamPEFragmentSizeMixin():
                     d[cols[0]]["F99"] = float(cols[18])
             except:
                 # Obviously this isn't really the output from bamPEFragmentSize
-                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(f.name))
+                log.warning("{} was initially flagged as the tabular output from bamPEFragmentSize, but that seems to not be the case. Skipping...".format(fname))
                 return dict()
         return d

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -32,14 +32,14 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
         # bamPEFragmentSize
         n['bamPEFragmentSize'] = self.parse_bamPEFragmentSize()
         if n['bamPEFragmentSize'] > 0:
-            log.info("Found {} deepTools 'bamPEFragmentSize --table' samples".format(n['bamPEFragmentSize']))
+            log.debug("Found {} deepTools 'bamPEFragmentSize --table' samples".format(n['bamPEFragmentSize']))
         else:
             log.debug("Could not find any 'bamPEFragmentSize --table' outputs in {}".format(config.analysis_dir))
 
         # estimateReadFiltering
         n['estimateReadFiltering'] = self.parse_estimateReadFiltering()
         if n['estimateReadFiltering'] > 0:
-            log.info("Found {} deepTools estimateReadFiltering samples".format(n['estimateReadFiltering']))
+            log.debug("Found {} deepTools estimateReadFiltering samples".format(n['estimateReadFiltering']))
         else:
             log.debug("Could not find any estimateReadFiltering outputs in {}".format(config.analysis_dir))
 
@@ -49,14 +49,14 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
             extra = ''
             if n['plotCoverageOutRawCounts'] == 0:
                 extra = ' (you may need to increase the maximum log file size to find plotCoverage --outRawCounts files)'
-            log.info("Found {} and {} deepTools plotCoverage standard output and --outRawCounts samples, respectively{}".format(n['plotCoverageStdout'], n['plotCoverageOutRawCounts'], extra))
+            log.debug("Found {} and {} deepTools plotCoverage standard output and --outRawCounts samples, respectively{}".format(n['plotCoverageStdout'], n['plotCoverageOutRawCounts'], extra))
         else:
             log.debug("Could not find any plotCoverage outputs in {} (you may need to increase the maximum log file size)".format(config.analysis_dir))
 
         # plotEnrichment
         n['plotEnrichment'] = self.parse_plotEnrichment()
         if n['plotEnrichment'] > 0:
-            log.info("Found {} deepTools plotEnrichment samples".format(n['plotEnrichment']))
+            log.debug("Found {} deepTools plotEnrichment samples".format(n['plotEnrichment']))
         else:
             log.debug("Could not find any plotEnrichment outputs in {}".format(config.analysis_dir))
 
@@ -66,6 +66,12 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
             extra = ''
             if n['plotFingerprintOutRawCounts'] == 0:
                 extra = ' (you may need to increase the maximum log file size to find plotFingerprint --outRawCounts files)'
-            log.info("Found {} and {} deepTools plotFingerprint --outQualityMetrics and --outRawCounts samples, respectively{}".format(n['plotFingerprintOutQualityMetrics'], n['plotFingerprintOutRawCounts'], extra))
+            log.debug("Found {} and {} deepTools plotFingerprint --outQualityMetrics and --outRawCounts samples, respectively{}".format(n['plotFingerprintOutQualityMetrics'], n['plotFingerprintOutRawCounts'], extra))
         else:
             log.debug("Could not find any plotFingerprint outputs in {} (you may need to increase the maximum log file size)".format(config.analysis_dir))
+
+        tot = sum(n.values())
+        if tot > 0:
+            log.info('Found {} total deepTools samples'.format(tot))
+        else:
+            log.debug('Could not find any deepTools samples in {}'.format(config.analysis_dir))

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -9,12 +9,13 @@ from multiqc.modules.base_module import BaseMultiqcModule
 # deepTools modules
 from .bamPEFragmentSize import bamPEFragmentSizeMixin
 from .estimateReadFiltering import estimateReadFilteringMixin
+from .plotCoverage import plotCoverageMixin
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
 
-class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin):
+class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin, plotCoverageMixin):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(name='deepTools', anchor='deepTools', target='deepTools',
@@ -26,16 +27,26 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
         self.general_stats_data = dict()
         n = dict()
 
-        # Parse the various output file types
         # bamPEFragmentSize
         n['bamPEFragmentSize'] = self.parse_bamPEFragmentSize()
         if n['bamPEFragmentSize'] > 0:
             log.info("Found {} deepTools 'bamPEFragmentSize --table' samples".format(n['bamPEFragmentSize']))
         else:
             log.debug("Could not find any 'bamPEFragmentSize --table' outputs in {}".format(config.analysis_dir))
+
         # estimateReadFiltering
         n['estimateReadFiltering'] = self.parse_estimateReadFiltering()
         if n['estimateReadFiltering'] > 0:
             log.info("Found {} deepTools estimateReadFiltering samples".format(n['estimateReadFiltering']))
         else:
             log.debug("Could not find any estmateReadFiltering outputs in {}".format(config.analysis_dir))
+
+        # plotCoverage
+        n['plotCoverageStdout'], n['plotCoverageOutRawCounts'] = self.parse_plotCoverage()
+        if n['plotCoverageStdout'] + n['plotCoverageOutRawCounts'] > 0:
+            extra = ''
+            if n['plotCoverageOutRawCounts'] == 0:
+                extra = ' (you may need to increase the maximum log file size to find plotCoverage --outRawCounts files)'
+            log.info("Found {} and {} deepTools plotCoverage standard output and --outRawCounts samples, respectively{}".format(n['plotCoverageStdout'], n['plotCoverageOutRawCounts'], extra))
+        else:
+            log.debug("Could not find any plotCoverage outputs in {} (you may need to increase the maximum log file size)".format(config.analysis_dir))

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -11,12 +11,13 @@ from .bamPEFragmentSize import bamPEFragmentSizeMixin
 from .estimateReadFiltering import estimateReadFilteringMixin
 from .plotCoverage import plotCoverageMixin
 from .plotEnrichment import plotEnrichmentMixin
+from .plotFingerprint import plotFingerprintMixin
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
 
-class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin, plotCoverageMixin, plotEnrichmentMixin):
+class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin, plotCoverageMixin, plotEnrichmentMixin, plotFingerprintMixin):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(name='deepTools', anchor='deepTools', target='deepTools',
@@ -58,3 +59,13 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
             log.info("Found {} deepTools plotEnrichment samples".format(n['plotEnrichment']))
         else:
             log.debug("Could not find any plotEnrichment outputs in {}".format(config.analysis_dir))
+
+        # plotFingerprint
+        n['plotFingerprintOutQualityMetrics'], n['plotFingerprintOutRawCounts'] = self.parse_plotFingerprint()
+        if n['plotFingerprintOutQualityMetrics'] + n['plotFingerprintOutRawCounts'] > 0:
+            extra = ''
+            if n['plotFingerprintOutRawCounts'] == 0:
+                extra = ' (you may need to increase the maximum log file size to find plotFingerprint --outRawCounts files)'
+            log.info("Found {} and {} deepTools plotFingerprint --outQualityMetrics and --outRawCounts samples, respectively{}".format(n['plotFingerprintOutQualityMetrics'], n['plotFingerprintOutRawCounts'], extra))
+        else:
+            log.debug("Could not find any plotFingerprint outputs in {} (you may need to increase the maximum log file size)".format(config.analysis_dir))

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -10,12 +10,13 @@ from multiqc.modules.base_module import BaseMultiqcModule
 from .bamPEFragmentSize import bamPEFragmentSizeMixin
 from .estimateReadFiltering import estimateReadFilteringMixin
 from .plotCoverage import plotCoverageMixin
+from .plotEnrichment import plotEnrichmentMixin
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
 
-class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin, plotCoverageMixin):
+class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin, plotCoverageMixin, plotEnrichmentMixin):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(name='deepTools', anchor='deepTools', target='deepTools',
@@ -39,7 +40,7 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
         if n['estimateReadFiltering'] > 0:
             log.info("Found {} deepTools estimateReadFiltering samples".format(n['estimateReadFiltering']))
         else:
-            log.debug("Could not find any estmateReadFiltering outputs in {}".format(config.analysis_dir))
+            log.debug("Could not find any estimateReadFiltering outputs in {}".format(config.analysis_dir))
 
         # plotCoverage
         n['plotCoverageStdout'], n['plotCoverageOutRawCounts'] = self.parse_plotCoverage()
@@ -50,3 +51,10 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilte
             log.info("Found {} and {} deepTools plotCoverage standard output and --outRawCounts samples, respectively{}".format(n['plotCoverageStdout'], n['plotCoverageOutRawCounts'], extra))
         else:
             log.debug("Could not find any plotCoverage outputs in {} (you may need to increase the maximum log file size)".format(config.analysis_dir))
+
+        # plotEnrichment
+        n['plotEnrichment'] = self.parse_plotEnrichment()
+        if n['plotEnrichment'] > 0:
+            log.info("Found {} deepTools plotEnrichment samples".format(n['plotEnrichment']))
+        else:
+            log.debug("Could not find any plotEnrichment outputs in {}".format(config.analysis_dir))

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -8,12 +8,13 @@ from multiqc.modules.base_module import BaseMultiqcModule
 
 # deepTools modules
 from .bamPEFragmentSize import bamPEFragmentSizeMixin
+from .estimateReadFiltering import estimateReadFilteringMixin
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
 
-class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin):
+class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin, estimateReadFilteringMixin):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(name='deepTools', anchor='deepTools', target='deepTools',
@@ -29,8 +30,12 @@ class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin):
         # bamPEFragmentSize
         n['bamPEFragmentSize'] = self.parse_bamPEFragmentSize()
         if n['bamPEFragmentSize'] > 0:
-            log.info("Found {} deepTools 'bamPEFragmentSize --table' outputs".format(n['bamPEFragmentSize']))
-        # computeGCBias
-        #n['computeGCBias'] = self.parse_computeGCBias()
-        #if n['computGCBias'] > 0:
-        #    log.info("Found {} deepTools computeGCBias outputs".format(n['computeGCBias']))
+            log.info("Found {} deepTools 'bamPEFragmentSize --table' samples".format(n['bamPEFragmentSize']))
+        else:
+            log.debug("Could not find any 'bamPEFragmentSize --table' outputs in {}".format(config.analysis_dir))
+        # estimateReadFiltering
+        n['estimateReadFiltering'] = self.parse_estimateReadFiltering()
+        if n['estimateReadFiltering'] > 0:
+            log.info("Found {} deepTools estimateReadFiltering samples".format(n['estimateReadFiltering']))
+        else:
+            log.debug("Could not find any estmateReadFiltering outputs in {}".format(config.analysis_dir))

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""MultiQC module to parse the output from deepTools"""
+from collections import OrderedDict
+import logging
+
+from multiqc import config
+from multiqc.modules.base_module import BaseMultiqcModule
+
+# deepTools modules
+from .bamPEFragmentSize import bamPEFragmentSizeMixin
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule, bamPEFragmentSizeMixin):
+    def __init__(self):
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(name='deepTools', anchor='deepTools', target='deepTools',
+                                            href="http://deeptools.readthedocs.io",
+                                            info=" is a suite of tools to process and analyze deep sequencing data.")
+
+        # Set up class objects to hold parsed data
+        self.general_stats_headers = OrderedDict()
+        self.general_stats_data = dict()
+        n = dict()
+
+        # Parse the various output file types
+        # bamPEFragmentSize
+        n['bamPEFragmentSize'] = self.parse_bamPEFragmentSize()
+        if n['bamPEFragmentSize'] > 0:
+            log.info("Found {} deepTools 'bamPEFragmentSize --table' outputs".format(n['bamPEFragmentSize']))
+        # computeGCBias
+        #n['computeGCBias'] = self.parse_computeGCBias()
+        #if n['computGCBias'] > 0:
+        #    log.info("Found {} deepTools computeGCBias outputs".format(n['computeGCBias']))

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -7,7 +7,6 @@ import re
 from collections import OrderedDict
 
 from multiqc import config
-from multiqc.plots import table, linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -7,6 +7,7 @@ import re
 from collections import OrderedDict
 
 from multiqc import config
+from multiqc.plots import table
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -53,7 +54,11 @@ class estimateReadFilteringMixin():
                         '% Singletons': 100. * v['singletons'] / float(v['total']),
                         '% Strand Filtered': 100. * v['strand'] / float(v['total'])}
 
-            self.general_stats_addcols(d, header)
+            config = {'namespace': 'deepTools bamPEFragmentSize'}
+            self.add_section(name="Filtering metrics",
+                             anchor="estimateReadFiltering",
+                             description="Estimated percentages of alignments filtered independently for each setting in `estimateReadFiltering`",
+                             plot=table.plot(d, header, config))
 
         return len(self.deeptools_estimateReadFiltering)
 

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from deepTools estimateReadFiltering """
+
+import logging
+import re
+from collections import OrderedDict
+
+from multiqc import config
+from multiqc.plots import table, linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class estimateReadFilteringMixin():
+    def parse_estimateReadFiltering(self):
+        """Find estimateReadFiltering output. Only the output from --table is supported."""
+        self.deeptools_estimateReadFiltering = dict()
+        for f in self.find_log_files('deeptools/estimateReadFiltering'):
+            parsed_data = self.parseEstimateReadFilteringFile(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_estimateReadFiltering:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_estimateReadFiltering[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='estimateReadFiltering')
+
+        if len(self.deeptools_estimateReadFiltering) > 0:
+            header = OrderedDict()
+            header["M Entries"] = {'title': 'M entries', 'description': 'Number of entries in the file (millions)'}
+            header["% Aligned"] = {'title': '% Aligned', 'description': 'Percent of aligned entries'}
+            header["% Filtered"] = {'title': '% Tot. Filtered', 'description': 'Percent of alignment that would be filtered for any reason.'}
+            header["% Blacklisted"] = {'title': '% Blacklisted', 'description': 'Percent of alignments falling (at least partially) inside a blacklisted region'}
+            header["% MAPQ"] = {'title': '% MAPQ', 'description': 'Percent of alignments having MAPQ scores below the specified threshold'}
+            header["% Missing Flags"] = {'title': '% Missing Flags', 'description': 'Percent of alignments lacking at least on flag specified by --samFlagInclude'}
+            header["% Forbidden Flags"] = {'title': '% Forbidden Flags', 'description': 'Percent of alignments having at least one flag specified by --samFlagExclude'}
+            header["% deepTools Dupes"] = {'title': '% deepTools Dupes', 'description': 'Percent of alignments marked by deepTools as being duplicates'}
+            header["% Duplication"] = {'title': '% Duplication', 'description': 'Percent of alignments originally marked as being duplicates'}
+            header["% Singletons"] = {'title': '% Singletons', 'description': 'Percent of alignments that are singletons (i.e., paired-end reads where the mates don\'t align as a pair'}
+            header["% Strand Filtered"] = {'title': '% Strand Filtered', 'description': 'Percent of alignments arising from the wrong strand'}
+
+            d = dict()
+            for k, v in self.deeptools_estimateReadFiltering.items():
+                d[k] = {'M Entries': v['total'] / 1000000.0,
+                        '% Aligned': 100. * v['mapped'] / float(v['total']),
+                        '% Filtered': 100. * v['filtered'] / float(v['total']),
+                        '% Blacklisted': 100. * v['blacklisted'] / float(v['total']),
+                        '% Below MAPQ': 100. * v['mapq'] / float(v['total']),
+                        '% Missing Flags': 100. * v['required flags'] / float(v['total']),
+                        '% Forbidden Flags': 100. * v['excluded flags'] / float(v['total']),
+                        '% deepTools Dupes': 100. * v['internal dupes'] / float(v['total']),
+                        '% Duplication': 100. * v['dupes'] / float(v['total']),
+                        '% Singletons': 100. * v['singletons'] / float(v['total']),
+                        '% Strand Filtered': 100. * v['strand'] / float(v['total'])}
+
+            self.general_stats_addcols(d, header)
+
+        return len(self.deeptools_estimateReadFiltering)
+
+    def parseEstimateReadFilteringFile(self, f, fname):
+        d = {}
+        firstLine = True
+        for line in f.splitlines():
+            if firstLine:
+                firstLine = False
+                continue
+            cols = line.strip().split("\t")
+
+            if len(cols) != 12:
+                # This is not really the output from estimateReadFiltering!
+                log.warning("{} was initially flagged as the tabular output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            if cols[0] in d:
+                log.warning("Replacing duplicate sample {}.".format(cols[0]))
+            d[cols[0]] = dict()
+
+            try:
+                d[cols[0]]["total"] = int(cols[1])
+                d[cols[0]]["mapped"] = int(cols[2])
+                d[cols[0]]["blacklisted"] = int(cols[3])
+                d[cols[0]]["filtered"] = float(cols[4])
+                d[cols[0]]["mapq"] = float(cols[5])
+                d[cols[0]]["required flags"] = float(cols[6])
+                d[cols[0]]["excluded flags"] = float(cols[7])
+                d[cols[0]]["internal dupes"] = float(cols[8])
+                d[cols[0]]["dupes"] = float(cols[9])
+                d[cols[0]]["singletons"] = float(cols[10])
+                d[cols[0]]["strand"] = float(cols[11])
+            except:
+                # Obviously this isn't really the output from estimateReadFiltering
+                log.warning("{} was initially flagged as the output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+        return d

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -16,7 +16,7 @@ class estimateReadFilteringMixin():
         """Find estimateReadFiltering output. Only the output from --table is supported."""
         self.deeptools_estimateReadFiltering = dict()
         for f in self.find_log_files('deeptools/estimateReadFiltering'):
-            parsed_data = self.parseEstimateReadFilteringFile(f['f'], f['fn'])
+            parsed_data = self.parseEstimateReadFilteringFile(f)
             for k, v in parsed_data.items():
                 if k in self.deeptools_estimateReadFiltering:
                     log.warning("Replacing duplicate sample {}.".format(k))
@@ -57,10 +57,10 @@ class estimateReadFilteringMixin():
 
         return len(self.deeptools_estimateReadFiltering)
 
-    def parseEstimateReadFilteringFile(self, f, fname):
+    def parseEstimateReadFilteringFile(self, f):
         d = {}
         firstLine = True
-        for line in f.splitlines():
+        for line in f['f'].splitlines():
             if firstLine:
                 firstLine = False
                 continue
@@ -68,27 +68,28 @@ class estimateReadFilteringMixin():
 
             if len(cols) != 12:
                 # This is not really the output from estimateReadFiltering!
-                log.warning("{} was initially flagged as the tabular output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(fname))
+                log.warning("{} was initially flagged as the tabular output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(f['fn']))
                 return dict()
 
-            if cols[0] in d:
-                log.warning("Replacing duplicate sample {}.".format(cols[0]))
-            d[cols[0]] = dict()
+            s_name = self.clean_s_name(cols[0], f['root'])
+            if s_name in d:
+                log.debug("Replacing duplicate sample {}.".format(s_name))
+            d[s_name] = dict()
 
             try:
-                d[cols[0]]["total"] = int(cols[1])
-                d[cols[0]]["mapped"] = int(cols[2])
-                d[cols[0]]["blacklisted"] = int(cols[3])
-                d[cols[0]]["filtered"] = float(cols[4])
-                d[cols[0]]["mapq"] = float(cols[5])
-                d[cols[0]]["required flags"] = float(cols[6])
-                d[cols[0]]["excluded flags"] = float(cols[7])
-                d[cols[0]]["internal dupes"] = float(cols[8])
-                d[cols[0]]["dupes"] = float(cols[9])
-                d[cols[0]]["singletons"] = float(cols[10])
-                d[cols[0]]["strand"] = float(cols[11])
+                d[s_name]["total"] = int(cols[1])
+                d[s_name]["mapped"] = int(cols[2])
+                d[s_name]["blacklisted"] = int(cols[3])
+                d[s_name]["filtered"] = float(cols[4])
+                d[s_name]["mapq"] = float(cols[5])
+                d[s_name]["required flags"] = float(cols[6])
+                d[s_name]["excluded flags"] = float(cols[7])
+                d[s_name]["internal dupes"] = float(cols[8])
+                d[s_name]["dupes"] = float(cols[9])
+                d[s_name]["singletons"] = float(cols[10])
+                d[s_name]["strand"] = float(cols[11])
             except:
                 # Obviously this isn't really the output from estimateReadFiltering
-                log.warning("{} was initially flagged as the output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(fname))
+                log.warning("{} was initially flagged as the output from estimateReadFiltering, but that seems to not be the case. Skipping...".format(f['fn']))
                 return dict()
         return d

--- a/multiqc/modules/deeptools/plotCoverage.py
+++ b/multiqc/modules/deeptools/plotCoverage.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from deepTools plotCoverage """
+
+import logging
+import re
+from collections import OrderedDict
+
+from multiqc import config
+from multiqc.plots import table, linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class plotCoverageMixin():
+    def parse_plotCoverage(self):
+        """Find plotCoverage output. Both stdout and --outRawCounts"""
+        self.deeptools_plotCoverageStdout = dict()
+        for f in self.find_log_files('deeptools/plotCoverageStdout'):
+            parsed_data = self.parsePlotCoverageStdout(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_plotCoverageStdout:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_plotCoverageStdout[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='plotCoverage')
+
+        self.deeptools_plotCoverageOutRawCounts= dict()
+        for f in self.find_log_files('deeptools/plotCoverageOutRawCounts'):
+            parsed_data = self.parsePlotCoverageOutRawCounts(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_plotCoverageOutRawCounts:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_plotCoverageOutRawCounts[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='plotCoverage')
+
+        if len(self.deeptools_plotCoverageStdout) > 0:
+            header = OrderedDict()
+            header["mean"] = {'title': 'Mean Cov.', 'description': 'Mean coverage'}
+            header["std"] = {'title': 'Std. Dev.', 'description': 'Coverage standard deviation'}
+            header["min"] = {'title': 'Min. Cov.', 'description': 'Minimum Coverage'}
+            header["25%"] = {'title': '1st Q.', 'description': 'First quartile coverage'}
+            header["50%"] = {'title': 'Med. Cov.', 'description': 'Median coverage (second quartile)'}
+            header["75%"] = {'title': '3rd Q.', 'description': 'Third quartile coverage'}
+            header["max"] = {'title': 'Max. Cov.', 'description': 'Maximum coverage'}
+            self.add_section(name="plotCoverage (standard output)",
+                             anchor="plotCoverage",
+                             plot=table.plot(self.deeptools_plotCoverageStdout, header))
+
+        if len(self.deeptools_plotCoverageOutRawCounts) > 0:
+            config = dict(xlab='Coverage', ylab='Fraction of bases sampled')
+            self.add_section(name="plotCoverage",
+                             anchor="plotCoverage",
+                             plot=linegraph.plot(self.deeptools_plotCoverageOutRawCounts, config))
+
+
+
+        return len(self.deeptools_plotCoverageStdout), len(self.deeptools_plotCoverageOutRawCounts)
+
+    def parsePlotCoverageStdout(self, f, fname):
+        d = {}
+        firstLine = True
+        for line in f.splitlines():
+            if firstLine:
+                firstLine = False
+                continue
+            cols = line.strip().split("\t")
+
+            if len(cols) != 8:
+                log.warning("{} was initially flagged as the standard output from plotCoverage, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            if cols[0] in d:
+                log.warning("Replacing duplicate sample {}.".format(cols[0]))
+            d[cols[0]] = dict()
+
+            try:
+                d[cols[0]]["mean"] = float(cols[1])
+                d[cols[0]]["std"] = float(cols[2])
+                d[cols[0]]["min"] = float(cols[3])
+                d[cols[0]]["25%"] = float(cols[4])
+                d[cols[0]]["50%"] = float(cols[5])
+                d[cols[0]]["75%"] = float(cols[6])
+                d[cols[0]]["max"] = float(cols[7])
+            except:
+                log.warning("{} was initially flagged as the standard output from plotCoverage, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+        return d
+
+    def parsePlotCoverageOutRawCounts(self, f, fname):
+        samples = []
+        d = {}
+        nCols = 0
+        nRows = 0
+        for line in f.splitlines():
+            cols = line.strip().split('\t')
+            if len(cols) < 4:
+                log.warning("{} was initially flagged as the output from plotCoverage --outRawCounts, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            if cols[0] == "#'chr'":
+                nCols = len(cols)
+                for col in cols[3:]:
+                    samples.append(col.strip("'"))
+                    d[col.strip("'")] = dict()
+                continue
+
+            if len(cols) != nCols:
+                log.warning("{} was initially flagged as the output from plotCoverage --outRawCounts, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            for i, v in enumerate(cols[3:]):
+                v = float(v)
+                if v not in d[samples[i]]:
+                    d[samples[i]][v] = 0
+                d[samples[i]][v] += 1
+            nRows += 1
+
+        # Convert values to a fraction
+        nRows = float(nRows)
+        for k, v in d.items():
+            for k2, v2 in v.items():
+                v[k2] /= nRows
+
+        return d

--- a/multiqc/modules/deeptools/plotEnrichment.py
+++ b/multiqc/modules/deeptools/plotEnrichment.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from deepTools plotEnrichment """
+
+import logging
+import re
+from collections import OrderedDict
+
+from multiqc import config
+from multiqc.plots import linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class plotEnrichmentMixin():
+    def parse_plotEnrichment(self):
+        """Find plotEnrichment output."""
+        self.deeptools_plotEnrichment = dict()
+        for f in self.find_log_files('deeptools/plotEnrichment'):
+            parsed_data = self.parsePlotEnrichment(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_plotEnrichment:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_plotEnrichment[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='plotEnrichment')
+
+        if len(self.deeptools_plotEnrichment) > 0:
+            dCounts = {}
+            dPercents = {}
+            for k, v in self.deeptools_plotEnrichment.items():
+                dCounts[k] = dict()
+                dPercents[k] = dict()
+                for k2, v2 in v.items():
+                    dCounts[k][k2] = v2['count']
+                    dPercents[k][k2] = v2['percent']
+            config = {'data_labels': [
+                          {'name': 'Counts', 'ylab': 'Counts in feature'},
+                          {'name': 'Percents', 'ylab': 'Percent of reads in feature'}],
+                      'ylab': 'Counts',
+                      'categories': True,
+                      'ymin': 0.0}
+            self.add_section(name="plotEnrichment",
+                             anchor="plotEnrichment",
+                             plot=linegraph.plot([dCounts, dPercents], config))
+
+        return len(self.deeptools_plotEnrichment)
+
+    def parsePlotEnrichment(self, f, fname):
+        d = {}
+        firstLine = True
+        for line in f.splitlines():
+            if firstLine:
+                firstLine = False
+                continue
+            cols = line.strip().split("\t")
+
+            if len(cols) != 5:
+                log.warning("{} was initially flagged as the output from plotEnrichment, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            if cols[0] not in d:
+                d[cols[0]] = dict()
+            cols[1] = str(cols[1])
+            if cols[1] in d[cols[0]]:
+                log.warning("Replacing duplicate sample:featureType {}:{}.".format(cols[0], cols[1]))
+            d[cols[0]][cols[1]] = dict()
+
+            try:
+                d[cols[0]][cols[1]]["percent"] = float(cols[2])
+                d[cols[0]][cols[1]]["count"] = int(cols[3])
+            except:
+                log.warning("{} was initially flagged as the output from plotEnrichment, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+        return d

--- a/multiqc/modules/deeptools/plotEnrichment.py
+++ b/multiqc/modules/deeptools/plotEnrichment.py
@@ -7,7 +7,7 @@ import re
 from collections import OrderedDict
 
 from multiqc import config
-from multiqc.plots import linegraph
+from multiqc.plots import bargraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -27,23 +27,26 @@ class plotEnrichmentMixin():
                 self.add_data_source(f, section='plotEnrichment')
 
         if len(self.deeptools_plotEnrichment) > 0:
-            dCounts = {}
-            dPercents = {}
-            for k, v in self.deeptools_plotEnrichment.items():
-                dCounts[k] = dict()
-                dPercents[k] = dict()
-                for k2, v2 in v.items():
-                    dCounts[k][k2] = v2['count']
-                    dPercents[k][k2] = v2['percent']
+            dCounts = OrderedDict()
+            dPercents = OrderedDict()
+            for sample, v in self.deeptools_plotEnrichment.items():  # Key is sample
+                for category, v2 in v.items():  # Key is categ
+                    if category not in dCounts:
+                        dCounts[category] = dict()
+                        dPercents[category] = dict()
+                    dCounts[category][sample] = v2['count']
+                    dPercents[category][sample] = v2['percent']
             config = {'data_labels': [
-                          {'name': 'Counts', 'ylab': 'Counts in feature'},
-                          {'name': 'Percents', 'ylab': 'Percent of reads in feature'}],
-                      'ylab': 'Counts',
-                      'categories': True,
-                      'ymin': 0.0}
+                          {'name': 'Counts in features', 'ylab': 'Counts in feature'},
+                          {'name': 'Percents in features', 'ylab': 'Percent of reads in feature'}],
+                      'ylab': 'Counts in feature',
+                      'stacking': None,
+                      'ymin': 0.0,
+                      'tt_percentages': False,
+                      'cpswitch': False}
             self.add_section(name="plotEnrichment",
                              anchor="plotEnrichment",
-                             plot=linegraph.plot([dCounts, dPercents], config))
+                             plot=bargraph.plot([dCounts, dPercents], pconfig=config))
 
         return len(self.deeptools_plotEnrichment)
 

--- a/multiqc/modules/deeptools/plotEnrichment.py
+++ b/multiqc/modules/deeptools/plotEnrichment.py
@@ -7,7 +7,7 @@ import re
 from collections import OrderedDict
 
 from multiqc import config
-from multiqc.plots import bargraph
+from multiqc.plots import linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -29,27 +29,24 @@ class plotEnrichmentMixin():
         if len(self.deeptools_plotEnrichment) > 0:
             dCounts = OrderedDict()
             dPercents = OrderedDict()
-            for sample, v in self.deeptools_plotEnrichment.items():  # Key is sample
-                for category, v2 in v.items():  # Key is categ
-                    if category not in dCounts:
-                        dCounts[category] = dict()
-                        dPercents[category] = dict()
-                    dCounts[category][sample] = v2['count']
-                    dPercents[category][sample] = v2['percent']
+            for sample, v in self.deeptools_plotEnrichment.items():
+                dCounts[sample] = OrderedDict()
+                dPercents[sample] = OrderedDict()
+                for category, v2 in v.items():
+                    dCounts[sample][category] = v2['count']
+                    dPercents[sample][category] = v2['percent']
             config = {'data_labels': [
                           {'name': 'Counts in features', 'ylab': 'Counts in feature'},
                           {'name': 'Percents in features', 'ylab': 'Percent of reads in feature'}],
                       'id': 'plotEnrichment',
                       'title': 'Signal enrichment per feature',
                       'ylab': 'Counts in feature',
-                      'stacking': None,
-                      'ymin': 0.0,
-                      'tt_percentages': False,
-                      'cpswitch': False}
+                      'categories': True,
+                      'ymin': 0.0}
             self.add_section(name="Signal enrichment per feature",
                              description="Signal enrichment per feature according to plotEnrichment",
                              anchor="plotEnrichment",
-                             plot=bargraph.plot([dCounts, dPercents], pconfig=config))
+                             plot=linegraph.plot([dCounts, dPercents], pconfig=config))
 
         return len(self.deeptools_plotEnrichment)
 

--- a/multiqc/modules/deeptools/plotFingerprint.py
+++ b/multiqc/modules/deeptools/plotFingerprint.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import numpy as np
 
 from multiqc import config
-from multiqc.plots import bargraph, linegraph
+from multiqc.plots import linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -39,22 +39,13 @@ class plotFingerprintMixin():
                 self.add_data_source(f, section='plotFingerprint')
 
         if len(self.deeptools_plotFingerprintOutQualityMetrics) > 0:
-            d = OrderedDict()
-            categories = []
-            for sample, v in self.deeptools_plotFingerprintOutQualityMetrics.items():
-                sample = str(sample)
-                for category, v2 in v.items():
-                    if category not in d:
-                        d[category] = dict()
-                        categories.append(category)
-                    d[category][sample] = v2
-            config = dict(cpswitch=False, hide_zero_cats=False, ymin=0.0, ymax=1.0, ylab='Value', stacking=None, tt_percentages=False, tt_decimals=3)
+            config = dict(ymin=0.0, ymax=1.0, ylab='Value', categories=True)
             config['id'] = 'plotFingerprint_quality_metrics'
             config['title'] = 'Fingerprint quality metrics'
             self.add_section(name="Fingerprint quality metrics",
                              anchor="plotFingerprint",
                              description="Various quality metrics returned by plotFingerprint",
-                             plot=bargraph.plot(d, pconfig=config))
+                             plot=linegraph.plot(self.deeptools_plotFingerprintOutQualityMetrics, config))
 
         if len(self.deeptools_plotFingerprintOutRawCounts) > 0:
             config = dict(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0, xlab='rank', ylab='Fraction w.r.t. bin with highest coverage')

--- a/multiqc/modules/deeptools/plotFingerprint.py
+++ b/multiqc/modules/deeptools/plotFingerprint.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+""" MultiQC submodule to parse output from deepTools plotFingerprint """
+
+import logging
+import re
+from collections import OrderedDict
+import numpy as np
+
+from multiqc import config
+from multiqc.plots import linegraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class plotFingerprintMixin():
+    def parse_plotFingerprint(self):
+        """Find plotFingerprint output. Both --outQualityMetrics and --outRawCounts"""
+        self.deeptools_plotFingerprintOutQualityMetrics = dict()
+        for f in self.find_log_files('deeptools/plotFingerprintOutQualityMetrics'):
+            parsed_data = self.parsePlotFingerprintOutQualityMetrics(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_plotFingerprintOutQualityMetrics:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_plotFingerprintOutQualityMetrics[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='plotFingerprint')
+
+        self.deeptools_plotFingerprintOutRawCounts= dict()
+        for f in self.find_log_files('deeptools/plotFingerprintOutRawCounts'):
+            parsed_data = self.parsePlotFingerprintOutRawCounts(f['f'], f['fn'])
+            for k, v in parsed_data.items():
+                if k in self.deeptools_plotFingerprintOutRawCounts:
+                    log.warning("Replacing duplicate sample {}.".format(k))
+                self.deeptools_plotFingerprintOutRawCounts[k] = v
+
+            if len(parsed_data) > 0:
+                self.add_data_source(f, section='plotFingerprint')
+
+        if len(self.deeptools_plotFingerprintOutQualityMetrics) > 0:
+            config = {'categories': True, 'ymin': 0.0, 'ymax': 1.0, 'ylab': 'Value'}
+            self.add_section(name="plotFingerprint (quality metrics)",
+                             anchor="plotFingerprint",
+                             plot=linegraph.plot(self.deeptools_plotFingerprintOutQualityMetrics, config))
+
+        if len(self.deeptools_plotFingerprintOutRawCounts) > 0:
+            config = dict(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0, xlab='rank', ylab='Fraction w.r.t. bin with highest coverage')
+            self.add_section(name="plotFingerprint",
+                             anchor="plotFingerprint",
+                             plot=linegraph.plot(self.deeptools_plotFingerprintOutRawCounts, config))
+
+        return len(self.deeptools_plotFingerprintOutQualityMetrics), len(self.deeptools_plotFingerprintOutRawCounts)
+
+    def parsePlotFingerprintOutQualityMetrics(self, f, fname):
+        d = {}
+        firstLine = True
+        header = []
+        for line in f.splitlines():
+            cols = line.strip().split("\t")
+
+            if len(cols) < 7:
+                log.warning("{} was initially flagged as the output from plotFingerprint --outQualityMetrics, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+
+            if firstLine:
+                header = [str(x) for x in cols[1:]]
+                firstLine = False
+                continue
+
+            if cols[0] in d:
+                log.warning("Replacing duplicate sample {}.".format(cols[0]))
+            d[cols[0]] = OrderedDict()
+
+            try:
+                for i, c in enumerate(cols[1:]):
+                    if i >= len(header):
+                        log.warning("{} was initially flagged as the output from plotFingerprint --outQualityMetrics, but that seems to not be the case. Skipping...".format(fname))
+                        return dict()
+                    if header[i] == "AUC" or header[i] == "Synthetic AUC":
+                        continue
+                    d[cols[0]][header[i]] = float(c)
+            except:
+                log.warning("{} was initially flagged as the output from plotFingerprint --outQualityMetrics, but that seems to not be the case. Skipping...".format(fname))
+                return dict()
+        return d
+
+    def parsePlotFingerprintOutRawCounts(self, f, fname):
+        d = dict()
+        samples = []
+        firstLine = True
+        for line in f.splitlines():
+            cols = line.strip().split('\t')
+            if cols[0] == "#plotFingerprint --outRawCounts":
+                continue
+
+            if firstLine:
+                for c in cols:
+                    c = str(c).strip("'")
+                    d[c] = []
+                    samples.append(c)
+                firstLine = False
+                continue
+
+            for idx, c in enumerate(cols):
+                d[samples[idx]].append(int(c))
+
+        # Switch to numpy, get the normalized cumsum
+        x = np.linspace(0, len(d[samples[0]]) - 1, endpoint=True, num=100, dtype=int)  # The indices into the vectors that we'll actually return for plotting
+        xp = np.arange(len(d[samples[0]]) + 1) / float(len(d[samples[0]]) + 1)
+        for k, v in d.items():
+            v = np.array(v)
+            v = np.sort(v)
+            cs = np.cumsum(v)
+            cs = cs / float(cs[-1])
+            # Convert for plotting
+            v2 = dict()
+            v2[0.0] = 0.0
+            for _ in x:
+                v2[xp[_]] = cs[_]
+            d[k] = v2
+        return d

--- a/multiqc/modules/deeptools/plotFingerprint.py
+++ b/multiqc/modules/deeptools/plotFingerprint.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 import numpy as np
 
 from multiqc import config
-from multiqc.plots import linegraph
+from multiqc.plots import bargraph, linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -39,10 +39,19 @@ class plotFingerprintMixin():
                 self.add_data_source(f, section='plotFingerprint')
 
         if len(self.deeptools_plotFingerprintOutQualityMetrics) > 0:
-            config = {'categories': True, 'ymin': 0.0, 'ymax': 1.0, 'ylab': 'Value'}
+            d = OrderedDict()
+            categories = []
+            for sample, v in self.deeptools_plotFingerprintOutQualityMetrics.items():
+                sample = str(sample)
+                for category, v2 in v.items():
+                    if category not in d:
+                        d[category] = dict()
+                        categories.append(category)
+                    d[category][sample] = v2
+            config = dict(cpswitch=False, hide_zero_cats=False, ymin=0.0, ymax=1.0, ylab='Value', stacking=None, tt_percentages=False, tt_decimals=3)
             self.add_section(name="plotFingerprint (quality metrics)",
                              anchor="plotFingerprint",
-                             plot=linegraph.plot(self.deeptools_plotFingerprintOutQualityMetrics, config))
+                             plot=bargraph.plot(d, pconfig=config))
 
         if len(self.deeptools_plotFingerprintOutRawCounts) > 0:
             config = dict(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0, xlab='rank', ylab='Fraction w.r.t. bin with highest coverage')

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -95,7 +95,10 @@ def plot (data, cats=None, pconfig=None):
     plotsamples = list()
     plotdata = list()
     for idx, d in enumerate(data):
-        hc_samples = sorted(list(d.keys()))
+        if isinstance(d, OrderedDict):
+            hc_samples = list(d.keys())
+        else:
+            hc_samples = sorted(list(d.keys()))
         hc_data = list()
         sample_dcount = dict()
         for c in cats[idx].keys():

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -237,6 +237,11 @@ module_order:
     - disambiguate:
         module_tag:
             - RNA
+    - deeptools:
+        module_tag:
+            - DNA
+            - RNA
+            - chip
     # Post-alignment processing
     - homer:
         module_tag:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -55,6 +55,9 @@ cutadapt:
     contents: 'This is cutadapt'
     # contents: 'cutadapt version' # Use this instead if using very old versions of cutadapt (eg. v1.2)
     shared: true
+deeptools/bamPEFragmentSize:
+    contents: '	Frag. Sampled	Frag. Len. Min.	Frag. Len. 1st. Qu.	Frag. Len. Mean	Frag. Len. Median	Frag. Len. 3rd Qu.'
+    num_lines: 1
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -67,6 +67,9 @@ deeptools/plotCoverageStdout:
 deeptools/plotCoverageOutRawCounts:
     contents: "#'chr'	'start'	'end'	'"
     num_lines: 1
+deeptools/plotEnrichment:
+    contents: 'file	featureType	percent	featureReadCount	totalReadCount'
+    num_lines: 1
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -61,6 +61,12 @@ deeptools/bamPEFragmentSize:
 deeptools/estimateReadFiltering:
     contents: 'Sample	Total Reads	Mapped Reads	Alignments in blacklisted regions	Estimated mapped reads'
     num_lines: 1
+deeptools/plotCoverageStdout:
+    contents: 'sample	mean	std	min	25%	50%	75%	max'
+    num_lines: 1
+deeptools/plotCoverageOutRawCounts:
+    contents: "#'chr'	'start'	'end'	'"
+    num_lines: 1
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -58,6 +58,9 @@ cutadapt:
 deeptools/bamPEFragmentSize:
     contents: '	Frag. Sampled	Frag. Len. Min.	Frag. Len. 1st. Qu.	Frag. Len. Mean	Frag. Len. Median	Frag. Len. 3rd Qu.'
     num_lines: 1
+deeptools/estimateReadFiltering:
+    contents: 'Sample	Total Reads	Mapped Reads	Alignments in blacklisted regions	Estimated mapped reads'
+    num_lines: 1
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -70,6 +70,12 @@ deeptools/plotCoverageOutRawCounts:
 deeptools/plotEnrichment:
     contents: 'file	featureType	percent	featureReadCount	totalReadCount'
     num_lines: 1
+deeptools/plotFingerprintOutRawCounts:
+    contents: '#plotFingerprint --outRawCounts'
+    num_lines: 1
+deeptools/plotFingerprintOutQualityMetrics:
+    contents: 'Sample	AUC	Synthetic AUC	X-intercept	Synthetic X-intercept	Elbow Point	Synthetic Elbow Point'
+    num_lines: 1
 fastq_screen:
     fn: '*_screen.txt'
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -65,7 +65,7 @@ deeptools/plotCoverageStdout:
     contents: 'sample	mean	std	min	25%	50%	75%	max'
     num_lines: 1
 deeptools/plotCoverageOutRawCounts:
-    contents: "#'chr'	'start'	'end'	'"
+    contents: "#plotCoverage --outRawCounts"
     num_lines: 1
 deeptools/plotEnrichment:
     contents: 'file	featureType	percent	featureReadCount	totalReadCount'

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
             'custom_content = multiqc.modules.custom_content:custom_module_classes', # special case
             'cutadapt = multiqc.modules.cutadapt:MultiqcModule',
             'disambiguate = multiqc.modules.disambiguate:MultiqcModule',
+            'deeptools = multiqc.modules.deeptools:MultiqcModule',
             'fastq_screen = multiqc.modules.fastq_screen:MultiqcModule',
             'fastqc = multiqc.modules.fastqc:MultiqcModule',
             'featureCounts = multiqc.modules.featureCounts:MultiqcModule',


### PR DESCRIPTION
This adds support for a number of outputs produced by deepTools (xref https://github.com/fidelram/deepTools/issues/554). Note that it also implements a possible solution to issue #581, so either the code related to that in this PR needs to be removed or it needs to be resolved that the solution provided here is OK before merging.

As an aside, my goal with this module is less to make deepTools' default output interactive and more to merge information from multiple runs into a single very convenient format. I know there has been work done by others to allow MultiQC to handle the output from things like `plotPCA`, but in deepTools 2.6 I've already added interactive images (via plotly), so foresee adding a multiQC module for that as adding much that's really useful. At least in our use-cases, we often run things like `plotFingerprint` multiple times with various subsets of samples so that we can get appropriate jensen-shannon divergence values, so combining all of them (and the other produced metrics) into a single interactive plot would be immensely helpful for us.