### PR TITLE
Bcl2fastq: rename Total reads to Clusters

### DIFF
--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -210,7 +210,7 @@ class MultiqcModule(BaseMultiqcModule):
         }
         headers = OrderedDict()
         headers['total'] = {
-            'title': '{} Total Reads'.format(config.read_count_prefix),
+            'title': '{} Clusters'.format(config.read_count_prefix),
             'description': 'Total number of reads for this sample as determined by bcl2fastq demultiplexing ({})'.format(config.read_count_desc),
             'min': 0,
             'scale': 'Blues',


### PR DESCRIPTION
Addressing this issue https://github.com/ewels/MultiQC/issues/591