### PR TITLE
Fix typo in Picard AlignmentSummaryMetrics

### DIFF
--- a/multiqc/modules/picard/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/picard/AlignmentSummaryMetrics.py
@@ -118,7 +118,7 @@ def parse_reports(self):
         self.add_section (
             name = 'Alignment Summary',
             anchor = 'picard-alignmentsummary',
-            description = "Plase note that Picard's read counts are divided by two for paired-end data.",
+            description = "Please note that Picard's read counts are divided by two for paired-end data.",
             plot = bargraph.plot(pdata, keys, pconfig)
         )
 


### PR DESCRIPTION
 Very small change, just a typo, do I need to add it to the change log?

- [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this
