### PR TITLE
Update links for bcl2fastq modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Many thanks to those involved!
 * [**AfterQC**](https://github.com/OpenGene/AfterQC) - New module!
     * Added parsing of the _AfterQC_ json file data, with a plot of filtered reads.
     * Work by [@raonyguimaraes](https://github.com/raonyguimaraes)
-* [**bcl2fastq**](https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html)
+* [**bcl2fastq**](https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html)
     * bcl2fastq can be used to both demultiplex data and convert BCL files to FASTQ file formats for downstream analysis
     * New module parses JSON output from recent versions and summarises some key statistics from the demultiplexing process.
     * Work by [@iimog](https://github.com/iimog) (with a little help from [@tbooth](https://github.com/tbooth) and [@ewels](https://github.com/ewels))

--- a/docs/modules/bcl2fastq.md
+++ b/docs/modules/bcl2fastq.md
@@ -1,12 +1,12 @@
 ---
 Name: bcl2fastq
-URL: https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html
+URL: https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html
 Description: >
     bcl2fastq can be used to both demultiplex data and convert BCL files to
     FASTQ file formats for downstream analysis.
 ---
 
-There are two versions of this software: [bcl2fastq](https://support.illumina.com/downloads/bcl2fastq_conversion_software_184.html) for MiSeq and HiSeq
-sequencing systems running RTA versions earlier than 1.8, and [bcl2fastq2](https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html)
-for Illumina sequencing systems running RTA version 1.18.54 and above.
-This module currently only covers output from the latter.
+There are two versions of this software: bcl2fastq for MiSeq and HiSeq
+sequencing systems running RTA versions earlier than 1.8, and bcl2fastq2 for
+Illumina sequencing systems running RTA version 1.18.54 and above. This module
+currently only covers output from the latter.

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -12,7 +12,7 @@ class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(name='bcl2fastq', anchor='bcl2fastq',
-        href="https://support.illumina.com/downloads/bcl2fastq-conversion-software-v2-18.html",
+        href="https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html",
         info="can be used to both demultiplex data and convert BCL files to FASTQ file formats for downstream analysis.")
 
         # Gather data from all json files


### PR DESCRIPTION
- Fixes the broken link for bcl2fastq2
- Uses the overview page for both bcl2fastq and bcl2fastq2