### PR TITLE
update keys in YAML header for csv/tsv file

### DIFF
--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -84,9 +84,9 @@ For maximum compatibility with other tools, you can also use comma-separated or 
 Include commented header lines with plot configuration in YAML format:
 
 ```bash
-# title: 'Output from my script'
+# id: "Output from my script'
+# section_name: 'Custom data file'
 # description: 'This output is described in the file header. Any MultiQC installation will understand it without prior configuration.'
-# section: 'Custom Data File'
 # format: 'tsv'
 # plot_type: 'bargraph'
 # pconfig:


### PR DESCRIPTION
The keys in the YAML header for the custom csv/tsv files weren't correct, updated `title` to `id` and `section` to `section_id` following the pure YAML and JSON examples. Purely a documentation change, probably doesn't need to go in the CHANGELOG.md.

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
