### PR TITLE
Fix Issue 1094: bcl2fastq sample id bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * **MTNucRatioCalculator**
     * Fixed misleading value suffix in general stats table
+* **bcl2fastq**
+    * Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -174,7 +174,7 @@ class MultiqcModule(BaseMultiqcModule):
             run_data[lane]["unknown_barcodes"] = unknown_barcode
 
             for demuxResult in conversionResult.get("DemuxResults", []):
-                if demuxResult["SampleName"] == demuxResult["SampleName"]:
+                if demuxResult["SampleName"] == demuxResult["SampleId"]:
                     sample = demuxResult["SampleName"]
                 else:
                     sample = "{}-{}".format(demuxResult["SampleId"], demuxResult["SampleName"])


### PR DESCRIPTION
This fixes #1094 , a bug in the bcl2fastq module that causes metrics for samples with multiple preps to be counted incorrectly. Number of clusters will e.g. be counted only for the last index/barcode on all lanes. 

## If this PR is _not_ a new module
 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change
