### PR TITLE
Modified the clean_s_name function so that if the cleaned sample name become empty return the original file name

### DIFF
--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -174,6 +174,7 @@ class BaseMultiqcModule(object):
         :config.prepend_dirs: boolean, whether to prepend dir name to s_name
         :return: The cleaned sample name, ready to be used
         """
+        bak_name=s_name
         if root is None:
             root = ''
         if config.prepend_dirs:
@@ -216,6 +217,8 @@ class BaseMultiqcModule(object):
 
         # Remove trailing whitespace
         s_name = s_name.strip()
+        if s_name=='':
+            s_name=bak_name
 
         return s_name
 


### PR DESCRIPTION
I have a problem with the parsing of featurecounts summary. My bam  #files are named like that
``STAR/fastq/__ACTUAL_SAMPLE_NAME__.STAR/Aligned.sortedByCoord.out.ribo.ex.bam``
I found that ``clean_s_name `` in ``base_module.py`` convert this path to an empty sting, thus reporting only one record in the featurecounts plot.

I have introduced a workaround  that may be of general interest: just return the original file name if clean_s_name will convert this name in an empty string.