### PR TITLE
Add mean and sd of WGScoverage to general stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
     * New plot showing sex checks versus het ratios ([@oyvinev](https://github.com/oyvinev))
 * **Picard**
     * New submodule to handle `ValidateSamFile` reports ([@cpavanrun](https://github.com/cpavanrun))
+    * WGSMetrics now add the mean and standard-deviation coverage to the general stats table (hidden) ([@cpavanrun](https://github.com/cpavanrun))
 * **QUAST**
     * Null values (`-`) in reports now handled properly. Bargraphs always shown despite varying thresholds. ([@vladsaveliev](https://github.com/vladsaveliev))
 * **RNA-SeQC**

--- a/multiqc/modules/picard/WgsMetrics.py
+++ b/multiqc/modules/picard/WgsMetrics.py
@@ -96,7 +96,22 @@ def parse_reports(self):
             'suffix': 'X',
             'scale': 'GnBu',
         }
-
+        self.general_stats_headers['MEAN_COVERAGE'] = {
+            'title': 'Mean Coverage',
+            'description': 'The mean coverage in bases of the genome territory, after all filters are applied.',
+            'min': 0,
+            'suffix': 'X',
+            'scale': 'GnBu',
+            'hidden': True,
+        }
+        self.general_stats_headers['SD_COVERAGE'] = {
+            'title': 'Median Coverage',
+            'description': 'The standard deviation coverage in bases of the genome territory, after all filters are applied.',
+            'min': 0,
+            'suffix': 'X',
+            'scale': 'GnBu',
+            'hidden': True,
+        }
         # user configurable coverage level
         try:
             covs = config.picard_config['general_stats_target_coverage']


### PR DESCRIPTION
By default these stats are hidden. In practice we tend to end up diving into the actual metrics file to find these two stats.

Also mention the changes in changelog

Cheers,
Chris