### PR TITLE
VerifyBamID: fix column headers for contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
     * Fixed edge case bug where MultiQC could crash if a sample had zero count coverage with idxstats.
 * **Tophat**
     * Fixed bug where some samples could be given a blank sample name ([@lparsons](https://github.com/lparsons))
+* **VerifyBamID**
+    * Change column header help text for contamination to match percentage output ([@chapmanb](https://github.com/chapmanb))
 
 #### New MultiQC Features:
 * Add `path_filters_exclude` to exclude certain files when running modules multiple times. You could previously only include certain files.

--- a/multiqc/modules/verifybamid/verifybamid.py
+++ b/multiqc/modules/verifybamid/verifybamid.py
@@ -128,13 +128,13 @@ class MultiqcModule(BaseMultiqcModule):
 		if not self.hide_chip_columns:
 			headers['CHIPMIX'] = dict(self.col_config_defaults, **{
 				'title': 'Contamination (S+A)',
-				'description': 'VerifyBamID: CHIPMIX -   Sequence+array estimate of contamination (NA if the external genotype is unavailable) (0-1 scale)'
+				'description': 'VerifyBamID: CHIPMIX -   Sequence+array estimate of contamination (NA if the external genotype is unavailable)'
 			})
 
 		# add the FREEMIX column. set the title and description
 		headers['FREEMIX'] = dict(self.col_config_defaults, **{
 			'title': 'Contamination (S)',
-			'description': 'VerifyBamID: FREEMIX -   Sequence-only estimate of contamination (0-1 scale).',
+			'description': 'VerifyBamID: FREEMIX -   Sequence-only estimate of contamination.',
 		})
 
 		# pass the data dictionary and header dictionary to function to add to table.
@@ -185,7 +185,7 @@ class MultiqcModule(BaseMultiqcModule):
 		# use default columns
 		headers['FREEMIX'] = dict(self.col_config_defaults, **{
 			'title': 'Contamination (Seq)',
-			'description': 'VerifyBamID: FREEMIX -   Sequence-only estimate of contamination (0-1 scale).',
+			'description': 'VerifyBamID: FREEMIX -   Sequence-only estimate of contamination.',
 		})
 		headers['FREELK1'] = {
 			'title': 'FREEELK1',
@@ -216,7 +216,7 @@ class MultiqcModule(BaseMultiqcModule):
 		if not self.hide_chip_columns:
 			headers['CHIPMIX'] = dict(self.col_config_defaults, **{
 				'title': 'Contamination S+A',
-				'description': 'VerifyBamID: CHIPMIX -   Sequence+array estimate of contamination (NA if the external genotype is unavailable) (0-1 scale)'
+				'description': 'VerifyBamID: CHIPMIX -   Sequence+array estimate of contamination (NA if the external genotype is unavailable)'
 			})
 			headers['CHIPLK1'] = {
 				'title': 'CHIPLK1',


### PR DESCRIPTION
Column headers currently report contamination as a 0-1 range, which it's
actually displayed as a percentage. This removes that mention in the
header pop up, allowing users to infer from the actual percent values.

![multiqc-contamination](https://user-images.githubusercontent.com/39391/42332265-8bd7ab82-8045-11e8-99e1-2d7993316f76.png)

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated