### PR TITLE
Stacks: Fixed parsing of multiline populations sum stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
     * Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 * **SnpEff**
     * Increased the default summary csv file-size limit from 1MB to 5MB.
+* **Stacks**
+    * Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/ewels/MultiQC/issues/906))
 * **VCFTools**
     * Fixed a bug where `tstv_by_qual.py` produced invalid json from infinity-values.
 * **snpEff**

--- a/multiqc/modules/stacks/stacks.py
+++ b/multiqc/modules/stacks/stacks.py
@@ -250,8 +250,6 @@ class MultiqcModule(BaseMultiqcModule):
         for l in var_lines:
             if l.startswith("# Pop ID	Private	Num_Indv"):
                 headers = l.split("\t")
-            elif l.startswith("# All positions (variant and fixed)"):
-                break
             elif headers is not None:
                 cdict = OrderedDict()
                 content = l.split("\t")

--- a/multiqc/modules/stacks/stacks.py
+++ b/multiqc/modules/stacks/stacks.py
@@ -248,14 +248,16 @@ class MultiqcModule(BaseMultiqcModule):
         var_lines = fl[fl.index("# Variant positions")+1:fl.index("# All positions (variant and fixed)")]
         headers = None
         for l in var_lines:
-            if l.startswith("# Pop ID"):
+            if l.startswith("# Pop ID	Private	Num_Indv"):
                 headers = l.split("\t")
+            elif l.startswith("# All positions (variant and fixed)"):
+                break
             elif headers is not None:
                 cdict = OrderedDict()
                 content = l.split("\t")
                 for i in fields:
                     cdict[headers[i]] = content[i]
-                out_dict[s_name] = cdict
+                out_dict[s_name + " | "+ content[0]] = cdict
 
         return out_dict
 


### PR DESCRIPTION
When specifying multiple populations for `--popmap` in Stacks, the resulting `populations.sumstats_summary.tsv` file was not parsed correctly.

closes #906 
