### PR TITLE
use file suffix when adding column to general stats

### DIFF
--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -149,7 +149,7 @@ class MultiqcModule(BaseMultiqcModule):
         headers['sex_het_ratio'] = {
             'title': 'Sex / Het Ratio',
         }
-        headers['error'] = {
+        headers['error_sex_check'] = {
             'title': 'Sex Error',
             'description': 'Error in sample sex prediction',
         }


### PR DESCRIPTION
Added suffix to the self.peddy_data but didn't use this suffix when trying to add a column into general stats 'error' --> error_sex_check