### PR TITLE
add Dockerfile for MultiQC 1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:2.7-slim
+
+LABEL \
+  author="Phil Ewels" \
+  description="MultiQC" \
+  maintainer="phil.ewels@scilifelab.se"
+
+# Setup ENV variables
+ENV MULTIQC_VERSION="1.1"
+
+# Install libraries
+RUN \
+  apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  git \
+  wget \
+  && wget --quiet -O /opt/get-pip.py https://bootstrap.pypa.io/get-pip.py \
+  && python /opt/get-pip.py \
+  && rm -rf /var/lib/apt/lists/* /opt/get-pip.py
+
+# Install MultiQC
+RUN \
+  pip install networkx==1.11 \
+  && pip install git+git://github.com/ewels/MultiQC.git@v${MULTIQC_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ LABEL \
   description="MultiQC" \
   maintainer="phil.ewels@scilifelab.se"
 
-# Setup ENV variables
-ENV MULTIQC_VERSION="1.1"
-
 # Install libraries
 RUN \
   apt-get update && apt-get install -y --no-install-recommends \
@@ -19,6 +16,4 @@ RUN \
   && rm -rf /var/lib/apt/lists/* /opt/get-pip.py
 
 # Install MultiQC
-RUN \
-  pip install networkx==1.11 \
-  && pip install git+git://github.com/ewels/MultiQC.git@v${MULTIQC_VERSION}
+RUN pip install git+git://github.com/ewels/MultiQC.git

--- a/README.md
+++ b/README.md
@@ -140,25 +140,26 @@ If in doubt, feel free to get in touch with the author directly:
 Project lead and main author: [@ewels](https://github.com/ewels)
 
 Code contributions from:
-[@moonso](https://github.com/moonso),
-[@lpantano](https://github.com/lpantano),
-[@dakl](https://github.com/dakl),
-[@robinandeer](https://github.com/robinandeer),
-[@mlusignan](https://github.com/mlusignan),
-[@HLWiencko](https://github.com/HLWiencko),
-[@guillermo-carrasco](https://github.com/guillermo-carrasco),
-[@avilella](https://github.com/avilella),
-[@vladsaveliev](https://github.com/vladsaveliev),
-[@t-neumann](https://github.com/t-neumann),
 [@ahvigil](https://github.com/ahvigil),
-[@bschiffthaler](https://github.com/bschiffthaler),
-[@jrderuiter](https://github.com/jrderuiter),
-[@epruesse](https://github.com/epruesse),
+[@avilella](https://github.com/avilella),
 [@boulund](https://github.com/boulund),
-[@iimog](https://github.com/iimog),
-[@rlegendre](https://github.com/rlegendre),
+[@bschiffthaler](https://github.com/bschiffthaler),
+[@dakl](https://github.com/dakl),
 [@ehsueh](https://github.com/ehsueh)
+[@epruesse](https://github.com/epruesse),
+[@guillermo-carrasco](https://github.com/guillermo-carrasco),
+[@HLWiencko](https://github.com/HLWiencko),
+[@iimog](https://github.com/iimog),
+[@jrderuiter](https://github.com/jrderuiter),
+[@lpantano](https://github.com/lpantano),
+[@MaxUlysse](https://github.com/MaxUlysse),
+[@mlusignan](https://github.com/mlusignan),
+[@moonso](https://github.com/moonso),
 [@noirot](https://github.com/noirot)
+[@rlegendre](https://github.com/rlegendre),
+[@robinandeer](https://github.com/robinandeer),
+[@t-neumann](https://github.com/t-neumann),
+[@vladsaveliev](https://github.com/vladsaveliev),
 [@wkretzsch](https://github.com/wkretzsch)
 
 and many others. Thanks for your support!
@@ -184,11 +185,11 @@ and many others. Thanks for your support!
 [flexbar]:        http://multiqc.info/docs/#flexbar
 [gatk]:           http://multiqc.info/docs/#gatk
 [goleft]:         http://multiqc.info/docs/#goleft-indexcov
-[jellyfish]:      http://multiqc.info/docs/#jellyfish
 [hicup]:          http://multiqc.info/docs/#hicup
 [hisat2]:         http://multiqc.info/docs/#hisat2
 [homer]:          http://multiqc.info/docs/#homer
 [htseq]:          http://multiqc.info/docs/#htseq
+[jellyfish]:      http://multiqc.info/docs/#jellyfish
 [kallisto]:       http://multiqc.info/docs/#kallisto
 [leehom]:         http://multiqc.info/docs/#leehom
 [macs2]:          http://multiqc.info/docs/#macs2
@@ -205,14 +206,14 @@ and many others. Thanks for your support!
 [rseqc]:          http://multiqc.info/docs/#rseqc
 [salmon]:         http://multiqc.info/docs/#salmon
 [samblaster]:     http://multiqc.info/docs/#samblaster
-[slamdunk]:       http://multiqc.info/docs/#slamdunk
+[samtools]:       http://multiqc.info/docs/#samtools
 [skewer]:         http://multiqc.info/docs/#skewer
+[slamdunk]:       http://multiqc.info/docs/#slamdunk
 [snpeff]:         http://multiqc.info/docs/#snpeff
 [sortmerna]:      http://multiqc.info/docs/#sortmerna
 [star]:           http://multiqc.info/docs/#star
-[samtools]:       http://multiqc.info/docs/#samtools
-[theta2]:         http://multiqc.info/docs/#theta2
-[trimmomatic]:    http://multiqc.info/docs/#trimmomatic
-[tophat]:         http://multiqc.info/docs/#tophat
-[vcftools]:       http://multiqc.info/docs/#vcftools
 [supernova]:      http://multiqc.info/docs/#supernova
+[theta2]:         http://multiqc.info/docs/#theta2
+[tophat]:         http://multiqc.info/docs/#tophat
+[trimmomatic]:    http://multiqc.info/docs/#trimmomatic
+[vcftools]:       http://multiqc.info/docs/#vcftools

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,3 +152,12 @@ prepend-path    PATH        $modroot/bin
 prepend-path	PYTHONPATH	$modroot/lib/python2.7/site-packages
 ```
 
+## Using the Docker container
+A Docker container based on `python:2.7-slim` is provided.
+Specify the volume to bind mount as desired with `-v`, same for the working directory inside the container with `-w`. Or just use `-v "$PWD":"$PWD" -w "$PWD"` to run in current directory.
+For more information, look into [the Docker documentation](https://docs.docker.com/engine/reference/commandline/run/)
+
+The usual multiqc command line should work fine:
+```
+docker run -v "$PWD":"$PWD" -w "$PWD" ewels/multiqc multiqc .
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -180,13 +180,3 @@ you want to run. Alternatively, use `-e`/`--exclude` to run all modules
 except those listed.
 
 You can get a group of modules by using `--tag` followed by a tag e.g. RNA or DNA.
-
-## Using the Docker container
-A Docker container based on `python:2.7-slim` is provided.
-Specify the volume to bind mount as desired with `-v`, same for the working directory inside the container with `-w`. Or just use `-v "$PWD":"$PWD" -w "$PWD"` to run in current directory.
-For more information, look into [the Docker documentation](https://docs.docker.com/engine/reference/commandline/run/)
-
-The usual multiqc command line should work fine:
-```
-docker run -v "$PWD":"$PWD" -w "$PWD" ewels/multiqc multiqc .
-```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -179,4 +179,14 @@ You can do this by using `-m`/`--modules` to explicitly define which modules
 you want to run. Alternatively, use `-e`/`--exclude` to run all modules
 except those listed.
 
-You can get a group of modules by using `--tag` followed by a tag e.g. RNA or DNA. 
+You can get a group of modules by using `--tag` followed by a tag e.g. RNA or DNA.
+
+## Using the Docker container
+A Docker container based on `python:2.7-slim` is provided.
+Specify the volume to bind mount as desired with `-v`, same for the working directory inside the container with `-w`. Or just use `-v "$PWD":"$PWD" -w "$PWD"` to run in current directory.
+For more information, look into [the Docker documentation](https://docs.docker.com/engine/reference/commandline/run/)
+
+The usual multiqc command line should work fine:
+```
+docker run -v "$PWD":"$PWD" -w "$PWD" ewels/multiqc multiqc .
+```


### PR DESCRIPTION
Add a Dockerfile based on `python:2.7-slim`.
Works well for MultiQC 1.1, haven't tried 1.2 or 1.3-dev, but I can see no reason why it would not work either.
I'll advise to make a tag for each version, so that people will still be able to try older versions.