### PR TITLE
Replace inf values with nan in vcftools tstv by qual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
     * Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 * **SnpEff**
     * Increased the default summary csv file-size limit from 1MB to 5MB.
+* **VCFTools**
+    * Fixed a bug where `tstv_by_qual.py` produced invalid json from infinity-values.
 
 #### New MultiQC Features:
 _..no updates yet.._
@@ -19,7 +21,6 @@ _..no updates yet.._
 #### Bug Fixes:
 * MultiQC now ignores all `.md5` files
 * Added some installation docs for windows
-
 
 
 

--- a/multiqc/modules/vcftools/tstv_by_qual.py
+++ b/multiqc/modules/vcftools/tstv_by_qual.py
@@ -19,6 +19,8 @@ class TsTvByQualMixin():
             for line in f['f'].readlines()[1:]: # don't add the header line (first row)
                 key = float(line.split()[0]) # taking the first column (QUAL_THRESHOLD) as key
                 val = float(line.split()[6]) # taking Ts/Tv_GT_QUAL_THRESHOLD as value
+                if (val == float('inf')) or (val == float('-inf')):
+                    val = float('nan')
                 d[key] = val
             self.vcftools_tstv_by_qual[f['s_name']] = d
 


### PR DESCRIPTION
Check and replace `inf` and `-inf` values to avoid javascript `json.parase` failure as reported in #894.

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change
