### PR TITLE
Get around needless enum34 requirement in python3.4+ in the next release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ MultiQC was written by Phil Ewels (http://phil.ewels.co.uk) at SciLifeLab Sweden
 """
 
 from setuptools import setup, find_packages
+import sys
 
 version = '1.4dev'
 dl_version = 'master' if 'dev' in version else 'v{}'.format(version)
@@ -31,6 +32,23 @@ print("""-----------------------------------
 -----------------------------------
 
 """.format(version))
+
+install_requires = [
+        'click',
+        'future>0.14.0',
+        'networkx<2',
+        'lzstring',
+        'jinja2>=2.9',
+        'matplotlib',
+        'markdown',
+        'numpy',
+        'pyyaml',
+        'requests',
+        'simplejson',
+        'spectra'
+    ]
+if sys.version_info < (3, 4):
+    install_requires.append('enum34')
 
 setup(
     name = 'multiqc',
@@ -47,21 +65,7 @@ setup(
     include_package_data = True,
     zip_safe = False,
     scripts = ['scripts/multiqc'],
-    install_requires = [
-        'click',
-        'future>0.14.0',
-        'networkx<2',
-        'lzstring',
-        'jinja2>=2.9',
-        'matplotlib',
-        'markdown',
-        'numpy',
-        'pyyaml',
-        'requests',
-        'simplejson',
-        'spectra',
-        'enum34'
-    ],
+    install_requires = install_requires,
     entry_points = {
         'multiqc.modules.v1': [
             'adapterRemoval = multiqc.modules.adapterRemoval:MultiqcModule',


### PR DESCRIPTION
In the most recent bioconda recipe, we ran into an issue due to `enum34` being listed as a requirement. This isn't actually needed as of python-3.4 and conda-forge has started making it python-2.7 only, meaning that one can't `conda install enum34` under python-3.6. While one could simply continue to build enum34 under versions of python not needing it, it's preferable to simply not require it unless needed. This PR essentially does what the patch for `setup.py` is currently doing in bioconda and removes `enum34` as a dependency in versions of python that already come with the `enum` built-in module.