### PR TITLE
Samtools stats: error rate description

### DIFF
--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -55,7 +55,7 @@ class StatsReportMixin():
             stats_headers = OrderedDict()
             stats_headers['error_rate'] = {
                 'title': 'Error rate',
-                'description': 'Error rate using CIGAR',
+                'description': 'Error rate: mismatches (NM) / bases mapped (CIGAR)',
                 'min': 0,
                 'max': 100,
                 'suffix': '%',
@@ -120,7 +120,7 @@ class StatsReportMixin():
             keys['reads_duplicated'] = dict(reads, **{'title': 'Duplicated', 'description': 'PCR or optical duplicate bit set'})
             keys['reads_QC_failed'] = dict(reads, **{'title': 'QC Failed'})
             keys['reads_MQ0'] = dict(reads, **{'title': 'Reads MQ0', 'description': 'Reads mapped and MQ=0'})
-            keys['bases_mapped_(cigar)'] = dict(bases, **{'title': 'Mapped bases (cigar)', 'description': 'Mapped bases (cigar)'})
+            keys['bases_mapped_(cigar)'] = dict(bases, **{'title': 'Mapped bases (CIGAR)', 'description': 'Mapped bases (CIGAR)'})
             keys['bases_trimmed'] = dict(bases, **{'title': 'Bases Trimmed'})
             keys['bases_duplicated'] = dict(bases, **{'title': 'Duplicated bases'})
             keys['pairs_on_different_chromosomes'] = dict(reads, **{'title': 'Diff chromosomes', 'description': 'Pairs on different chromosomes'})


### PR DESCRIPTION
10x LongRanger pipeline doesn't report the NM tag, so Error rate is calculated to 0. By description, it look like it only uses CIGAR, so not clear why it might equal 0. Clarifying that.