### PR TITLE
Add khtools extract_coding parser

### DIFF
--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -1,0 +1,4 @@
+# STAR logs are renamed to "log.final.out" instead of "Log.final.out"
+sp:
+    star:
+        fn: '*log.final.out'


### PR DESCRIPTION
Add parser for khtools extract_coding which predicts the protein-coding sequence of RNA-seq reads. Just got started!

## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work

Used in https://github.com/czbiohub/nf-predictorthologs/pull/1 and https://github.com/nf-core/kmermaid/pull/40
