### PR TITLE
Fix directories in file-list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - python -m unittest discover
   - multiqc data --ignore data/modules/
   - multiqc --lint data/modules/
+  - multiqc --file-list data/special_cases/dir_list.txt
   - multiqc --lint data/modules/ -m fastqc -f -d -dd 1 -i "Forced Report" -b "This command has lots of options" --filename custom_fn --no-data-dir
   - multiqc --lint data/modules/ -f --flat --tag methylation --exclude clusterflow --ignore-samples ngi --fullnames --zip-data-dir -c ../multiqc_config_example.yaml
   - multiqc -m star -o tests/multiqc_report_dev -t default_dev -k json --file-list data/special_cases/file_list.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 #### Bug Fixes:
 * Custom content no longer clobbers `col1_header` table configs
-
+* The option `--file-list` that refers to a text file with file paths to analyse will no longer ignore directory paths
+   
 ## [MultiQC v1.6](https://github.com/ewels/MultiQC/releases/tag/v1.6) - 2018-08-04
 
 Some of these updates are thanks to the efforts of people who attended the [NASPM](https://twitter.com/NordicGenomics) 2018 MultiQC hackathon session. Thanks to everyone who attended!

--- a/scripts/multiqc
+++ b/scripts/multiqc
@@ -303,11 +303,11 @@ export_plots, plots_flat, plots_interactive, lint, make_pdf, no_megaqc_upload, c
             for line in in_handle:
                 if os.path.exists(line.strip()):
                     path = os.path.abspath(line.strip())
-                    report.searchfiles.append([os.path.basename(path), os.path.dirname(path)])
-        if len(report.searchfiles) == 0:
-            logger.error("No files were added from {} using --file-list option.".format(analysis_dir[0]))
-            logger.error("Please, check that {} contains correct file paths.".format(analysis_dir[0]))
-            raise ValueError("Any files to be searched.")
+                    config.analysis_dir.append(path)
+        if len(config.analysis_dir) == 0:
+            logger.error("No files or directories were added from {} using --file-list option.".format(analysis_dir[0]))
+            logger.error("Please, check that {} contains correct paths.".format(analysis_dir[0]))
+            raise ValueError("Any files or directories to be searched.")
 
     if len(ignore) > 0:
         logger.debug("Ignoring files, directories and paths that match: {}".format(", ".join(ignore)))


### PR DESCRIPTION
Makes the `file-list` option also parse directory paths. (Currently ignores them)

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated
 - [X] https://github.com/ewels/MultiQC_TestData contains test data for this change
