### PR TITLE
Fix path_filters for config.top_modules and config.module_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## MultiQC v1.6dev
 
-_..nothing yet.._
+#### Bug Fixes
+* Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.
 
 
 ## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -94,7 +94,7 @@ class BaseMultiqcModule(object):
 
             # If path_filters is given, skip unless match
             if path_filters is not None and len(path_filters) > 0:
-                if not all([fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters]):
+                if not any([fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters]):
                     logger.debug("{} - Skipping '{}' as didn't match module path filters".format(sp_key, f['fn']))
                     continue
 


### PR DESCRIPTION
This PR fixes a bug when specifying multiple globs for `path_filters` for `config.top_modules` or `config.module_order`.

For instance, using the following configuration:
```yaml
top_modules:
    - moduleName:
        name: 'Module (filtered)'
        info: 'This section shows the module with different files'
        path_filters:
            - '*_special.txt'
            - '*_others.txt'
```

Would only select filename searches that match `*.special.txt` **and** `*_others.txt`. Wheras you would want it to match `*.special.txt` **or** `*_others.txt`.