### PR TITLE
Modified OxoGMetrics.py so that it will find files created with GATK CollectMultipleMetrics and ConvertSequencingArtifactToOxoG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
     * Fixed bug where module tries to parse QC_table.txt, a new log file in hicexplorer v2.2.
 * **LongRanger**
     * Added support for the LongRanger Align pipeline.
+* **Picard**
+    * Modified OxoGMetrics.py so that it will find files created with GATK CollectMultipleMetrics and ConvertSequencingArtifactToOxoG.
 * **QoRTs**
     * Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/ewels/MultiQC/issues/821))
 * **RNA-SeQC**

--- a/multiqc/modules/picard/OxoGMetrics.py
+++ b/multiqc/modules/picard/OxoGMetrics.py
@@ -26,7 +26,7 @@ def parse_reports(self):
         keys = None
         for l in f['f']:
             # New log starting
-            if 'CollectOxoGMetrics' in l and 'INPUT' in l:
+            if ('CollectOxoGMetrics' in l or 'ConvertSequencingArtifactToOxoG' in l) and 'INPUT' in l:
                 s_name = None
                 keys = None
                 context_col = None


### PR DESCRIPTION
Modified OxoGMetrics.py so that it will find files created with GATK CollectMultipleMetrics and ConvertSequencingArtifactToOxoG.

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated