### PR TITLE
[rseqc - read distribution] plot the number of intergenic reads

### DIFF
--- a/multiqc/modules/rseqc/read_distribution.py
+++ b/multiqc/modules/rseqc/read_distribution.py
@@ -50,6 +50,9 @@ def parse_reports(self):
                 d['{}_tag_count'.format(k)] = int(r_search.group(2))
                 d['{}_tags_kb'.format(k)] = float(r_search.group(2))
 
+        d['other_intergenic_tag_count'] = d['total_tags']-d['total_assigned_tags']
+        d['other_intergenic_total_bases'] = 0
+
         # Calculate some percentages for parsed file
         if 'total_tags' in d:
             t = float(d['total_tags'])
@@ -86,6 +89,7 @@ def parse_reports(self):
         keys['tes_down_1kb_tag_count'] = {'name': "TES_down_1kb"}
         keys['tes_down_5kb_tag_count'] = {'name': "TES_down_5kb"}
         keys['tes_down_10kb_tag_count'] = {'name': "TES_down_10kb"}
+        keys['other_intergenic_tag_count'] = {'name': "Other_intergenic"}
 
         # Config for the plot
         pconfig = {


### PR DESCRIPTION
In the current plot of rseqc read distribution, the intergenic reads that do not fall inside the predefined region arount TSS are not represented at all.
This pull request add a new feature in the plot that account for this reads, with the label "other_intergenic".
![image](https://user-images.githubusercontent.com/5821630/37032783-f5f72904-2143-11e8-9b0a-f1aed521fe55.png)
