### PR TITLE
Added rRNA Alignment stats to summary table of RNA-SeqQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     * Catch `ZeroDivisionError` exceptions when there are 0 reads ([@aledj2](https://github.com/aledj2))
 * **Peddy**
     * Switch `Sex error` logic to `Correct sex` for better highlighting ([@aledj2](https://github.com/aledj2))
+* **RNA-SeQC**
+    * Added rRNA alignment stats to summary table [@Rolandde](https://github.com/Rolandde)
 
 
 

--- a/multiqc/modules/rna_seqc/rna_seqc.py
+++ b/multiqc/modules/rna_seqc/rna_seqc.py
@@ -105,6 +105,15 @@ class MultiqcModule(BaseMultiqcModule):
             'scale': 'Bu',
             'format': '{:,.0f}'
         }
+        headers['rRNA rate'] = {
+            'title': '% rRNA Alignment',
+            'description': ' rRNA reads (non-duplicate and duplicate reads) per total reads',
+            'max': 100,
+            'min': 0,
+            'suffix': '%',
+            'scale': 'Reds',
+            'modify': lambda x: float(x) * 100.0
+        }
 
         self.general_stats_addcols(self.rna_seqc_metrics, headers)
 


### PR DESCRIPTION
Currently, parsed RNA-SeqQC reports do not display the level of rRNA contamination. This is one of the first QC steps when analyzing RNA-Seq data, so I have added it to the summary table.