### PR TITLE
Peddy: add suffixes to multi-file headers

### DIFF
--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -164,7 +164,7 @@ class MultiqcModule(BaseMultiqcModule):
             'title': 'Ancestry',
             'description': 'Ancestry Prediction',
         }
-        headers['ancestry-prob'] = {
+        headers['ancestry-prob_het_check'] = {
             'title': 'P(Ancestry)',
             'description': 'Probability predicted ancestry is correct.'
         }
@@ -175,7 +175,7 @@ class MultiqcModule(BaseMultiqcModule):
             'title': 'Correct Sex',
             'description': 'Displays False if error in sample sex prediction',
         }
-        headers['predicted_sex'] = {
+        headers['predicted_sex_sex_check'] = {
             'title': 'Sex',
             'description': 'Predicted sex'
         }


### PR DESCRIPTION
In doing more Peddy testing I discovered some missing columns from the main table due to naming mismatches. This fixes those and gets all the improvements in development for peddy working.

Peddy input files have duplicated columns, so the combined inputs get
file specific suffixes. Two of the main stats table columns were missing
because the header did not match the suffixed column name. This fixes to
include these.
