### PR TITLE
[Small Fix] Remove reference to % when dealing with ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
     * Dropped Travis and AppVeyor, everything is now just on GitHub
     * Still testing on both Linux and Windows, with multiple versions of Python
     * CI tests should now run automatically for anyone who forks the MultiQC repository
-
+    
+#### Bug Fixes
+ 
+* Fixes misleading value suffix for MTNucRatioCalculator
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     
 #### Bug Fixes
  
-* Fixes misleading value suffix for MTNucRatioCalculator
+* Fixes misleading value suffix in general stats table for MTNucRatioCalculator
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
     * Still testing on both Linux and Windows, with multiple versions of Python
     * CI tests should now run automatically for anyone who forks the MultiQC repository
     
-#### Bug Fixes
- 
-* Fixes misleading value suffix in general stats table for MTNucRatioCalculator
+#### Module updates:
+
+* **MTNucRatioCalculator**
+    * Fixed misleading value suffix in general stats table
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/multiqc/modules/mtnucratio/mtnucratio.py
+++ b/multiqc/modules/mtnucratio/mtnucratio.py
@@ -89,11 +89,10 @@ class MultiqcModule(BaseMultiqcModule):
             'hidden': True
         }
         headers['mt_nuc_ratio'] = {
-            'title': '% MTNUC',
+            'title': 'MT to Nuclear Ratio',
             'description': 'Mitochondrial to nuclear reads ratio (MTNUC)',
             'min': 0,
             'max': 100,
-            'suffix': '%',
             'scale': 'RdYlGrn-rev',
         }
         headers['nucreads'] = {


### PR DESCRIPTION
Column header for a ratio was reporting % as the suffix. This removes references to % and leaves as a single number (i.e. no. of mitochondrial reads to each nuclear reads). 

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated