### PR TITLE
QUAST: fix for --scaffolds; Always plot barplot

### DIFF
--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -262,8 +262,8 @@ class MultiqcModule(BaseMultiqcModule):
             nums_by_t = dict()
             for k, v in d.items():
                 m = re.match('# contigs \(>= (\d+) bp\)', k)
-                if m:
-                    nums_by_t[int(m.groups()[0])] = v
+                if m and v != '-':
+                    nums_by_t[int(m.groups()[0])] = int(v)
 
             tresholds = sorted(nums_by_t.keys(), reverse=True)
             p = dict()
@@ -279,9 +279,6 @@ class MultiqcModule(BaseMultiqcModule):
                     p[c] = nums_by_t[t] - nums_by_t[tresholds[i - 1]]
             if not categories:
                 categories = cats
-            elif set(cats) != set(categories):
-                log.warning("Different contig threshold categories for samples, skip plotting barplot".format(s_name))
-                continue
             data[s_name] = p
 
         pconfig = {


### PR DESCRIPTION
Fixing https://github.com/ewels/MultiQC/issues/719

Processing correctly the `-` placeholders in `report.tsv`.

Additionally, plotting the barplots even if the threshold categories are different - so we can always compare contigs and scaffolds. Plots are interpretable anyway even if for some sample a category is missing.