### PR TITLE
Allow to config modules running multiple times, and add Bcftools options

### DIFF
--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -152,6 +152,7 @@ The available options are:
 * `href`: Intro link URL
 * `info`: Intro text
 * `extra`: Additional HTML after intro.
+* `custom_config`: Custom module-level settings. Translated into `config.moduleName`, but specifically for this section.
 
 For example, to run the FastQC module twice, before and after adapter trimming, you could
 use the following config:

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 
 class BaseMultiqcModule(object):
 
-    def __init__(self, name='base', anchor='base', target=None, href=None, info=None, comment=None, extra=None, autoformat=True, autoformat_type='markdown'):
+    def __init__(self, name='base', anchor='base', target=None, href=None, info=None, comment=None, extra=None,
+                 autoformat=True, autoformat_type='markdown'):
 
         # Custom options from user config that can overwrite module values
         mod_cust_config = getattr(self, 'mod_cust_config', {})
@@ -28,6 +29,10 @@ class BaseMultiqcModule(object):
         info = mod_cust_config.get('info', info)
         self.comment = mod_cust_config.get('comment', comment)
         extra = mod_cust_config.get('extra', extra)
+        # Assuming all remaing values are for the module-level config:
+        config.update({anchor:
+            {k: v for k, v in mod_cust_config.items() if k not in
+            ['name', 'anchor', 'target', 'href', 'info', 'comment', 'extra', 'path_filters']}})
 
         # See if we have a user comment in the config
         if self.anchor in config.section_comments:

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -20,7 +20,7 @@ class BaseMultiqcModule(object):
     def __init__(self, name='base', anchor='base', target=None, href=None, info=None, comment=None, extra=None,
                  autoformat=True, autoformat_type='markdown'):
 
-        # Custom options from user config that can overwrite module values
+        # Custom options from user config that can overwrite base module values
         mod_cust_config = getattr(self, 'mod_cust_config', {})
         self.name = mod_cust_config.get('name', name)
         self.anchor = report.save_htmlid( mod_cust_config.get('anchor', anchor) )
@@ -29,10 +29,8 @@ class BaseMultiqcModule(object):
         info = mod_cust_config.get('info', info)
         self.comment = mod_cust_config.get('comment', comment)
         extra = mod_cust_config.get('extra', extra)
-        # Assuming all remaing values are for the module-level config:
-        config.update({anchor:
-            {k: v for k, v in mod_cust_config.items() if k not in
-            ['name', 'anchor', 'target', 'href', 'info', 'comment', 'extra', 'path_filters']}})
+        # Specific module level config to overwrite (e.g. config.bcftools, config.fastqc)
+        config.update({anchor: mod_cust_config.get('custom_config', {})})
 
         # See if we have a user comment in the config
         if self.anchor in config.section_comments:

--- a/multiqc/modules/bcftools/bcftools.py
+++ b/multiqc/modules/bcftools/bcftools.py
@@ -25,7 +25,7 @@ class MultiqcModule(BaseMultiqcModule, StatsReportMixin):
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
             name='Bcftools',
-            anchor='Bcftools', target='Bcftools',
+            anchor='bcftools', target='Bcftools',
             href='https://samtools.github.io/bcftools/',
             info=(" contains utilities for variant calling and manipulating VCFs and BCFs."))
 

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -5,7 +5,7 @@
 import logging
 from collections import OrderedDict
 from multiqc import config
-from multiqc.plots import bargraph, linegraph
+from multiqc.plots import bargraph, linegraph, table
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -109,8 +109,15 @@ class StatsReportMixin():
             # Write parsed report data to a file
             self.write_data_file(self.bcftools_stats, 'multiqc_bcftools_stats')
 
-            # General Stats Table
-            self.bcftools_stats_genstats_table()
+            # Stats Table
+            stats_headers = self.bcftools_stats_genstats_headers()
+            if getattr(config, 'bcftools', {}).get('write_general_stats', True):
+                self.general_stats_addcols(self.bcftools_stats, stats_headers, 'Bcftools Stats')
+            if getattr(config, 'bcftools', {}).get('write_separate_table', False):
+                self.add_section(
+                    name='Bcftools Stats',
+                    anchor='bcftools-stats',
+                    plot=table.plot(self.bcftools_stats, stats_headers))
 
             # Make bargraph plot of substitution types
             keys = OrderedDict()
@@ -165,7 +172,7 @@ class StatsReportMixin():
         # Return the number of logs that were found
         return len(self.bcftools_stats)
 
-    def bcftools_stats_genstats_table(self):
+    def bcftools_stats_genstats_headers(self):
         """ Add key statistics to the General Stats table """
         stats_headers = OrderedDict()
         stats_headers['number_of_records'] = {
@@ -203,4 +210,4 @@ class StatsReportMixin():
             'description': 'Variation multinucleotide polymorphisms',
             'min': 0, 'format': '{:,.0f}', "hidden": True,
         }
-        self.general_stats_addcols(self.bcftools_stats, stats_headers, 'Bcftools Stats')
+        return stats_headers

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -177,7 +177,7 @@ def mqc_add_config(conf, conf_path=None):
             logger.debug("New config '{}': {}".format(c, v))
             update({c: v})
 
-#### Function to load file containinga list of alternative sample-name swaps
+#### Function to load file containing a list of alternative sample-name swaps
 # Essentially a fancy way of loading stuff into the sample_names_rename config var
 # As such, can also be done directly using a config file
 def load_sample_names(snames_file):

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -172,10 +172,10 @@ def mqc_add_config(conf, conf_path=None):
                 logger.error("Config '{}' path not found, skipping ({})".format(c, fpath))
                 continue
             logger.debug("New config '{}': {}".format(c, fpath))
-            update_dict(globals(), {c: fpath})
+            update({c: fpath})
         else:
             logger.debug("New config '{}': {}".format(c, v))
-            update_dict(globals(), {c: v})
+            update({c: v})
 
 #### Function to load file containinga list of alternative sample-name swaps
 # Essentially a fancy way of loading stuff into the sample_names_rename config var
@@ -203,6 +203,9 @@ def load_sample_names(snames_file):
     except (IOError, AttributeError) as e:
         logger.error("Error loading sample names file: {}".format(e))
     logger.debug("Found {} sample renaming patterns".format(len(sample_names_rename_buttons)))
+
+def update(u):
+    return update_dict(globals(), u)
 
 def update_dict(d, u):
     """ Recursively updates nested dict d from nested dict u


### PR DESCRIPTION
Add `bcftools` options `write_general_stats` and `write_separate_table` to control where the table stats go (useful when `bcftools` running multiple times)

So for bcbio MultiQC report, I wanted to run `bcftools` twice once for germline and once for somatic variants (https://github.com/chapmanb/bcbio-nextgen/issues/2081). The new MultiQC feature that allowed to run modules twice is really great, however since the `bcftools` module reports at least 5 useful metrics, making it twice makes the general stats table expand beyond the screen width. So I wanted to hide the "germline" stats by default, and rather move them to a separate table. I added a parameter for `bcftools` that controls where the stats would go (the first commit), which works nicely, however `module_order` doesn't allow user to set any custom config parameters specifically for a run. This PR tries to address that. If any custom value outside of default `name/anchor/target/href/info/comment/extra` is set in `module_order`, it will affect `config.<module_anchor>` dict, e.g.:
```
module_order:
- bcftools:
       name: 'Bcftools (somatic)',
       info: 'Bcftools stats for somatic varaiant calls only.'
       path_filters: ['*_bcftools_stats.txt']
       write_general_stats: true
       write_separate_table: true
- bcftools:
       name: 'Bcftools (germline)'
       info: 'Bcftools stats for germline variant calls only.'
       path_filters: ['*_bcftools_stats_germline.txt']
       write_general_stats: false
       write_separate_table: true
```

Let me know if you would implement it in other way and I'll fix it. For instance, one way would be to contain values in an explicit parameter `custom_config` provided to the `module_order` item, e.g.:
```
module_order:
- bcftools:
       name: 'Bcftools (germline)'
       info: 'Bcftools stats for germline variant calls only.'
       path_filters: ['*_bcftools_stats_germline.txt']
       custom_config:
            write_general_stats: false
            write_separate_table: true
```
More verbose, but less error-prone. Sticking to the first version however.