### PR TITLE
Fix linegraph and scatter plots data conversion to work with data_labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 * Stop prepend_dirs set in the config from getting clobbered by an unpassed CLI option ([@tsnowlan](https://github.com/tsnowlan))
 * Modules running multiple times now have multiple sets of columns in the General Statistics table again, instead of overwriting one another.
 * Prevent tables from clobbering sorted row orders.
+* Fix linegraph and scatter plots data conversion (sporadically the incorrect `ymax` was used to drop data points) ([@cpavanrun](https://github.com/cpavanrun))
 
 
 ## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -80,12 +80,19 @@ def plot (data, pconfig=None):
 
     # Generate the data dict structure expected by HighCharts series
     plotdata = list()
-    for d in data:
+    for data_index, d in enumerate(data):
         thisplotdata = list()
+
         for s in sorted(d.keys()):
+
+            # Ensure any overwritting conditionals from data_labels (e.g. ymax) are taken in consideration
+            series_config = pconfig.copy()
+            if 'data_labels' in pconfig and type(pconfig['data_labels'][data_index]) is dict:  # if not a dict: only dataset name is provided
+                series_config.update(pconfig['data_labels'][data_index])
+
             pairs = list()
             maxval = 0
-            if 'categories' in pconfig:
+            if 'categories' in series_config:
                 pconfig['categories'] = list()
                 for k in d[s].keys():
                     pconfig['categories'].append(k)
@@ -94,24 +101,24 @@ def plot (data, pconfig=None):
             else:
                 for k in sorted(d[s].keys()):
                     if k is not None:
-                        if 'xmax' in pconfig and float(k) > float(pconfig['xmax']):
+                        if 'xmax' in series_config and float(k) > float(series_config['xmax']):
                             continue
-                        if 'xmin' in pconfig and float(k) < float(pconfig['xmin']):
+                        if 'xmin' in series_config and float(k) < float(series_config['xmin']):
                             continue
                     if d[s][k] is not None:
-                        if 'ymax' in pconfig and float(d[s][k]) > float(pconfig['ymax']):
+                        if 'ymax' in series_config and float(d[s][k]) > float(series_config['ymax']):
                             continue
-                        if 'ymin' in pconfig and float(d[s][k]) < float(pconfig['ymin']):
+                        if 'ymin' in series_config and float(d[s][k]) < float(series_config['ymin']):
                             continue
                     pairs.append([k, d[s][k]])
                     try:
                         maxval = max(maxval, d[s][k])
                     except TypeError:
                         pass
-            if maxval > 0 or pconfig.get('hide_empty') is not True:
+            if maxval > 0 or series_config.get('hide_empty') is not True:
                 this_series = { 'name': s, 'data': pairs }
                 try:
-                    this_series['color'] = pconfig['colors'][s]
+                    this_series['color'] = series_config['colors'][s]
                 except:
                     pass
                 thisplotdata.append(this_series)

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -26,21 +26,26 @@ def plot (data, pconfig=None):
 
     # Generate the data dict structure expected by HighCharts series
     plotdata = list()
-    for ds in data:
+    for data_index, ds in enumerate(data):
         d = list()
         for s_name in ds:
+            # Ensure any overwritting conditionals from data_labels (e.g. ymax) are taken in consideration
+            series_config = pconfig.copy()
+            if 'data_labels' in pconfig and type(pconfig['data_labels'][data_index]) is dict:  # if not a dict: only dataset name is provided
+                series_config.update(pconfig['data_labels'][data_index])
+
             if type(ds[s_name]) is not list:
                 ds[s_name] = [ ds[s_name] ]
             for k in ds[s_name]:
                 if k['x'] is not None:
-                    if 'xmax' in pconfig and float(k['x']) > float(pconfig['xmax']):
+                    if 'xmax' in series_config and float(k['x']) > float(series_config['xmax']):
                         continue
-                    if 'xmin' in pconfig and float(k['x']) < float(pconfig['xmin']):
+                    if 'xmin' in series_config and float(k['x']) < float(series_config['xmin']):
                         continue
                 if k['y'] is not None:
-                    if 'ymax' in pconfig and float(k['y']) > float(pconfig['ymax']):
+                    if 'ymax' in series_config and float(k['y']) > float(series_config['ymax']):
                         continue
-                    if 'ymin' in pconfig and float(k['y']) < float(pconfig['ymin']):
+                    if 'ymin' in series_config and float(k['y']) < float(series_config['ymin']):
                         continue
                 this_series = { 'x': k['x'], 'y': k['y'] }
                 try:
@@ -51,7 +56,7 @@ def plot (data, pconfig=None):
                     this_series['color'] = k['color']
                 except KeyError:
                     try:
-                        this_series['color'] = pconfig['colors'][s_name]
+                        this_series['color'] = series_config['colors'][s_name]
                     except KeyError:
                         pass
                 d.append(this_series)


### PR DESCRIPTION
Fixes #766 by making sure that any labels set in data_label overwrite those set in pconfig when converting the data holding dictionaries to a format that HighCharts can handle.

This is now the case for both `linegraph` and `scatter`. The rest of the plots didn't really seem to use any data-conversions based on `pconfig` content.

Cheers,
Chris