### PR TITLE
New feature: path_filters_exclude setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## MultiQC v1.6dev
 
+#### New MultiQC Features:
+* Add `path_filters_exclude` to exclude certain files when running modules multiple times. You could previously only include certain files.
+
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Code contributions from:
 [@boulund](https://github.com/boulund),
 [@bschiffthaler](https://github.com/bschiffthaler),
 [@Cashalow](https://github.com/Cashalow/),
+[@cpavanrun](https://github.com/cpavanrun),
 [@dakl](https://github.com/dakl),
 [@ehsueh](https://github.com/ehsueh)
 [@epruesse](https://github.com/epruesse),

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -140,11 +140,22 @@ top_modules:
             - '*_special.txt'
             - '*_others.txt'
     - moduleName:
-        name: 'Module (all)'
+        name: 'Module (not-special)'
+        path_filters_exclude:
+            - '*_special.txt'
 ```
-These overwrite the defaults that are hardcoded in the module code. `path_filters` is the
-exception, which filters the file searches for a given list of glob filename patterns.
-The available options are:
+These overwrite the defaults that are hardcoded in the module code. `path_filters` and `path_filters_exclude` being the exception. These filter the file searches for a given list of glob filename patterns:
+
+| Pattern | Meaning                             |
+|---------|-------------------------------------|
+| \*       | matches everything                 |
+| ?       | matches any single character        |
+| [seq]   | matches any character in seq        |
+| [!seq]  | matches any character not in seq    |
+
+Note that exclusion superseeds inclusion for the path filters.
+
+The other available configuration options are:
 
 * `name`: Section name
 * `anchor`: Section report ID

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -95,19 +95,19 @@ class BaseMultiqcModule(object):
 
             # Filter out files based on exclusion patterns
             if path_filters_exclude and len(path_filters_exclude) > 0:
-                exlusion_criteria = (fnmatch.fnmatch(report.last_found_file, pfe) for pfe in path_filters_exclude)
-                if any(exlusion_criteria):
-                    logger.debug("{} - Skipping '{}' as it matched the an exclusion path_filter".format(sp_key, f['fn']))
+                exlusion_hits = (fnmatch.fnmatch(report.last_found_file, pfe) for pfe in path_filters_exclude)
+                if any(exlusion_hits):
+                    logger.debug("{} - Skipping '{}' as it matched the path_filter_exclude".format(sp_key, f['fn']))
                     continue
 
             # Filter out files based on inclusion patterns
             if path_filters and len(path_filters) > 0:
-                inclusion_criteria = (fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters)
-                if not any(inclusion_criteria):
-                    logger.debug("{} - Skipping '{}' as it didn't match a module path_filter".format(sp_key, f['fn']))
+                inclusion_hits = (fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters)
+                if not any(inclusion_hits):
+                    logger.debug("{} - Skipping '{}' as it didn't match the path_filter".format(sp_key, f['fn']))
                     continue
                 else:
-                    logger.debug("{} - Selecting '{}' as it matched a module path_filter".format(sp_key, f['fn']))
+                    logger.debug("{} - Selecting '{}' as it matched the path_filter".format(sp_key, f['fn']))
 
             # Make a sample name from the filename
             f['s_name'] = self.clean_s_name(f['fn'], f['root'])

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -97,17 +97,17 @@ class BaseMultiqcModule(object):
             if path_filters_exclude and len(path_filters_exclude) > 0:
                 exlusion_hits = (fnmatch.fnmatch(report.last_found_file, pfe) for pfe in path_filters_exclude)
                 if any(exlusion_hits):
-                    logger.debug("{} - Skipping '{}' as it matched the path_filters_exclude".format(sp_key, f['fn']))
+                    logger.debug("{} - Skipping '{}' as it matched the path_filters_exclude for '{}'".format(sp_key, f['fn'], self.name))
                     continue
 
             # Filter out files based on inclusion patterns
             if path_filters and len(path_filters) > 0:
                 inclusion_hits = (fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters)
                 if not any(inclusion_hits):
-                    logger.debug("{} - Skipping '{}' as it didn't match the path_filters".format(sp_key, f['fn']))
+                    logger.debug("{} - Skipping '{}' as it didn't match the path_filters for '{}'".format(sp_key, f['fn'], self.name))
                     continue
                 else:
-                    logger.debug("{} - Selecting '{}' as it matched the path_filters".format(sp_key, f['fn']))
+                    logger.debug("{} - Selecting '{}' as it matched the path_filters for '{}'".format(sp_key, f['fn'], self.name))
 
             # Make a sample name from the filename
             f['s_name'] = self.clean_s_name(f['fn'], f['root'])

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -71,6 +71,7 @@ class BaseMultiqcModule(object):
         # Pick up path filters if specified.
         # Allows modules to be called multiple times with different sets of files
         path_filters = getattr(self, 'mod_cust_config', {}).get('path_filters')
+        path_filters_exclude = getattr(self, 'mod_cust_config', {}).get('path_filters_exclude')
 
         # Old, depreciated syntax support. Likely to be removed in a future version.
         if isinstance(sp_key, dict):
@@ -92,11 +93,21 @@ class BaseMultiqcModule(object):
             # Make a note of the filename so that we can report it if something crashes
             report.last_found_file = os.path.join(f['root'], f['fn'])
 
-            # If path_filters is given, skip unless match
-            if path_filters is not None and len(path_filters) > 0:
-                if not any([fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters]):
-                    logger.debug("{} - Skipping '{}' as didn't match module path filters".format(sp_key, f['fn']))
+            # Filter out files based on exclusion patterns
+            if path_filters_exclude and len(path_filters_exclude) > 0:
+                exlusion_criteria = (fnmatch.fnmatch(report.last_found_file, pfe) for pfe in path_filters_exclude)
+                if any(exlusion_criteria):
+                    logger.debug("{} - Skipping '{}' as it matched the an exclusion path_filter".format(sp_key, f['fn']))
                     continue
+
+            # Filter out files based on inclusion patterns
+            if path_filters and len(path_filters) > 0:
+                inclusion_criteria = (fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters)
+                if not any(inclusion_criteria):
+                    logger.debug("{} - Skipping '{}' as it didn't match a module path_filter".format(sp_key, f['fn']))
+                    continue
+                else:
+                    logger.debug("{} - Selecting '{}' as it matched a module path_filter".format(sp_key, f['fn']))
 
             # Make a sample name from the filename
             f['s_name'] = self.clean_s_name(f['fn'], f['root'])

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -97,17 +97,17 @@ class BaseMultiqcModule(object):
             if path_filters_exclude and len(path_filters_exclude) > 0:
                 exlusion_hits = (fnmatch.fnmatch(report.last_found_file, pfe) for pfe in path_filters_exclude)
                 if any(exlusion_hits):
-                    logger.debug("{} - Skipping '{}' as it matched the path_filter_exclude".format(sp_key, f['fn']))
+                    logger.debug("{} - Skipping '{}' as it matched the path_filters_exclude".format(sp_key, f['fn']))
                     continue
 
             # Filter out files based on inclusion patterns
             if path_filters and len(path_filters) > 0:
                 inclusion_hits = (fnmatch.fnmatch(report.last_found_file, pf) for pf in path_filters)
                 if not any(inclusion_hits):
-                    logger.debug("{} - Skipping '{}' as it didn't match the path_filter".format(sp_key, f['fn']))
+                    logger.debug("{} - Skipping '{}' as it didn't match the path_filters".format(sp_key, f['fn']))
                     continue
                 else:
-                    logger.debug("{} - Selecting '{}' as it matched the path_filter".format(sp_key, f['fn']))
+                    logger.debug("{} - Selecting '{}' as it matched the path_filters".format(sp_key, f['fn']))
 
             # Make a sample name from the filename
             f['s_name'] = self.clean_s_name(f['fn'], f['root'])


### PR DESCRIPTION
This PR adds the `path_filters_exclude` and makes some slight improvements to path filtering (_e.g._ debug statements and filter _generators_ instead of _lists_).

The `path_filters_exclude` allows you to exclude certain files when running modules multiple times.

A use case would be as follows:

Take the input files which would cause duplicate sample names when ran together:
- S1.HsMetrics_trimmed.txt
- S1.HsMetrics.txt
...
- S10.HsMetrics_trimmed.txt
- S10.HsMetrics.txt

One could run the module twice and preventing duplicate sample names clashes by adding the following to your MultiQC configuration:
```yaml
top_modules:
    - moduleName:
        name: 'Module (trimmed)'
        path_filters:
            - '*_trimmed.txt'
    - moduleName:
        name: 'Module (not trimmed)'
        path_filters_exclude:
            - '*_trimmed.txt'
```