### PR TITLE
Make the WgsMetrics module compatible with GATK4

### DIFF
--- a/multiqc/modules/picard/WgsMetrics.py
+++ b/multiqc/modules/picard/WgsMetrics.py
@@ -50,7 +50,7 @@ def parse_reports(self):
                     s_name = self.clean_s_name(s_name, f['root'])
 
             if s_name is not None:
-                if 'CollectWgsMetrics$WgsMetrics' in l and '## METRICS CLASS' in l:
+                if 'WgsMetrics' in l and '## METRICS CLASS' in l:
                     if s_name in self.picard_wgsmetrics_data:
                         log.debug("Duplicate sample name found in {}! Overwriting: {}".format(f['fn'], s_name))
                     self.add_data_source(f, s_name, section='WgsMetrics')


### PR DESCRIPTION
PICARD tools WgsMetrics results starts with the line:
`## METRICS CLASS        picard.analysis.CollectWgsMetrics$WgsMetrics`
whereas GATK4 WgsMetrics results starts with the line:
`## METRICS CLASS        picard.analysis.WgsMetrics`

The new code should be able to match the results from both PICAD tools and GATK4 after removing the `CollectWgsMetrics$` pattern from the search string.
