### PR TITLE
Add TOC to pipeline examples

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -17,6 +17,11 @@ If you know exactly which modules will be used by MultiQC, you can use the
 This will probably only make a noticeable impact if your pipeline has thousands
 of input files for MultiQC.
 
+## Table of Contents
+- [Nextflow](#nextflow)
+- [Snakemake](#snakemake)
+
+
 ## Nextflow
 
 An example mini-pipeline for [nextflow](https://www.nextflow.io/) which runs FastQC

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -17,10 +17,7 @@ If you know exactly which modules will be used by MultiQC, you can use the
 This will probably only make a noticeable impact if your pipeline has thousands
 of input files for MultiQC.
 
-## Table of Contents
-- [Nextflow](#nextflow)
-- [Snakemake](#snakemake)
-
+In the following, we show examples for [Nextflow](#nextflow) and [Snakemake](#snakemake) integration.
 
 ## Nextflow
 


### PR DESCRIPTION
By that, we make available examples visible from the start.