### PR TITLE
Support opening MultiQC on websites with CSP `script-src 'self'` with some sha256 exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
     * New base image `czentye/matplotlib-minimal` reduces image size from ~200MB to ~80MB
     * Proper installation method ensures latest version of the code
     * New entrypoint allows easier command-line usage
+* Support opening MultiQC on websites with CSP `script-src 'self'` with some sha256 exceptions
+    * Plot data is no longer intertwined with javascript code so hashes stay the same
 
 #### Bug Fixes:
 * MultiQC now ignores all `.md5` files

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -161,37 +161,41 @@ class MultiqcModule(BaseMultiqcModule):
                     td['linkedTo'] = ':previous'
                 data.append(td)
 
-        html = '<div id="fq_screen_plot" class="hc-plot"></div> \n\
-        <script type="text/javascript"> \n\
-            fq_screen_data = {};\n\
-            fq_screen_categories = {};\n\
-            $(function () {{ \n\
-                $("#fq_screen_plot").highcharts({{ \n\
-                    chart: {{ type: "column", backgroundColor: null }}, \n\
-                    title: {{ text: "FastQ Screen Results" }}, \n\
-                    xAxis: {{ categories: fq_screen_categories }}, \n\
-                    yAxis: {{ \n\
-                        max: 100, \n\
-                        min: 0, \n\
-                        title: {{ text: "Percentage Aligned" }} \n\
-                    }}, \n\
-                    tooltip: {{ \n\
-                        formatter: function () {{ \n\
-                            return "<b>" + this.series.stackKey.replace("column","") + " - " + this.x + "</b><br/>" + \n\
-                                this.series.name + ": " + this.y + "%<br/>" + \n\
-                                "Total Alignment: " + this.point.stackTotal + "%"; \n\
-                        }}, \n\
-                    }}, \n\
-                    plotOptions: {{ \n\
-                        column: {{ \n\
-                            pointPadding: 0, \n\
-                            groupPadding: 0.02, \n\
-                            stacking: "normal" }} \n\
-                    }}, \n\
-                    series: fq_screen_data \n\
-                }}); \n\
-            }}); \n\
-        </script>'.format(json.dumps(data), json.dumps(categories))
+        html = '''<div id="fq_screen_plot" class="hc-plot"></div>
+        <script type="text/javascript">
+            fq_screen_data = {};
+            fq_screen_categories = {};
+        </script>'''.format(json.dumps(data), json.dumps(categories))
+
+        html += '''<script type="text/javascript">
+            $(function () {
+                $("#fq_screen_plot").highcharts({
+                    chart: { type: "column", backgroundColor: null },
+                    title: { text: "FastQ Screen Results" },
+                    xAxis: { categories: fq_screen_categories },
+                    yAxis: {
+                        max: 100,
+                        min: 0,
+                        title: { text: "Percentage Aligned" }
+                    },
+                    tooltip: {
+                        formatter: function () {
+                            return "<b>" + this.series.stackKey.replace("column","") + " - " + this.x + "</b><br/>" +
+                                this.series.name + ": " + this.y + "%<br/>" +
+                                "Total Alignment: " + this.point.stackTotal + "%";
+                        },
+                    },
+                    plotOptions: {
+                        column: {
+                            pointPadding: 0,
+                            groupPadding: 0.02,
+                            stacking: "normal"
+                        }
+                    },
+                    series: fq_screen_data
+                });
+            });
+        </script>'''
 
         return html
 

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -162,12 +162,14 @@ class MultiqcModule(BaseMultiqcModule):
                 data.append(td)
 
         html = '''<div id="fq_screen_plot" class="hc-plot"></div>
-        <script type="text/javascript">
-            fq_screen_data = {};
-            fq_screen_categories = {};
-        </script>'''.format(json.dumps(data), json.dumps(categories))
+        <script type="application/json" id="fq_screen_data">{}</script>
+        <script type="application/json" id="fq_screen_categories">{}</script>
+        '''.format(json.dumps(data), json.dumps(categories))
 
         html += '''<script type="text/javascript">
+            fq_screen_data = JSON.parse(document.getElementById('fq_screen_data').innerHTML);
+            fq_screen_categories = JSON.parse(document.getElementById('fq_screen_categories').innerHTML);
+
             $(function () {
                 $("#fq_screen_plot").highcharts({
                     chart: { type: "column", backgroundColor: null },

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -17,11 +17,19 @@ max_bp = 0;
 current_single_plot = undefined;
 
 fastqc_passfails = {}; // { <module>: { <section>: { <sample>: { data } } }
+fastqc_seq_content = {}; // { <module>: { <sample>: data } }
 
 function load_fastqc_passfails() {
     $('.fastqc_passfails').each(function (i, elem) {
         var key_value = JSON.parse(elem.innerHTML);
         fastqc_passfails[key_value[0]] = key_value[1];
+    });
+}
+
+function load_fastqc_seq_content() {
+    $('.fastqc_seq_content').each(function (i, elem) {
+        var key_value = JSON.parse(elem.innerHTML);
+        fastqc_seq_content[key_value[0]] = key_value[1];
     });
 }
 
@@ -33,7 +41,7 @@ function fastqc_seq_content_heatmap() {
     sample_statuses = [];
     var p_data = {};
     var hidden_samples = 0;
-    $.each(fastqc_seq_content_data, function(s_name, data){
+    $.each(fastqc_seq_content['fastqc'], function(s_name, data){
         // rename sample names
         var t_status = fastqc_passfails['fastqc']['per_base_sequence_content'][s_name];
         $.each(window.mqc_rename_f_texts, function(idx, f_text){
@@ -171,6 +179,8 @@ function fastqc_seq_content_heatmap() {
 
 // Set up listeners etc on page load
 $(function () {
+    load_fastqc_seq_content();
+    fastqc_seq_content_heatmap();
 
     // Go through each section in case FastQC is there multiple times
     $('.mqc-module-section').each(function(i){
@@ -315,7 +325,7 @@ $(function () {
     });
     $('#fastqc_per_base_sequence_content_plot').on('mqc_plotexport_data', function(e, cfg){
         if(cfg['ft'] == 'json'){
-            json_str = JSON.stringify(fastqc_seq_content_data, null, 2);
+            json_str = JSON.stringify(fastqc_seq_content['fastqc'], null, 2);
             var blob = new Blob([json_str], {type: "text/plain;charset=utf-8"});
             saveAs(blob, cfg['fname']);
         } else {
@@ -346,11 +356,11 @@ $(function () {
 
         // Update the key with the raw data for this position
         var hover_bp = Math.max(1, Math.floor((x/c_width)*max_bp));
-        var thispoint = fastqc_seq_content_data[s_name][hover_bp];
+        var thispoint = fastqc_seq_content['fastqc'][s_name][hover_bp];
         if(!thispoint){
             var nearestkey = 0;
             var guessdata = null;
-            $.each(fastqc_seq_content_data[s_name], function(bp, v){
+            $.each(fastqc_seq_content['fastqc'][s_name], function(bp, v){
                 bp = parseInt(bp);
                 if(bp < hover_bp && bp > nearestkey){
                     nearestkey = bp;
@@ -406,14 +416,14 @@ $(function () {
         current_single_plot = s_name;
         // Prep the new plot data
         var plot_data = [[],[],[],[]];
-        var bases = Object.keys(fastqc_seq_content_data[s_name]).sort(function (a, b) {  return a - b;  });
+        var bases = Object.keys(fastqc_seq_content['fastqc'][s_name]).sort(function (a, b) {  return a - b;  });
         for (i=0; i<bases.length; i++){
-          var base = fastqc_seq_content_data[s_name][bases[i]]['base'].toString().split('-');
+          var base = fastqc_seq_content['fastqc'][s_name][bases[i]]['base'].toString().split('-');
           base = parseFloat(base[0]);
-          plot_data[0].push([base, fastqc_seq_content_data[s_name][bases[i]]['t']]);
-          plot_data[1].push([base, fastqc_seq_content_data[s_name][bases[i]]['c']]);
-          plot_data[2].push([base, fastqc_seq_content_data[s_name][bases[i]]['a']]);
-          plot_data[3].push([base, fastqc_seq_content_data[s_name][bases[i]]['g']]);
+          plot_data[0].push([base, fastqc_seq_content['fastqc'][s_name][bases[i]]['t']]);
+          plot_data[1].push([base, fastqc_seq_content['fastqc'][s_name][bases[i]]['c']]);
+          plot_data[2].push([base, fastqc_seq_content['fastqc'][s_name][bases[i]]['a']]);
+          plot_data[3].push([base, fastqc_seq_content['fastqc'][s_name][bases[i]]['g']]);
         }
         // Update the chart
         var hc = $('#fastqc_sequence_content_single').highcharts();
@@ -444,7 +454,7 @@ $(function () {
 
 function plot_single_seqcontent(s_name){
   current_single_plot = s_name;
-  var data = fastqc_seq_content_data[s_name];
+  var data = fastqc_seq_content['fastqc'][s_name];
   var plot_data = [
     {'name': '% T', 'data':[]},
     {'name': '% C', 'data':[]},

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -182,19 +182,15 @@ $(function () {
     load_fastqc_seq_content();
     fastqc_seq_content_heatmap();
 
-    // Go through each section in case FastQC is there multiple times
-    $('.mqc-module-section').each(function(i){
 
-        // Skip this module if it's not FastQC
-        if(!$(this).attr('id').startsWith('mqc-module-section-fastqc')){
-            return true;
-        }
+    // Go through each FastQC module in case there are multiple
+    $('.mqc-module-section[id^="mqc-module-section-fastqc"]').each(function(){
+        var module_element = this;
+        var parent_id = $(module_element).attr('id');
+        var module_key = parent_id.replace(/-/g, '_').replace('mqc_module_section_', '');
 
         // Add the pass / warning / fails counts to each of the FastQC submodule headings
-        var parent_id = $(this).attr('id');
-        var module_key = parent_id.replace(/-/g, '_').replace('mqc_module_section_', '');
         $.each(fastqc_passfails[module_key], function(k, vals){
-            var pid = '#'+parent_id+' [id^=fastqc_'+k+']';
             var total = 0;
             var v = { 'pass': 0, 'warn': 0, 'fail': 0 };
             $.each(vals, function(s_name, status){
@@ -206,7 +202,7 @@ $(function () {
                 <div class="progress-bar progress-bar-warning" style="width: '+(v['warn']/total)*100+'%" title="'+v['warn']+'&nbsp;/&nbsp;'+total+' samples with warnings">'+v['warn']+'</div> \
                 <div class="progress-bar progress-bar-danger" style="width: '+(v['fail']/total)*100+'%" title="'+v['fail']+'&nbsp;/&nbsp;'+total+' samples failed">'+v['fail']+'</div> \
             </div>';
-            $(pid).first().append(p_bar);
+            $(module_element).find('[id^=fastqc_'+k+']').first().append(p_bar);
         });
     });
 

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -16,6 +16,15 @@ ypos = 0;
 max_bp = 0;
 current_single_plot = undefined;
 
+fastqc_passfails = {}; // { <module>: { <section>: { <sample>: { data } } }
+
+function load_fastqc_passfails() {
+    $('.fastqc_passfails').each(function (i, elem) {
+        var key_value = JSON.parse(elem.innerHTML);
+        fastqc_passfails[key_value[0]] = key_value[1];
+    });
+}
+
 // Function to plot heatmap
 function fastqc_seq_content_heatmap() {
 
@@ -26,7 +35,7 @@ function fastqc_seq_content_heatmap() {
     var hidden_samples = 0;
     $.each(fastqc_seq_content_data, function(s_name, data){
         // rename sample names
-        var t_status = fastqc_passfails_fastqc['per_base_sequence_content'][s_name];
+        var t_status = fastqc_passfails['fastqc']['per_base_sequence_content'][s_name];
         $.each(window.mqc_rename_f_texts, function(idx, f_text){
             if(window.mqc_rename_regex_mode){
                 var re = new RegExp(f_text,'g');
@@ -173,8 +182,8 @@ $(function () {
 
         // Add the pass / warning / fails counts to each of the FastQC submodule headings
         var parent_id = $(this).attr('id');
-        var fastqc_passfails = window['fastqc_passfails_'+parent_id.replace(/-/g, '_').replace('mqc_module_section_', '')];
-        $.each(fastqc_passfails, function(k, vals){
+        var module_key = parent_id.replace(/-/g, '_').replace('mqc_module_section_', '');
+        $.each(fastqc_passfails[module_key], function(k, vals){
             var pid = '#'+parent_id+' [id^=fastqc_'+k+']';
             var total = 0;
             var v = { 'pass': 0, 'warn': 0, 'fail': 0 };
@@ -196,15 +205,15 @@ $(function () {
         // Does this element already have a popover?
         if ($(this).attr('data-original-title')) { return false; }
         // Get data target
-        var parent_id = $(this).closest('.mqc-module-section').attr('id').replace(/-/g, '_').replace('mqc_module_section_', '');
-        var fastqc_passfails = window['fastqc_passfails_'+parent_id.replace(/-/g, '_').replace('mqc_module_section_', '')];
+        var parent_id = $(this).closest('.mqc-module-section').attr('id');
+        var module_key = parent_id.replace(/-/g, '_').replace('mqc_module_section_', '');
         // Create it
         var pid = $(this).closest('h3').attr('id');
         var k = pid.substr(7);
         // Remove suffix when there are multiple fastqc sections
         var n = k.indexOf('-');
         k = k.substring(0, n != -1 ? n : k.length);
-        var vals = fastqc_passfails[k];
+        var vals = fastqc_passfails[module_key][k];
         var passes = $(this).hasClass('progress-bar-success') ? true : false;
         var warns = $(this).hasClass('progress-bar-warning') ? true : false;
         var fails = $(this).hasClass('progress-bar-danger') ? true : false;

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -100,7 +100,9 @@ class MultiqcModule(BaseMultiqcModule):
                     statuses[section][s_name] = status
                 except KeyError:
                     statuses[section] = {s_name: status}
-        self.intro += '<script type="text/javascript">fastqc_passfails_{} = {};</script>'.format(self.anchor.replace('-','_'), json.dumps(statuses))
+        self.intro += '<script type="application/json" class="fastqc_passfails">{}</script>'.format(json.dumps([self.anchor.replace('-', '_'), statuses ]))
+
+        self.intro += '<script type="text/javascript">load_fastqc_passfails();</script>'
 
         # Now add each section in order
         self.read_count_plot()

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -459,10 +459,8 @@ class MultiqcModule(BaseMultiqcModule):
             </div>
             <div class="clearfix"></div>
         </div>
-        <script type="text/javascript">
-            fastqc_seq_content_data = {d};
-            $(function () {{ fastqc_seq_content_heatmap(); }});
-        </script>'''.format(d=json.dumps(data))
+        <script type="application/json" class="fastqc_seq_content">{d}</script>
+        '''.format(d=json.dumps([self.anchor.replace('-', '_'), data]))
 
         self.add_section (
             name = 'Per Base Sequence Content',

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -65,7 +65,7 @@ $(function () {
   $('.hc-plot.not_rendered:visible:not(.gt_max_num_ds)').each(function(){
     var target = $(this).attr('id');
     // Only one point per dataset, so multiply limit by arbitrary number.
-    var max_num = num_datasets_plot_limit * 50;
+    var max_num = mqc_config['num_datasets_plot_limit'] * 50;
     // Deferring each plot call prevents browser from locking up
     setTimeout(function(){
         plot_graph(target, undefined, max_num);

--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -25,9 +25,9 @@ $(function () {
     if(j == 0){
       apply_mqc_renamesamples();
     } else {
-      for(i=0; i<mqc_sample_names_rename.length; i++){
-        var ft = mqc_sample_names_rename[i][0];
-        var tt = mqc_sample_names_rename[i][j];
+      for(i=0; i<mqc_config['sample_names_rename'].length; i++){
+        var ft = mqc_config['sample_names_rename'][i][0];
+        var tt = mqc_config['sample_names_rename'][i][j];
         $('#mqc_renamesamples_filters').append('<li class="mqc_sname_switches_li"> \
           <input class="f_text from_text" value="'+ft+'" /><small class="glyphicon glyphicon-chevron-right"></small><input class="f_text to_text" value="'+tt+'" /> \
           <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button> \
@@ -57,7 +57,7 @@ $(function () {
   $(document).on('mqc_config_loaded', function(e){
     $('.hc-plot').each(function(){
       var target = $(this).attr('id');
-      plot_graph(target, undefined, num_datasets_plot_limit);
+      plot_graph(target, undefined, mqc_config['num_datasets_plot_limit']);
     });
   });
 

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -16,14 +16,26 @@ page contents, it's machine-readable tags for browsers and search engines.
 <title>{{ config.title + ': ' if config.title != None }}MultiQC Report</title>
 
 <!-- JSON plot data -->
-<script type="text/javascript">
-mqc_compressed_plotdata = '{{ report.plot_compressed_json }}';
-num_datasets_plot_limit = {{ config.num_datasets_plot_limit}};
-mqc_sample_names_rename = {{ config.sample_names_rename | tojson }};
-</script>
+<script type="text/plain" id="mqc_compressed_plotdata">{{ report.plot_compressed_json }}</script>
 
+<script type="application/json" id="mqc_config">{{
+{
+    "num_datasets_plot_limit": config.num_datasets_plot_limit,
+    "sample_names_rename": config.sample_names_rename,
+    "decimalPoint_format": config.decimalPoint_format,
+    "thousandsSep_format": config.thousandsSep_format,
+} | tojson
+}}</script>
+
+<!-- Instead of saving data directly into variables in a normal <script>, data is separated into
+     above non-executed script blocks. This way, potential Content Security Policy restrictions
+     only apply to static script blocks, which can be added as sha256 exceptions.
+
+     As a precaution the script is wrapped in raw block to remind developers that data should
+     not be injected directly into it. -->
+{% raw %}
 <script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
+mqc_compressed_plotdata = document.getElementById('mqc_compressed_plotdata').innerHTML;
+mqc_config = JSON.parse(document.getElementById('mqc_config').innerHTML);
 </script>
+{% endraw %}

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -21,3 +21,9 @@ mqc_compressed_plotdata = '{{ report.plot_compressed_json }}';
 num_datasets_plot_limit = {{ config.num_datasets_plot_limit}};
 mqc_sample_names_rename = {{ config.sample_names_rename | tojson }};
 </script>
+
+<script type="text/javascript">
+mqc_config = {}
+{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
+{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
+</script>

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -66,8 +66,3 @@ it prints the contents of these files into the report.
 <script type="text/javascript">{{ include_file( js_href, None ) }}</script>
 {% endif %}
 {%- endfor %}{% endif %}{% endfor %}
-<script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
-</script>

--- a/multiqc/templates/default_dev/includes.html
+++ b/multiqc/templates/default_dev/includes.html
@@ -54,8 +54,3 @@ it prints the contents of these files into the report.
 {%- for m in report.modules_output %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js.keys() %}
 <script type="text/javascript" src="{{ js_href }}"></script>
 {%- endfor %}{% endif %}{% endfor %}
-<script type="text/javascript">
-mqc_config = {}
-{% if config.decimalPoint_format is not none %}mqc_config['decimalPoint_format'] = '{{ config.decimalPoint_format }}'; {% endif %}
-{% if config.thousandsSep_format is not none %}mqc_config['thousandsSep_format'] = '{{ config.thousandsSep_format }}'; {% endif %}
-</script>


### PR DESCRIPTION
So far MultiQC reports could not be opened on websites that use [Content-Security-Policy](https://content-security-policy.com/) header to limit XSS attacks (it would require `script-src 'unsafe-inline'`).

With this pullrequest, data passed into html is separated from javascript. This allows using CSP with hash exception for each script (because hash doesn't change with data anymore)
`script-src 'self' 'sha256-<script>' 'sha256-<script>' ...;`

It isn't a perfect solution, as server admins using CSP will have to update exceptions with MultiQC releases, but at least they can avoid `'unsafe-inline'`.

## List of CSP hash codes for this MultiQC version

```
Content-Security-Policy:
    script-src 
        'self'
        'sha256-X9boLn1Jzgn6VfdR/mbleypCzQB7wVaQ45tYrsWmfBQ=' // load mqc_compressed_plotdata and mqc_config
        'sha256-+F66a8s8ponoNnBnP06kgZ4LvQ6IBedFeTJHpTbA0O0=' // load_fastqc_passfails();
        'sha256-hBQTjaW1/EOhnTxMz3aTwQHziBXZnlSP6On3OlSNP0A=' // load_fastqc_seq_content();
        'sha256-6Iyez8LRQbIQe12+IHNW66k9OJvzlLF1yPb2gK11T5o=' // fastq screen inline script

        'sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=' // jquery-3.1.1.min.js
        'sha256-iWO8z1sbOFlW9jqHm6PDldXb2wCcqo3gBNPZxg/TBBs=' // jquery-ui.min.js
        'sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=' // bootstrap.min.js
        'sha256-QwUrND/LJhYUBcYRAAxtMNWjZhZI+Yr8N7fpvHSFd4E=' // highcharts.js
        'sha256-X5AUZ+9MCHrVWj/x7N3Rkc/02lN9YB7fEx9RODM7A+k=' // highcharts.heatmap.js
        'sha256-+9tTm/2PzXj/LVTpB+PDvRvk7tG4QGM5YZIKs4DE45o=' // highcharts.exporting.js
        'sha256-Vndz/rd9+SJEYoVVpV/BqYrULpr5CA+pwbE6rbynp/0=' // highcharts.offline-exporting.js
        'sha256-qRzmKGpTQ9kQfjgKtYTcIxkIAwipJOcF3c6psri9FAc=' // highcharts.export-csv.js
        'sha256-AhtCowp6HzQCEXZP0Bdbk1Jg9PEYtx8/jZkfHJgXY2c=' // jquery.tablesorter.min.js
        'sha256-mYqjlBuTYmeoEFTjuPCrwns2stAp2HOJyXR5X2xjP70=' // clipboard.min.js
        'sha256-FPJJt8nA+xL4RU6/gsriA8p8xAeLGatoyTjldvQKGdE=' // FileSaver.min.js
        'sha256-nRoO8HoupfqozUr7YKBRgHXmdx40Hl/04OSBzv7e7L8=' // lz-string.min.js
        'sha256-v69SxdPeknzXy0hkSHL/SrchLvO8QDQS4N7V50xE0Ks=' // jquery.toast.min.js
        'sha256-7gUXukWB8g8TYIxnHrzoQrukADhWL1n8vcdPVzDvf9o=' // multiqc.js
        'sha256-bXJ/DLuHU3+9ybEepMTgDM965n8Cp2jD7JEJZtsWxGc=' // multiqc_tables.js
        'sha256-+pOrbPU8yLRc3gIYFSyzUfvh3zDWjv4P+WgZr3tm8yg=' // multiqc_plotting.js
        'sha256-8kPZc83fQr/qzo5ISaYAcLl4M5meLuuTzHFVRGb4GhU=' // multiqc_mpl.js
        'sha256-1pWjCVoi5AoQvT52zb72qGCpIpfJzlc9trKcbcarXUY=' // multiqc_toolbox.js
        'sha256-AzuP74MO1xsRljs7mAfk56aLW7JT0TNECViHCvfj7c8=' // multiqc_fastqc.js
    ;
```

## This PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
