### PR TITLE
Add read_count_multiplier functionality to flagstat plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 _..no updates yet.._
 
 #### Module updates:
-_..no updates yet.._
+* **Samtools**
+    * Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely 
 
 #### New MultiQC Features:
 _..no updates yet.._

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -52,7 +52,7 @@ class FlagstatReportMixin():
             reads = {
                 'min': 0,
                 'modify': lambda x: float(x) * config.read_count_multiplier,
-                'suffix': 'M reads',
+                 'suffix': '{} reads'.format(config.read_count_prefix),
                 'decimalPlaces': 2,
                 'shared_key': 'read_count'
             }

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -51,7 +51,7 @@ class FlagstatReportMixin():
             keys = OrderedDict()
             reads = {
                 'min': 0,
-                'modify': lambda x: float(x) / 1000000.0,
+                'modify': lambda x: float(x) * config.read_count_multiplier,
                 'suffix': 'M reads',
                 'decimalPlaces': 2,
                 'shared_key': 'read_count'


### PR DESCRIPTION
This should address https://github.com/ewels/MultiQC/issues/881 

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated

