### PR TITLE
Add missing README link for mosdepth module

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ MultiQC is released under the GPL v3 or later licence.
 [methylqa]:       http://multiqc.info/docs/#methylqa
 [minionqc]:       http://multiqc.info/docs/#minionqc
 [mirtrace]:       http://multiqc.info/docs/#mirtrace
+[mosdepth]:       http://multiqc.info/docs/#mosdepth
 [peddy]:          http://multiqc.info/docs/#peddy
 [phantompeakqualtools]: http://multiqc.info/docs/#phantompeakqualtools
 [picard]:         http://multiqc.info/docs/#picard


### PR DESCRIPTION
Many thanks to contributing to MultiQC!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things I request on pull requests (PRs).

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work
