### PR TITLE
Add snpeff effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@
     * Increased the default summary csv file-size limit from 1MB to 5MB.
 * **VCFTools**
     * Fixed a bug where `tstv_by_qual.py` produced invalid json from infinity-values.
+* **bcl2fastq**
+    * Added handling of demultiplexing of more than 2 reads
 * **snpEff**
-    * Added plot of effects.
+    * Added plot of effects
 
 #### New MultiQC Features:
 * Added some installation docs for windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
     * Increased the default summary csv file-size limit from 1MB to 5MB.
 * **VCFTools**
     * Fixed a bug where `tstv_by_qual.py` produced invalid json from infinity-values.
-* **bcl2fastq**
-    * Added handling of demultiplexing of more than 2 reads
+* **snpEff**
+    * Added plot of effects.
 
 #### New MultiQC Features:
 * Added some installation docs for windows

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -188,16 +188,14 @@ class MultiqcModule(BaseMultiqcModule):
                     "perfectIndex": 0,
                     "filename": os.path.join(myfile['root'], myfile["fn"]),
                     "yieldQ30": 0,
-                    "qscore_sum": 0,
-                    "R1_yield": 0,
-                    "R2_yield": 0,
-                    "R1_Q30": 0,
-                    "R2_Q30": 0,
-                    "R1_trimmed_bases": 0,
-                    "R2_trimmed_bases": 0
+                    "qscore_sum": 0
                 }
                 # simplify the population of dictionaries
                 lsample = run_data[lane]["samples"][sample]
+                for r in range(1,5):
+                        lsample["R{}_yield".format(r)] = 0
+                        lsample["R{}_Q30".format(r)] = 0
+                        lsample["R{}_trimmed_bases".format(r)] = 0
                 rlane["total"] += demuxResult["NumberReads"]
                 rlane["total_yield"] += demuxResult["Yield"]
                 lsample["total"] += demuxResult["NumberReads"]

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -189,14 +189,16 @@ class MultiqcModule(BaseMultiqcModule):
                     "perfectIndex": 0,
                     "filename": os.path.join(myfile['root'], myfile["fn"]),
                     "yieldQ30": 0,
-                    "qscore_sum": 0
+                    "qscore_sum": 0,
+                    "R1_yield": 0,
+                    "R2_yield": 0,
+                    "R1_Q30": 0,
+                    "R2_Q30": 0,
+                    "R1_trimmed_bases": 0,
+                    "R2_trimmed_bases": 0
                 }
                 # simplify the population of dictionnaries
                 lsample = run_data[lane]["samples"][sample]
-                for r in range(1,5):
-                        lsample["R{}_yield".format(r)] = 0
-                        lsample["R{}_Q30".format(r)] = 0
-                        lsample["R{}_trimmed_bases".format(r)] = 0
                 rlane["total"] += demuxResult["NumberReads"]
                 rlane["total_yield"] += demuxResult["Yield"]
                 lsample["total"] += demuxResult["NumberReads"]
@@ -213,11 +215,6 @@ class MultiqcModule(BaseMultiqcModule):
                     lsample["R{}_yield".format(r)] += readMetric["Yield"]
                     lsample["R{}_Q30".format(r)] += readMetric["YieldQ30"]
                     lsample["R{}_trimmed_bases".format(r)] += readMetric["TrimmedBases"]
-                for r in range(1,5):
-                    if not lsample["R{}_yield".format(r)] and not lsample["R{}_Q30".format(r)] and not lsample["R{}_trimmed_bases".format(r)]:
-                        lsample.pop("R{}_yield".format(r))
-                        lsample.pop("R{}_Q30".format(r))
-                        lsample.pop("R{}_trimmed_bases".format(r))
             undeterminedYieldQ30 = 0
             undeterminedQscoreSum = 0
             undeterminedTrimmedBases = 0

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -87,6 +87,19 @@ class MultiqcModule(BaseMultiqcModule):
                 "level and the number of variants for each effect type."
             ),
             helptext = (
+                "This plot shows the effect of variants with respect to"
+                "the mRNA."
+            ),
+            anchor = 'snpeff-effects',
+            plot = self.effects_plot()
+        )
+        self.add_section (
+            name = 'Variant by Effects',
+            description = (
+                "The stacked bar plot shows the effect of variants and"
+                "the number of variants for each effect type."
+            ),
+            helptext = (
                 "This plot shows the effect of variants on the translation of "
                 "the mRNA as protein. There are three possible cases:"
                 "<ul>"
@@ -228,6 +241,26 @@ class MultiqcModule(BaseMultiqcModule):
 
         return bargraph.plot(self.snpeff_data, pkeys, pconfig)
 
+    def effects_plot(self):
+        """ Generate the SnpEff Counts by Effects plot """
+
+        # Sort the keys based on the total counts
+        keys = self.snpeff_section_totals['# Count by effects']
+        sorted_keys = sorted(keys, reverse=True, key=keys.get)
+
+        # Make nicer label names
+        pkeys = OrderedDict()
+        for k in sorted_keys:
+            pkeys[k] = {'name': k.replace('_', ' ').title().replace('Utr', 'UTR') }
+
+        # Config for the plot
+        pconfig = {
+            'id': 'snpeff_effects',
+            'title': 'SnpEff: Counts by Effects',
+            'ylab': '# Reads',
+            'logswitch': False
+        }
+        return bargraph.plot(self.snpeff_data, pkeys, pconfig)
 
     def effects_impact_plot(self):
         """ Generate the SnpEff Counts by Effects Impact plot """

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -81,7 +81,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot = self.effects_impact_plot()
         )
         self.add_section (
-            name = 'Variant Effects by Class',
+            name = 'Variant by Effects',
             description = (
                 "The stacked bar plot shows the effect of variants at protein "
                 "level and the number of variants for each effect type."
@@ -94,7 +94,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot = self.effects_plot()
         )
         self.add_section (
-            name = 'Variant by Effects',
+            name = 'Variant Effects by Class',
             description = (
                 "The stacked bar plot shows the effect of variants and"
                 "the number of variants for each effect type."


### PR DESCRIPTION
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

The section `# Counts by effects` was not plotted from snpEff. It is the sections which includes the most data about the effects of any variants (it has more than 20 categories, frameshifs, stop gain, stop less). It includes more info than `Effects by Class` and `Genomic Regions`. I needed this for my project so I would like to include it in the MultiQC, this could be hidden by default if necessary.

Cheers