### PR TITLE
Adding parsing of general error rate from qualimap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN \
   && rm -rf /var/lib/apt/lists/* /opt/get-pip.py
 
 # Install MultiQC
-RUN pip install git+git://github.com/ewels/MultiQC.git
+RUN pip install git+git://github.com/metagenlab/MultiQC.git
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN \
   && rm -rf /var/lib/apt/lists/* /opt/get-pip.py
 
 # Install MultiQC
-RUN pip install git+git://github.com/metagenlab/MultiQC.git
+RUN pip install git+git://github.com/ewels/MultiQC.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,3 @@ RUN \
 
 # Install MultiQC
 RUN pip install git+git://github.com/metagenlab/MultiQC.git
-
-

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -554,7 +554,7 @@ def general_stats_headers (self):
         'max': 100,
         'min': 0,
         'suffix': '%',
-        'scale': 'OrRd'
+        'scale': 'OrRd',
         'format': '{0:.2f}'
     }
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -84,6 +84,7 @@ def parse_genome_results(self, f):
         'mean_insert_size': r"mean insert size = ([\d,\.]+)",
         'median_insert_size': r"median insert size = ([\d,\.]+)",
         'mean_mapping_quality': r"mean mapping quality = ([\d,\.]+)",
+        'general_error_rate': r"general error rate = ([\d,\.]+)",
     }
     d = dict()
     for k, r in regexes.items():
@@ -93,6 +94,7 @@ def parse_genome_results(self, f):
                 d[k] = float(r_search.group(1).replace(',',''))
             except ValueError:
                 d[k] = r_search.group(1)
+    print(d)
 
     # Check we have an input filename
     if 'bam_file' not in d:
@@ -546,6 +548,14 @@ def general_stats_headers (self):
         'scale': 'Blues',
         'shared_key': 'read_count',
         'hidden': True
+    }
+    self.general_stats_headers['general_error_rate'] = {
+        'title': 'Error rate'.format(config.read_count_prefix),
+        'description': 'General error rate of the reads',
+        'max': 100,
+        'min': 0,
+        'suffix': '%',
+        'scale': 'Blues'
     }
 
 def _calculate_bases_within_thresholds(bases_by_depth, total_size, depth_thresholds):

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -554,7 +554,8 @@ def general_stats_headers (self):
         'max': 100,
         'min': 0,
         'suffix': '%',
-        'scale': 'Blues'
+        'scale': 'OrRd'
+        'format': '{0:.2f}'
     }
 
 def _calculate_bases_within_thresholds(bases_by_depth, total_size, depth_thresholds):

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -110,6 +110,7 @@ def parse_genome_results(self, f):
         self.general_stats_data[s_name]['mapped_reads'] = d['mapped_reads']
         d['percentage_aligned'] = (d['mapped_reads'] / d['total_reads'])*100
         self.general_stats_data[s_name]['percentage_aligned'] = d['percentage_aligned']
+        self.general_stats_data[s_name]['general_error_rate'] = d['general_error_rate']
     except KeyError:
         pass
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -94,8 +94,6 @@ def parse_genome_results(self, f):
                 d[k] = float(r_search.group(1).replace(',',''))
             except ValueError:
                 d[k] = r_search.group(1)
-    print(d)
-
     # Check we have an input filename
     if 'bam_file' not in d:
         log.debug("Couldn't find an input filename in genome_results file {}".format(f['fn']))

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -110,7 +110,7 @@ def parse_genome_results(self, f):
         self.general_stats_data[s_name]['mapped_reads'] = d['mapped_reads']
         d['percentage_aligned'] = (d['mapped_reads'] / d['total_reads'])*100
         self.general_stats_data[s_name]['percentage_aligned'] = d['percentage_aligned']
-        self.general_stats_data[s_name]['general_error_rate'] = d['general_error_rate']
+        self.general_stats_data[s_name]['general_error_rate'] = d['general_error_rate']*100
     except KeyError:
         pass
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -549,13 +549,14 @@ def general_stats_headers (self):
         'hidden': True
     }
     self.general_stats_headers['general_error_rate'] = {
-        'title': 'Error rate'.format(config.read_count_prefix),
-        'description': 'General error rate of the reads',
+        'title': 'Error rate',
+        'description': 'General error rate of the reads. Defined as the total edit distance (NM field of the SAM format specification) over the number of mapped bases',
         'max': 100,
         'min': 0,
         'suffix': '%',
         'scale': 'OrRd',
-        'format': '{0:.2f}'
+        'format': '{0:.2f}',
+        'hidden': True
     }
 
 def _calculate_bases_within_thresholds(bases_by_depth, total_size, depth_thresholds):


### PR DESCRIPTION
Hello !

First thanks a lot for this very useful tool, I have discorded it recently and it's really awesome !

For my development I wanted to be able to study the general error rate of the reads, parameter that is calculated by qualimap but that was not included in your parsing. It is now included in the general table because I think it is a rather useful metrics but maybe it should be hidden by default ? Let me know what you think.

I have tried to add it and keep the code as close as yours, so please tell me if this is not sufficient or if quality is subpar.

Cheers !
