### PR TITLE
Set several modules too-global search patterns to share

### DIFF
--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -4,13 +4,15 @@
 
 adapterRemoval:
     fn: '*.settings'
-    shared: true
+    contents: 'AdapterRemoval'
+    num_lines: 1
 afterqc:
     fn: '*.json'
     contents: 'allow_mismatch_in_poly'
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true
+    num_lines: 2
 bbmap/stats:
     contents: '#Name	Reads	ReadsPct'
     num_lines: 4
@@ -112,7 +114,8 @@ bowtie2:
     shared: true
 busco:
     fn: 'short_summary_*'
-    shared: true
+    contents: 'BUSCO version is:'
+    num_lines: 1
 custom_content:
     fn_re: '.+_mqc\.(yaml|yml|json|txt|csv|tsv|log|out)'
 clipandmerge:
@@ -123,7 +126,8 @@ clusterflow/logs:
     shared: true
 clusterflow/runfiles:
     fn: '*.run'
-    shared: true
+    contents: 'Cluster Flow Run File'
+    num_lines: 2
 conpair/concordance:
     contents: 'markers (coverage per marker threshold : '
     num_lines: 3
@@ -344,7 +348,7 @@ rseqc/infer_experiment:
       max_filesize: 500000
 salmon/meta:
     fn: 'meta_info.json'
-    shared: true
+    contents: 'salmon_version'
 salmon/fld:
     fn: 'flenDist.txt'
 samblaster:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -4,9 +4,11 @@
 
 adapterRemoval:
     fn: '*.settings'
+    shared: true
 afterqc:
     fn: '*.json'
     contents: 'allow_mismatch_in_poly'
+    shared: true
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true
@@ -108,6 +110,7 @@ bowtie2:
     shared: true
 busco:
     fn: 'short_summary_*'
+    shared: true
 custom_content:
     fn_re: '.+_mqc\.(yaml|yml|json|txt|csv|tsv|log|out)'
 clipandmerge:
@@ -118,6 +121,7 @@ clusterflow/logs:
     shared: true
 clusterflow/runfiles:
     fn: '*.run'
+    shared: true
 conpair/concordance:
     contents: 'markers (coverage per marker threshold : '
     num_lines: 3
@@ -161,6 +165,7 @@ fastqc/theoretical_gc:
     fn: '*fastqc_theoretical_gc*'
 featurecounts:
     fn: '*.summary'
+    shared: true
 flexbar:
     contents: 'Flexbar - flexible barcode and adapter removal'
     shared: true
@@ -216,6 +221,7 @@ macs2:
     fn: '*_peaks.xls'
 methylQA:
     fn: '*.report'
+    shared: true
 disambiguate:
     contents: 'unique species A pairs'
     num_lines: 2
@@ -289,8 +295,10 @@ qualimap/rnaseq/coverage:
     fn: 'coverage_profile_along_genes_(total).txt'
 quast:
     fn: 'report.tsv'
+    shared: true
 rna_seqc/metrics:
     fn: 'metrics.tsv'
+    shared: true
 rna_seqc/coverage:
     fn_re: 'meanCoverageNorm_(high|medium|low)\.txt'
 rna_seqc/correlation:
@@ -322,6 +330,7 @@ rseqc/infer_experiment:
       max_filesize: 500000
 salmon/meta:
     fn: 'meta_info.json'
+    shared: true
 salmon/fld:
     fn: 'flenDist.txt'
 samblaster:
@@ -391,6 +400,7 @@ theta2:
     fn: '*.BEST.results'
 tophat:
     fn: '*align_summary.txt'
+    shared: true
 trimmomatic:
     contents: 'Trimmomatic'
     shared: true

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -8,7 +8,6 @@ adapterRemoval:
 afterqc:
     fn: '*.json'
     contents: 'allow_mismatch_in_poly'
-    shared: true
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true


### PR DESCRIPTION
Went over the search_patterns.yaml . 

Those modules which entries I thought too global had `shared: true` added to them in order to prevent them from incorectly claiming a file. Mostly these are entries with `fn` without any `content`.

This should reduce the number of times a module *eats* a log when it's search pattern had a false-positive hit. I don't think this will result in too much of a performance hit.

Cheers