### PR TITLE
#886 Fixing matplotlib plot bands

### DIFF
--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -401,11 +401,11 @@ def matplotlib_linegraph (plotdata, pconfig=None):
         if 'yPlotBands' in pconfig:
             xlim = axes.get_xlim()
             for pb in pconfig['yPlotBands']:
-                axes.barh(pb['from'], xlim[1], height = pb['to']-pb['from'], left=xlim[0], color=pb['color'], linewidth=0, zorder=0)
+                axes.barh(pb['from'], xlim[1], height = pb['to']-pb['from'], left=xlim[0], color=pb['color'], linewidth=0, zorder=0, align='edge')
         if 'xPlotBands' in pconfig:
             ylim = axes.get_ylim()
             for pb in pconfig['xPlotBands']:
-                axes.bar(pb['from'], ylim[1], width = pb['to']-pb['from'], bottom=ylim[0], color=pb['color'], linewidth=0, zorder=0)
+                axes.bar(pb['from'], ylim[1], width = pb['to']-pb['from'], bottom=ylim[0], color=pb['color'], linewidth=0, zorder=0, align='edge')
 
         # Tight layout - makes sure that legend fits in and stuff
         if len(pdata) <= 15:


### PR DESCRIPTION
The default alignment for matplotlib plot bars is to be centered, but the relevant (x/y)PlotBands array is originally constructed (e.g. in the fastqc module) with the assumption that the bar should begin at the specified point. This fixes the broken plot bars when MultiQC auto-switches from highcharts to matplotlib.

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
