### PR TITLE
prepend_dirs config value getting clobbered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Many of these updates are thanks to the efforts of people who attended the [NASP
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.
 * Empty sample names from cleaning are now no longer allowed
+* Stop prepend_dirs set in the config from getting clobbered by an unpassed CLI option ([@tsnowlan](https://github.com/tsnowlan))
 
 
 ## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -231,7 +231,8 @@ plots_flat, plots_interactive, lint, make_pdf, config_file, cl_config, verbose, 
         config.title = title
     if report_comment is not None:
         config.report_comment = report_comment
-    config.prepend_dirs = dirs
+    if dirs is True:
+        config.prepend_dirs = dirs
     if dirs_depth is not None:
         config.prepend_dirs = True
         config.prepend_dirs_depth = dirs_depth


### PR DESCRIPTION
If setting `prepend_dirs` in config files, it will get clobbered here since `dirs` is only not False when `-d` is specified.

Also checking for an unset attr, just in case that causes an issue somewhere.