### PR TITLE
Add BBDuk 'stats' table summary to report

### DIFF
--- a/docs/modules/bbmap.md
+++ b/docs/modules/bbmap.md
@@ -9,8 +9,10 @@ Description: >
 The BBMap module produces summary statistics from the
 [BBMap](http://jgi.doe.gov/data-and-tools/bbtools/bb-tools-user-guide/) suite of tools.
 The module can summarise data from the following BBMap output files
-(descriptions from `bbmap.sh` help output):
+(descriptions from command line help output):
 
+* `stats`
+    * BBDuk filtering statistics.
 * `covstats` _(not yet implemented)_
     * Per-scaffold coverage info.
 * `rpkm` _(not yet implemented)_

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -53,13 +53,14 @@ class MultiqcModule(BaseMultiqcModule):
                 log.debug("section %s has %d entries", file_type,
                           len(self.mod_data[file_type]))
 
-                self.add_section(
-                    name = file_types[file_type]['title'],
-                    anchor =  'bbmap-' + file_type,
-                    description = file_types[file_type]['descr'],
-                    helptext = file_types[file_type]['help_text'],
-                    plot = self.plot(file_type)
-                )
+                if file_types[file_type]['plot_func']:
+                    self.add_section(
+                        name = file_types[file_type]['title'],
+                        anchor =  'bbmap-' + file_type,
+                        description = file_types[file_type]['descr'],
+                        helptext = file_types[file_type]['help_text'],
+                        plot = self.plot(file_type)
+                    )
 
             if any(self.mod_data[file_type][sample]['kv']
                    for sample in self.mod_data[file_type]):
@@ -146,14 +147,13 @@ class MultiqcModule(BaseMultiqcModule):
         """
 
         samples = self.mod_data[file_type]
-        if file_types[file_type]['plot_func']:
-            plot_title = file_types[file_type]['title']
-            plot_func = file_types[file_type]['plot_func']
-            plot_params = file_types[file_type]['plot_params']
-            return plot_func(samples,
-                        file_type,
-                        plot_title=plot_title,
-                        plot_params=plot_params)
+        plot_title = file_types[file_type]['title']
+        plot_func = file_types[file_type]['plot_func']
+        plot_params = file_types[file_type]['plot_params']
+        return plot_func(samples,
+                    file_type,
+                    plot_title=plot_title,
+                    plot_params=plot_params)
 
 
     def make_basic_table(self, file_type):

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -106,16 +106,15 @@ class MultiqcModule(BaseMultiqcModule):
                             continue
                         kv["% filtered"] = float(line[2].strip("%"))
                         kv[line[0]] = line[1] 
-                        continue
                     elif len(line) != 2:
                         # Not two items? Wrong!
                         log.error("Expected key value pair in %s/%s:%d but found '%s'",
                                   root, s_name, line_number, repr(line))
                         log.error("Table header should begin with '%s'",
                                   cols[0])
-                        continue
-                    # save key value pair
-                    kv[line[0]] = line[1]
+                    else:
+                        # save key value pair
+                        kv[line[0]] = line[1]
                 else:
                     # It should be the table header. Verify:
                     if line != cols:

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -146,10 +146,10 @@ class MultiqcModule(BaseMultiqcModule):
         """
 
         samples = self.mod_data[file_type]
-        plot_title = file_types[file_type]['title']
-        plot_func = file_types[file_type]['plot_func']
-        plot_params = file_types[file_type]['plot_params']
-        if plot_func:
+        if file_types[file_type]['plot_func']:
+            plot_title = file_types[file_type]['title']
+            plot_func = file_types[file_type]['plot_func']
+            plot_params = file_types[file_type]['plot_params']
             return plot_func(samples,
                         file_type,
                         plot_title=plot_title,

--- a/multiqc/modules/bbmap/bbmap_filetypes.py
+++ b/multiqc/modules/bbmap/bbmap_filetypes.py
@@ -19,6 +19,7 @@ class slice2OrderedDict(object):
 odict = slice2OrderedDict()
 
 section_order = [
+    'stats',
     'covhist',
     'covstats',
     'bincov',
@@ -40,6 +41,23 @@ section_order = [
     'statsfile',
 ]
 file_types = {
+    'stats': {
+        'title': 'BBDuk filtering statistics',
+        'descr': 'Proportion of reads that matched adapters/contaminants.',
+        'help_text': '',
+        'kvrows': ['Total', 'Matched'],
+        'kv_descriptions': {
+            'Total': ('Total number of reads processed', {'hidden': True}),
+            'Matched': ('Total number of reads matching adapters/contaminants', {'hidden': True}),
+            '% filtered': ('Proportion of reads filtered, matching adapters/contaminants', {'hidden': False}),
+        },
+        'cols': odict[
+            'Name':str,
+            'Reads':int,
+            'ReadsPct':lambda v: float(v.strip("%"))],
+        'plot_func': None,  ## Plotting for 'stats' not implemented
+        'plot_params': {},
+    },
     'aqhist': {
         'title': 'Read quality',
         'descr': 'Histogram of average read qualities (`aqhist`). '
@@ -161,10 +179,10 @@ file_types = {
         'help_text': '',
         'kvrows': ['Mean', 'Median', 'Mode', 'STDev'],
         'kv_descriptions': {
-            'Mean': 'Average GC content',
-            'Median': 'Median GC content',
-            'Mode': 'The most commonly occuring value of the GC content distribution',
-            'STDev': 'Standard deviation of average GC content'
+            'Mean': ('Average GC content', {}),
+            'Median': ('Median GC content', {}),
+            'Mode': ('The most commonly occuring value of the GC content distribution', {}),
+            'STDev': ('Standard deviation of average GC content', {}),
         },
         'cols': odict['GC':float, 'Count':int ],
         'plot_func': plot_basic_hist,
@@ -183,14 +201,14 @@ file_types = {
                    'Mode_reads', 'Mode_bases',
                    'STDev_reads', 'STDev_bases' ],
         'kv_descriptions': {
-            'Mean_reads': 'Average percent identity of aligned reads',
-            'Mean_bases': 'Average percent identity of aligned bases',
-            'Median_reads': 'Median percent identity of aligned reads',
-            'Median_bases': 'Median percent identity of aligned bases',
-            'Mode_reads': 'The most commonly occuring average value amongst aligned reads (i.e. the mode of the distribution)',
-            'Mode_bases': 'The most commonly occuring average value amongst aligned bases (i.e. the mode of the distribution)',
-            'STDev_reads': 'The standard deviation of the average percent identity distribution for aligned reads',
-            'STDev_bases': 'The standard deviation of the average percent identity distribution for aligned bases',
+            'Mean_reads': ('Average percent identity of aligned reads', {}),
+            'Mean_bases': ('Average percent identity of aligned bases', {}),
+            'Median_reads': ('Median percent identity of aligned reads', {}),
+            'Median_bases': ('Median percent identity of aligned bases', {}),
+            'Mode_reads': ('The most commonly occuring average value amongst aligned reads (i.e. the mode of the distribution)', {}),
+            'Mode_bases': ('The most commonly occuring average value amongst aligned bases (i.e. the mode of the distribution)', {}),
+            'STDev_reads': ('The standard deviation of the average percent identity distribution for aligned reads', {}),
+            'STDev_bases': ('The standard deviation of the average percent identity distribution for aligned bases', {}),
         },
         'cols': odict[
             'Identity':float, 'Reads':int, 'Bases':int
@@ -211,10 +229,10 @@ file_types = {
                      'shorter than the sum of the length of the reads pairs.',
         'kvrows': ['Mean', 'Median', 'STDev', 'PercentOfPairs'],
         'kv_descriptions': {
-            'Mean': 'Average insert length',
-            'Median': 'Median insert length',
-            'STDev': 'Standard deviation of insert size length distribution',
-            'PercentOfPairs': '',
+            'Mean': ('Average insert length', {}),
+            'Median': ('Median insert length', {}),
+            'STDev': ('Standard deviation of insert size length distribution', {}),
+            'PercentOfPairs': ('', {}),
         },
         'cols': odict['InsertSize':int, 'Count':int ],
         'plot_func': plot_ihist,
@@ -261,8 +279,8 @@ file_types = {
         'help_text': '',
         'kvrows': ['Deviation', 'DeviationSub' ],
         'kv_descriptions': {
-            'Deviation': '',
-            'DeviationSub': '',
+            'Deviation': ('', {}),
+            'DeviationSub': ('', {}),
         },
         'cols': odict[
             'Quality':int, 'Match':int, 'Sub':int, 'Ins':int, 'Del':int,
@@ -296,10 +314,10 @@ file_types = {
         'help_text': '',
         'kvrows': ['File', 'Reads', 'Mapped', 'RefSequences' ],
         'kv_descriptions': {
-            'File': '',
-            'Reads': '',
-            'Mapped': '',
-            'RefSequences': '',
+            'File': ('', {}),
+            'Reads': ('', {}),
+            'Mapped': ('', {}),
+            'RefSequences': ('', {}),
         },
         'cols': odict[
             'Name':str,

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -160,6 +160,7 @@ fn_clean_exts:
     - '_peaks.xls'
     - '.relatedness'
     - '.cnt'
+    - '.stats'
     - '.aqhist'
     - '.bhist'
     - '.bincov'

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -160,7 +160,6 @@ fn_clean_exts:
     - '_peaks.xls'
     - '.relatedness'
     - '.cnt'
-    - '.stats'
     - '.aqhist'
     - '.bhist'
     - '.bincov'
@@ -190,6 +189,7 @@ fn_clean_trim:
     - '_val'
     - '.idxstats'
     - '_trimmed'
+    - '.trimmed'
     - '.csv'
     - '.yaml'
     - '.yml'
@@ -201,6 +201,7 @@ fn_clean_trim:
     - '.align'
     - '.h5'
     - '_matrix'
+    - '.stats'
 
 # Files to ignore when indexing files.
 # Grep file match patterns.

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -10,6 +10,9 @@ afterqc:
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true
+bbmap/stats:
+    contents: '#Name	Reads	ReadsPct'
+    num_lines: 4
 bbmap/aqhist:
     contents: '#Quality	count1	fraction1	count2	fraction2'
     num_lines: 1


### PR DESCRIPTION
A few quick edits to include the BBDuk kmer-based adapter/contaminant filtering stats in a table. Includes two hidden columns with the observed counts that BBDuk uses internally to compute the proportion that is the only column this module shows for this filetype by default. Also added the extension '.stats' for stripping from filenames, as that is the most common file naming convention for this type of statistics output from BBDuk. 