### PR TITLE
Add ignore-symlinks flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 * Flag `--view-tags` now works without requiring an "analysis directory".
 * Removed Python dependency for `enum34` ([@boulund](https://github.com/boulund))
 * Columns can be added to `General Stats` table for custom content/module.
+* New `--ignore-links` flag which will ignore (sym)linked directories and files.
 
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 * Flag `--view-tags` now works without requiring an "analysis directory".
 * Removed Python dependency for `enum34` ([@boulund](https://github.com/boulund))
 * Columns can be added to `General Stats` table for custom content/module.
-* New `--ignore-links` flag which will ignore (sym)linked directories and files.
+* New `--ignore-symlinks` flag which will ignore symlinked directories and files.
 
 #### Bug Fixes
 * Fix path_filters for top_modules/module_order configuration only selecting if *all* globs match. It now filters searches that match *any* glob.

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -33,12 +33,12 @@ data_dir_name: 'multiqc_data'
 plots_dir_name: 'multiqc_plots'
 data_format: 'tsv'
 module_tag: []
-
 force: false
 prepend_dirs: false
 prepend_dirs_depth: 0
 prepend_dirs_sep: ' | '
 file_list: false
+
 make_data_dir: true
 zip_data_dir: false
 data_dump_file: true
@@ -76,6 +76,7 @@ thousandsSep_format: null
 section_comments: {}
 lint: False
 
+ignore_symlinks: false
 fn_ignore_dirs:
     - 'multiqc_data'
     - 'icarus_viewers'       # quast

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -147,10 +147,12 @@ def get_filelist(run_module_names):
 
     # Go through the analysis directories and get file list
     for path in config.analysis_dir:
-        if os.path.isfile(path):
+        if os.path.islink(path) and config.ignore_symlinks:
+            continue
+        elif os.path.isfile(path):
             searchfiles.append([os.path.basename(path), os.path.dirname(path)])
         elif os.path.isdir(path):
-            for root, dirnames, filenames in os.walk(path, followlinks=True, topdown=True):
+            for root, dirnames, filenames in os.walk(path, followlinks=(not config.ignore_symlinks), topdown=True):
                 bname = os.path.basename(root)
 
                 # Skip any sub-directories matching ignore params

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -101,6 +101,10 @@ logger = config.logger
                     multiple = True,
                     help = "Ignore sample names (glob expression)"
 )
+@click.option('--ignore-symlinks', 'ignore_symlinks',
+                    is_flag = True,
+                    help = "Ignore symlinked directories and files"
+)
 @click.option('--sample-names', 'sample_names',
                     type = click.Path(exists=True, readable=True),
                     help = "File containing alternative sample names"
@@ -177,8 +181,8 @@ logger = config.logger
 @click.version_option(__version__)
 
 def multiqc(analysis_dir, dirs, dirs_depth, no_clean_sname, title, report_comment, template, module_tag, module, exclude, outdir,
-ignore, ignore_samples, sample_names, file_list, filename, make_data_dir, no_data_dir, data_format, zip_data_dir, force, export_plots,
-plots_flat, plots_interactive, lint, make_pdf, config_file, cl_config, verbose, quiet, **kwargs):
+ignore, ignore_samples, sample_names, file_list, filename, make_data_dir, no_data_dir, data_format, zip_data_dir, force, ignore_symlinks,
+export_plots, plots_flat, plots_interactive, lint, make_pdf, config_file, cl_config, verbose, quiet, **kwargs):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
 
         It searches a given directory for analysis logs and compiles a HTML report.
@@ -248,6 +252,8 @@ plots_flat, plots_interactive, lint, make_pdf, config_file, cl_config, verbose, 
         config.make_data_dir = False
     if force:
         config.force = True
+    if ignore_symlinks:
+        config.ignore_symlinks = True
     if zip_data_dir:
         config.zip_data_dir = True
     if data_format is not None:


### PR DESCRIPTION
Hej @ewels,

This PR contains a discussed feature to have MultiQC ignore symlinked directories and files when flagged with `--ignore-symlinks`.

This should help speed up some ppl's MultiQC directory scans (mine anyway).

Cheers,
Chris