### PR TITLE
Tiny typo fixes (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
     * Parsed tables now exported to `multiqc_data` files
 * **Cutadapt**
     * Refactor parsing code to collect all length trimming plots
+* **FastQC**
+    * Fixed starting y-axis label for GC-content lineplot being incorrect.
 * **HiCExplorer**
     * Updated to work with v2.0 release.
 * **Homer**

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -419,7 +419,6 @@ class MultiqcModule(BaseMultiqcModule):
         pconfig = {
             'id': 'fastqc_per_sequence_gc_content_plot',
             'title': 'FastQC: Per Sequence GC Content',
-            'ylab': 'Count',
             'xlab': '% GC',
             'ymin': 0,
             'xmax': 100,

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -317,7 +317,7 @@ class MultiqcModule(BaseMultiqcModule):
         pconfig = {
             'id': 'fastqc_per_sequence_quality_scores_plot',
             'title': 'FastQC: Per Sequence Quality Scores',
-            'ylab': 'Percentage',
+            'ylab': 'Count',
             'xlab': 'Mean Sequence Quality (Phred Score)',
             'ymin': 0,
             'xmin': 0,

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -317,7 +317,7 @@ class MultiqcModule(BaseMultiqcModule):
         pconfig = {
             'id': 'fastqc_per_sequence_quality_scores_plot',
             'title': 'FastQC: Per Sequence Quality Scores',
-            'ylab': 'Count',
+            'ylab': 'Percentage',
             'xlab': 'Mean Sequence Quality (Phred Score)',
             'ymin': 0,
             'xmin': 0,

--- a/multiqc_config_example.yaml
+++ b/multiqc_config_example.yaml
@@ -61,7 +61,7 @@ fn_ignore_dirs:
 fn_ignore_paths:
     - '*/path/to/*_files/'
 
-# Ignore files larger than this when searcing for logs (bytes)
+# Ignore files larger than this when searching for logs (bytes)
 log_filesize_limit: 5000000
 
 # MultiQC skips a couple of debug messages when searching files as the


### PR DESCRIPTION
Made a mistake with the previous PR. This contains the **correct** fixes:

- Fixes y-axis label of FastQC GC-content line plot showing 'Count' instead of 'Percentage'. Muliqc.plot will now correctly source data_labels[0]. Related to issue #557.

- Fixes small typo in config example.

