### PR TITLE
Kallisto fullpath samplename fix rescues -d or -dd option

### DIFF
--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -4,6 +4,7 @@
 
 from __future__ import print_function
 from collections import OrderedDict
+import os
 import logging
 import re
 

--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -54,7 +54,7 @@ class MultiqcModule(BaseMultiqcModule):
             # Get input filename
             match = re.search(r'\[quant\] will process (pair|file) 1: (\S+)', l)
             if match:
-                s_name = self.clean_s_name(match.group(2), f['root'])
+                s_name = self.clean_s_name(os.path.basename(match.group(2)), f['root'])
 
             if s_name is not None:
                 # Alignment rates


### PR DESCRIPTION
Given that the sample_name from kallisto stdout contains a full path and -d is used:

base_module.clean_s_name at line:
``s_name = os.path.basename(s_name.split(ext['pattern'], 1)[0])``
will discard any prior directories for naming

example: 
```bash 
BEFORE: "compare-refs | kallisto_all_rf_test | /compare-refs/kallisto_all_rf_test/myname.fastq.gz"
AFTER: "myname.fastq.gz"
```
This is mitgated by using os.path.basename on the s_name.match  
