### PR TITLE
Remove enum34 dependency

### DIFF
--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -4,20 +4,14 @@
 """ MultiQC submodule to parse output from GATK BaseRecalibrator """
 
 import logging
-from enum import IntEnum
+from collections import namedtuple
 from multiqc.plots import linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
 
-
-class RecalTableType(IntEnum):
-    pre_recalibration = 0
-    post_recalibration = 1
-
-    def human_readable(self):
-        return self.name.capitalize().replace('_', '-')
-
+RecalTableType = namedtuple("RecalTableType", "pre_recalibration post_recalibration".split())
+recal_table_type = RecalTableType(0, 1)
 
 class BaseRecalibratorMixin():
     def parse_gatk_base_recalibrator(self):
@@ -30,12 +24,12 @@ class BaseRecalibratorMixin():
             '#:GATKTable:RecalTable1:': 'recal_table_1',
             '#:GATKTable:RecalTable2:': 'recal_table_2',
         }
-        samples_kept = {rt_type: set() for rt_type in RecalTableType}
+        samples_kept = {rt_type: set() for rt_type in recal_table_type}
         self.gatk_base_recalibrator = {recal_type:
                                            {table_name: {}
                                             for table_name
                                             in report_table_headers.values()}
-                                       for recal_type in RecalTableType}
+                                       for recal_type in recal_table_type}
 
         for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
             parsed_data = self.parse_report(f['f'].readlines(), report_table_headers)
@@ -52,12 +46,12 @@ class BaseRecalibratorMixin():
                         f['s_name']] = sample_tables
 
         # Filter to strip out ignored sample names
-        for rt_type in RecalTableType:
+        for rt_type in recal_table_type:
             for table_name, sample_tables in self.gatk_base_recalibrator[rt_type].items():
                 self.gatk_base_recalibrator[rt_type][table_name] = self.ignore_samples(
                     sample_tables)
 
-        n_reports_found = sum([len(samples_kept[rt_type]) for rt_type in RecalTableType])
+        n_reports_found = sum([len(samples_kept[rt_type]) for rt_type in recal_table_type])
 
         if n_reports_found > 0:
             log.info("Found {} BaseRecalibrator reports".format(n_reports_found))
@@ -71,7 +65,7 @@ class BaseRecalibratorMixin():
 
         sample_data = []
         data_labels = []
-        for rt_type in RecalTableType:
+        for rt_type_name, rt_type in recal_table_type._asdict().items():
             sample_tables = self.gatk_base_recalibrator[rt_type]['quality_quantization_map']
             if len(sample_tables) == 0:
                 continue
@@ -99,10 +93,10 @@ class BaseRecalibratorMixin():
                                 for sample, table in sample_tables.items()
                                 for y in table['Count']]
             prop_ymax = max(flat_proportions)
-            data_labels.append({'name': "{} Count".format(rt_type.human_readable()),
+            data_labels.append({'name': "{} Count".format(rt_type_name.capitalize().replace('_', '-')),
                                 'ylab': 'Count'})
             data_labels.append({'ymax': prop_ymax,
-                                'name': "{} Percent".format(rt_type.human_readable()),
+                                'name': "{} Percent".format(rt_type_name.capitalize().replace('_', '-')),
                                 'ylab': 'Percent'})
 
         plot = linegraph.plot(
@@ -137,6 +131,6 @@ class BaseRecalibratorMixin():
 def determine_recal_table_type(parsed_data):
     arguments = dict(zip(parsed_data['arguments']['Argument'], parsed_data['arguments']['Value']))
     if arguments['recalibration_report'] == 'null':
-        return RecalTableType.pre_recalibration
+        return recal_table_type.pre_recalibration
     else:
-        return RecalTableType.post_recalibration
+        return recal_table_type.post_recalibration

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ install_requires = [
         'simplejson',
         'spectra>=0.0.10'
     ]
-if sys.version_info < (3, 4):
-    install_requires.append('enum34')
 
 setup(
     name = 'multiqc',


### PR DESCRIPTION
A quick fix that removes enum/enum34 dependency in gatk module. Replaced it with a namedtuple that works kind of the same way as the enum in the original code. Only a slight modification to the part of the code that called the `human_readable`  method on the original enum types. 

I ran with the original version and my version and diffed the two output report outputs and found no differences (other than the line with run date and time, of course). Not sure if that is enough to solidly verify that it doesn't break anything, but I hope it's an indication that probably works. 