### PR TITLE
Move to GNU style option naming

### DIFF
--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -84,7 +84,7 @@ logger = config.logger
                     multiple = True,
                     help = "Use only modules which tagged with this keyword, eg. RNA"
 )
-@click.option( '--view_tags',
+@click.option( '--view-tags',
                     is_flag = True,
                     help = "View the available tags and which modules they load"
 )
@@ -157,7 +157,7 @@ logger = config.logger
                     multiple=True,
                     help = "Specific config file to load, after those in MultiQC dir / home dir / working dir."
 )
-@click.option('--cl_config',
+@click.option('--cl-config',
                     type = str,
                     multiple = True,
                     help = "Specify MultiQC config YAML on the command line"


### PR DESCRIPTION
Just noticed the options are mixed style between `_` and `-`. What about moving everything to GNU style options? 

See: https://www.gnu.org/prep/standards/standards.html#Option-Table

What do you think?