### PR TITLE
Make general stat work for custom content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Many of these updates are thanks to the efforts of people who attended the [NASP
     * Old underscore terms still maintained for backwards compatibility
 * Flag `--view-tags` now works without requiring an "analysis directory".
 * Removed Python dependency for `enum34` ([@boulund](https://github.com/boulund))
+* Columns can be added to `General Stats` table for custom content/module.
 
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -202,10 +202,12 @@ def custom_module_classes():
                         hs[k] = v
                 gsheaders = hs
 
-            # Add namespace if not specified
-            for k in gsheaders:
-                if 'namespace' not in gsheaders[k]:
-                    gsheaders[k]['namespace'] = c_id
+            # Add namespace and description if not specified
+            for h in gsheaders:
+                if 'namespace' not in gsheaders[h]:
+                    gsheaders[h]['namespace'] = mod['config'].get('namespace', k)
+                if 'description' not in gsheaders[k]:
+                    gsheaders[h]['description'] = mod['config'].get('description', "General stat for custom module {}".format(k))
 
             bm.general_stats_addcols(mod['data'], gsheaders)
 
@@ -399,6 +401,15 @@ def _parse_txt(f, conf):
                     first_row_str += 1
 
     all_numeric = all([ type(l) == float for l in d[i][1:] for i in range(1, len(d)) ])
+
+    # General stat info files - expected to be have atleast 2 rows (first row always being the header)
+    # and have atleast 2 columns (first column always being sample name)
+    if conf.get('plot_type') == 'generalstats' and len(d) >= 2 and ncols >= 2:
+        data = defaultdict(dict)
+        for i,l in enumerate(d[1:], 1):
+            for j,v in enumerate(l[1:], 1):
+                data[l[0]][d[0][j]] = v
+        return (data, conf)
 
     # Heatmap: Number of headers == number of lines
     if conf.get('plot_type') is None and first_row_str == len(lines) and all_numeric:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -191,8 +191,8 @@ def custom_module_classes():
                 headers = list(headers)
                 headers.sort()
                 gsheaders = OrderedDict()
-                for k in headers:
-                    gsheaders[k] = dict()
+                for h in headers:
+                    gsheaders[h] = dict()
 
             # Headers is a list of dicts
             if type(gsheaders) == list:
@@ -206,8 +206,6 @@ def custom_module_classes():
             for h in gsheaders:
                 if 'namespace' not in gsheaders[h]:
                     gsheaders[h]['namespace'] = mod['config'].get('namespace', k)
-                if 'description' not in gsheaders[k]:
-                    gsheaders[h]['description'] = mod['config'].get('description', "General stat for custom module {}".format(k))
 
             bm.general_stats_addcols(mod['data'], gsheaders)
 


### PR DESCRIPTION
If a `custom_content` need to be added in the _general stat_ table, now it would be possible with having a file in appropriate format