### PR TITLE
QualiMap RNAseq: fix parsing integer 5'/3' bias

### DIFF
--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -24,7 +24,7 @@ def parse_reports(self):
         'reads_aligned_genes': r"aligned to genes\s*=\s*([\d,]+)",
         'ambiguous_alignments': r"ambiguous alignments\s*=\s*([\d,]+)",
         'not_aligned': r"not aligned\s*=\s*([\d,]+)",
-        '5_3_bias': r"5'-3' bias\s*=\s*(\d+\.\d+)",
+        '5_3_bias': r"5'-3' bias\s*=\s*([\d,\.]+)$",
         'reads_aligned_exonic': r"exonic\s*=\s*([\d,]+)",
         'reads_aligned_intronic': r"intronic\s*=\s*([\d,]+)",
         'reads_aligned_intergenic': r"intergenic\s*=\s*([\d,]+)",


### PR DESCRIPTION
Regex to parse 5'/3' bias presumes it's a value with a decimal point. However when the result is exact integer, it will be written by QualiMap without decimal points, failing MultiQC to parse it:

```
>>>>>>> Transcript coverage profile

    5' bias = 0.74
    3' bias = 0.71
    5'-3' bias = 1
```

Fixing to support such edge cases as well.