### PR TITLE
Automatically modify read or base counts according shared_key set

### DIFF
--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -212,17 +212,13 @@ class MultiqcModule(BaseMultiqcModule):
         headers['total'] = {
             'title': '{} Clusters'.format(config.read_count_prefix),
             'description': 'Total number of reads for this sample as determined by bcl2fastq demultiplexing ({})'.format(config.read_count_desc),
-            'min': 0,
             'scale': 'Blues',
-            'modify': lambda x: x * config.read_count_multiplier,
             'shared_key': 'read_count'
         }
         headers['yieldQ30'] = {
             'title': '{} Yield &ge; Q30'.format(config.base_count_prefix),
             'description': 'Number of bases with a Phred score of 30 or higher ({})'.format(config.base_count_desc),
-            'min': 0,
             'scale': 'Greens',
-            'modify': lambda x: x * config.base_count_multiplier,
             'shared_key': 'base_count'
         }
         headers['perfectPercent'] = {
@@ -241,17 +237,13 @@ class MultiqcModule(BaseMultiqcModule):
         headers['total_yield'] = {
             'title': '{} Total Yield'.format(config.base_count_prefix),
             'description': 'Number of bases ({})'.format(config.base_count_desc),
-            'min': 0,
             'scale': 'Greens',
-            'modify': lambda x: x * config.base_count_multiplier,
             'shared_key': 'base_count'
         }
         headers['total'] = {
             'title': '{} Total Clusters'.format(config.read_count_prefix),
             'description': 'Total number of clusters for this lane ({})'.format(config.read_count_desc),
-            'min': 0,
             'scale': 'Blues',
-            'modify': lambda x: x * config.read_count_multiplier,
             'shared_key': 'read_count'
         }
         headers['percent_Q30'] = {

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -505,7 +505,6 @@ def general_stats_headers (self):
         'title': 'Ins. size',
         'description': 'Median insert size',
         'min': 0,
-        'suffix': 'bp',
         'scale': 'PuOr',
         'format': '{:,.0f}'
     }
@@ -537,19 +536,15 @@ def general_stats_headers (self):
     self.general_stats_headers['mapped_reads'] = {
         'title': '{} Aligned'.format(config.read_count_prefix),
         'description': 'Number of mapped reads ({})'.format(config.read_count_desc),
-        'min': 0,
         'scale': 'RdYlGn',
         'shared_key': 'read_count',
-        'modify': lambda x: x * config.read_count_multiplier,
         'hidden': True
     }
     self.general_stats_headers['total_reads'] = {
         'title': '{} Total reads'.format(config.read_count_prefix),
         'description': 'Number of reads ({})'.format(config.read_count_desc),
-        'min': 0,
         'scale': 'Blues',
         'shared_key': 'read_count',
-        'modify': lambda x: x * config.read_count_multiplier,
         'hidden': True
     }
 

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -129,11 +129,6 @@ def make_table (dt):
                 kname = '{}_{}'.format(header['namespace'], rid)
                 dt.raw_vals[s_name][kname] = val
 
-                if header.get('shared_key', None) == 'read_count' and header.get('modify') is None:
-                    header['modify'] = lambda x: x * config.read_count_multiplier
-                if header.get('shared_key', None) == 'base_count' and header.get('modify') is None:
-                    header['modify'] = lambda x: x * config.base_count_multiplier
-
                 if 'modify' in header and callable(header['modify']):
                     val = header['modify'](val)
 

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -129,13 +129,18 @@ def make_table (dt):
                 kname = '{}_{}'.format(header['namespace'], rid)
                 dt.raw_vals[s_name][kname] = val
 
+                if header.get('shared_key', None) == 'read_count' and header.get('modify') is None:
+                    header['modify'] = lambda x: x * config.read_count_multiplier
+                if header.get('shared_key', None) == 'base_count' and header.get('modify') is None:
+                    header['modify'] = lambda x: x * config.base_count_multiplier
+
                 if 'modify' in header and callable(header['modify']):
                     val = header['modify'](val)
 
                 try:
                     dmin = header['dmin']
                     dmax = header['dmax']
-                    percentage = ((float(val) - dmin) / (dmax - dmin)) * 100;
+                    percentage = ((float(val) - dmin) / (dmax - dmin)) * 100
                     percentage = min(percentage, 100)
                     percentage = max(percentage, 0)
                 except (ZeroDivisionError,ValueError):

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -78,6 +78,21 @@ class datatable (object):
                 # Unique id to avoid overwriting by other datasets
                 headers[idx][k]['rid'] = report.save_htmlid(re.sub(r'\W+', '_', k))
 
+                # Applying defaults presets for data keys if shared_key is set to base_count or read_count
+                shared_key = headers[idx][k].get('shared_key', None)
+                if shared_key in ['read_count', 'base_count']:
+                    if shared_key == 'read_count':
+                        multiplier = config.read_count_multiplier
+                    else:
+                        multiplier = config.base_count_multiplier
+                    if headers[idx][k].get('modify') is None:
+                        headers[idx][k]['modify'] = lambda x: x * multiplier
+                    if headers[idx][k].get('min') is None:
+                        headers[idx][k]['min'] = 0
+                    if headers[idx][k].get('format') is None:
+                        if multiplier == 1:
+                            headers[idx][k]['format'] = '{:,.0f}'
+
                 # Use defaults / data keys if headers not given
                 headers[idx][k]['namespace']   = headers[idx][k].get('namespace', pconfig.get('namespace', ''))
                 headers[idx][k]['title']       = headers[idx][k].get('title', k)


### PR DESCRIPTION
Will make the read and base counts in custom content affected by modifiers. 

The problem is that we can't assign lambdas in YAML, thus can't set proper `modify` value for custom content. Making use of `shared_key` to automatically set the modification would be nice, though the downside is that it makes it implicit and also breaks compatibility, which is probably not desired. So rather opening to start discussion.