### PR TITLE
Fix #1136: heatmap and toolbox hide/highlight need x and y to be swapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * **bcl2fastq**
     * Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
 
+#### Bug Fixes:
+* `heatmap` plotting function is now compatible with MultiQC toolbox `hide` and `highlight`
+
+
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 
 #### New Modules:

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -1171,6 +1171,8 @@ function plot_heatmap(target, ds){
   var data = JSON.parse(JSON.stringify(mqc_plots[target]['data']));
   var xcats = JSON.parse(JSON.stringify(mqc_plots[target]['xcats']));
   var ycats = JSON.parse(JSON.stringify(mqc_plots[target]['ycats']));
+  // "xcats" and "ycats" are labels of columns and rows respectively
+  // data[n] has form of [x,y,value], x/y are indices of columns/rows
 
   // Rename samples
   if(window.mqc_rename_f_texts.length > 0){
@@ -1228,6 +1230,7 @@ function plot_heatmap(target, ds){
           if(xcat_hl[i] == hl){
             new_xcats.push(xcats[i])
             for (j=0; j < data.length; j++) {
+              // data[j] element is [x,y,val], get "x"
               if(data[j][0] == i){ newdata[j][0] = xidx; }
             }
             xidx += 1;
@@ -1237,6 +1240,7 @@ function plot_heatmap(target, ds){
           if(ycat_hl[i] == hl){
             new_ycats.push(ycats[i])
             for (j=0; j < data.length; j++) {
+              // data[j] element is [x,y,val], get "y"
               if(data[j][1] == i){ newdata[j][1] = yidx; }
             }
             yidx += 1;
@@ -1254,15 +1258,10 @@ function plot_heatmap(target, ds){
   $('#'+target).closest('.hc-plot-wrapper').parent().find('.samples-hidden-warning').remove();
   $('#'+target).closest('.hc-plot-wrapper').show();
   if(window.mqc_hide_f_texts.length > 0){
-    // debug
-    console.log("Before hiding...");
-    console.log(data);
-    console.log(xcats);
-    console.log(ycats);
     var remove = Array();
     var i = xcats.length;
     var xhidden = 0;
-    // iterate over x-categories (rows)
+    // iterate over x-categories (columns)
     while (i--) {
       var match = false;
       for (j = 0; j < window.mqc_hide_f_texts.length; j++) {
@@ -1276,17 +1275,15 @@ function plot_heatmap(target, ds){
       if(window.mqc_hide_mode == 'show'){
         match = !match;
       }
-      // modify data if "i" is match for "hiding"
+      // modify data if "i" is match for "hiding":
+      // mark elements from "i"-th column (x) for removal,
+      // shift "x" of elements from "i+" columns to the left
       if(match){
         xcats.splice(i, 1);
         for (n=0; n < data.length; n++) {
-          // extract "x-coord"(row) of n-th data element
-          // "data" is sparse in COO format: (row, col ,val)
+          // data[n] element is [x,y,val], get "x"
           let x = data[n][0];
-          // add to "remove", if "i" matches "x-coord"(row)
           if (x == i){ remove.push(n); }
-          // shift "x-coord"(row) of n-th element by 1
-          // to replace the hidden row, when x>i
           else if(x > i){ data[n][0]  = x - 1; }
         }
         xhidden += 1;
@@ -1294,7 +1291,7 @@ function plot_heatmap(target, ds){
     }
     var i = ycats.length;
     var yhidden = 0;
-    // iterate over y-categories (cols)
+    // iterate over y-categories (rows)
     while (i--) {
       var match = false;
       for (j = 0; j < window.mqc_hide_f_texts.length; j++) {
@@ -1309,17 +1306,15 @@ function plot_heatmap(target, ds){
         match = !match;
       }
       // modify data if "i" is match for "hiding"
+      // mark elements from "i"-th row (x) for removal,
+      // shift "x" of elements from "i+" rows up
       if(match){
         ycats.splice(i, 1);
         for (n=0; n < data.length; n++) {
-          // extract "y-coord"(col) of n-th data element
-          // "data" is sparse in COO format: (row, col ,val)
+          // data[n] element is [x,y,val], get "y"
           let y = data[n][1];
           if (y == i){
-            // add to "remove", if "i" matches "y-coord"(col)
             if(remove.indexOf(n) < 0){ remove.push(n); }
-            // shift "y-coord"(col) of n-th element by 1
-            // to replace the hidden col, when y>i
           } else if(y > i){ data[n][1] = y - 1; }
         }
         yhidden += 1;
@@ -1331,11 +1326,6 @@ function plot_heatmap(target, ds){
     while(r--){
       data.splice( remove[r], 1);
     }
-    // debug
-    console.log("After hiding...");
-    console.log(data);
-    console.log(xcats);
-    console.log(ycats);
     // Report / hide the plot if we're hiding stuff
     var num_hidden = Math.max(xhidden, yhidden);
     // Some series hidden. Show a warning text string.
@@ -1359,8 +1349,10 @@ function plot_heatmap(target, ds){
         if(f_text == ''){ return true; }
         if((window.mqc_highlight_regex_mode && xcats[i].match(f_text)) || (!window.mqc_highlight_regex_mode && xcats[i].indexOf(f_text) > -1)){
           for (n=0; n < data.length; n++) {
+            // data[n] element is [x,y,val], get "x"
+            let x = data[n][0];
             highlight_cells[idx] = ( typeof highlight_cells[idx] != 'undefined' && highlight_cells[idx] instanceof Array ) ? highlight_cells[idx] : [];
-            if (data[n][1] == i){ highlight_cells[idx].push(n); }
+            if (x == i){ highlight_cells[idx].push(n); }
           }
         }
       });
@@ -1370,7 +1362,9 @@ function plot_heatmap(target, ds){
         if(f_text == ''){ return true; }
         if((window.mqc_highlight_regex_mode && ycats[i].match(f_text)) || (!window.mqc_highlight_regex_mode && ycats[i].indexOf(f_text) > -1)){
           for (n=0; n < data.length; n++) {
-            if (data[n][0] == i){
+            // data[n] element is [x,y,val], get "y"
+            let y = data[n][1];
+            if (y == i){
               highlight_cells[idx] = ( typeof highlight_cells[idx] != 'undefined' && highlight_cells[idx] instanceof Array ) ? highlight_cells[idx] : [];
               if(highlight_cells[idx].indexOf(n) < 0){ highlight_cells[idx].push(n); }
             }
@@ -1386,9 +1380,10 @@ function plot_heatmap(target, ds){
       while(h--){
         var i = hl[h];
         data[i] = {
-          x: data[i][1] === undefined ? data[i]['x'] : data[i][1],
-          y: data[i][0] === undefined ? data[i]['y'] : data[i][0],
-          value:data[i][2] === undefined ? data[i]['value'] : data[i][2],
+          // data[i] element is [x,y,val]
+          x: data[i][0] === undefined ? data[i]['x'] : data[i][0],
+          y: data[i][1] === undefined ? data[i]['y'] : data[i][1],
+          value: data[i][2] === undefined ? data[i]['value'] : data[i][2],
           borderWidth:2,
           borderColor: window.mqc_highlight_f_cols[idx]
         }

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -1306,8 +1306,8 @@ function plot_heatmap(target, ds){
         match = !match;
       }
       // modify data if "i" is match for "hiding"
-      // mark elements from "i"-th row (x) for removal,
-      // shift "x" of elements from "i+" rows up
+      // mark elements from "i"-th row (y) for removal,
+      // shift "y" of elements from "i+" rows up
       if(match){
         ycats.splice(i, 1);
         for (n=0; n < data.length; n++) {
@@ -1349,10 +1349,9 @@ function plot_heatmap(target, ds){
         if(f_text == ''){ return true; }
         if((window.mqc_highlight_regex_mode && xcats[i].match(f_text)) || (!window.mqc_highlight_regex_mode && xcats[i].indexOf(f_text) > -1)){
           for (n=0; n < data.length; n++) {
-            // data[n] element is [x,y,val], get "x"
-            let x = data[n][0];
             highlight_cells[idx] = ( typeof highlight_cells[idx] != 'undefined' && highlight_cells[idx] instanceof Array ) ? highlight_cells[idx] : [];
-            if (x == i){ highlight_cells[idx].push(n); }
+            // data[n] element is [x,y,val], get "x"
+            if (data[n][0] == i){ highlight_cells[idx].push(n); }
           }
         }
       });
@@ -1363,8 +1362,7 @@ function plot_heatmap(target, ds){
         if((window.mqc_highlight_regex_mode && ycats[i].match(f_text)) || (!window.mqc_highlight_regex_mode && ycats[i].indexOf(f_text) > -1)){
           for (n=0; n < data.length; n++) {
             // data[n] element is [x,y,val], get "y"
-            let y = data[n][1];
-            if (y == i){
+            if (data[n][1] == i){
               highlight_cells[idx] = ( typeof highlight_cells[idx] != 'undefined' && highlight_cells[idx] instanceof Array ) ? highlight_cells[idx] : [];
               if(highlight_cells[idx].indexOf(n) < 0){ highlight_cells[idx].push(n); }
             }
@@ -1383,7 +1381,7 @@ function plot_heatmap(target, ds){
           // data[i] element is [x,y,val]
           x: data[i][0] === undefined ? data[i]['x'] : data[i][0],
           y: data[i][1] === undefined ? data[i]['y'] : data[i][1],
-          value: data[i][2] === undefined ? data[i]['value'] : data[i][2],
+          value:data[i][2] === undefined ? data[i]['value'] : data[i][2],
           borderWidth:2,
           borderColor: window.mqc_highlight_f_cols[idx]
         }

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -1254,9 +1254,15 @@ function plot_heatmap(target, ds){
   $('#'+target).closest('.hc-plot-wrapper').parent().find('.samples-hidden-warning').remove();
   $('#'+target).closest('.hc-plot-wrapper').show();
   if(window.mqc_hide_f_texts.length > 0){
+    // debug
+    console.log("Before hiding...");
+    console.log(data);
+    console.log(xcats);
+    console.log(ycats);
     var remove = Array();
     var i = xcats.length;
     var xhidden = 0;
+    // iterate over x-categories (rows)
     while (i--) {
       var match = false;
       for (j = 0; j < window.mqc_hide_f_texts.length; j++) {
@@ -1270,18 +1276,25 @@ function plot_heatmap(target, ds){
       if(window.mqc_hide_mode == 'show'){
         match = !match;
       }
+      // modify data if "i" is match for "hiding"
       if(match){
         xcats.splice(i, 1);
         for (n=0; n < data.length; n++) {
-          var x = data[n][1];
+          // extract "x-coord"(row) of n-th data element
+          // "data" is sparse in COO format: (row, col ,val)
+          let x = data[n][0];
+          // add to "remove", if "i" matches "x-coord"(row)
           if (x == i){ remove.push(n); }
-          else if(x > i){ data[n][1] -= 1; }
+          // shift "x-coord"(row) of n-th element by 1
+          // to replace the hidden row, when x>i
+          else if(x > i){ data[n][0]  = x - 1; }
         }
         xhidden += 1;
       }
     }
     var i = ycats.length;
     var yhidden = 0;
+    // iterate over y-categories (cols)
     while (i--) {
       var match = false;
       for (j = 0; j < window.mqc_hide_f_texts.length; j++) {
@@ -1295,13 +1308,19 @@ function plot_heatmap(target, ds){
       if(window.mqc_hide_mode == 'show'){
         match = !match;
       }
+      // modify data if "i" is match for "hiding"
       if(match){
         ycats.splice(i, 1);
         for (n=0; n < data.length; n++) {
-          var y = data[n][0];
+          // extract "y-coord"(col) of n-th data element
+          // "data" is sparse in COO format: (row, col ,val)
+          let y = data[n][1];
           if (y == i){
+            // add to "remove", if "i" matches "y-coord"(col)
             if(remove.indexOf(n) < 0){ remove.push(n); }
-          } else if(y > i){ data[n][0] -= 1; }
+            // shift "y-coord"(col) of n-th element by 1
+            // to replace the hidden col, when y>i
+          } else if(y > i){ data[n][1] = y - 1; }
         }
         yhidden += 1;
       }
@@ -1312,6 +1331,11 @@ function plot_heatmap(target, ds){
     while(r--){
       data.splice( remove[r], 1);
     }
+    // debug
+    console.log("After hiding...");
+    console.log(data);
+    console.log(xcats);
+    console.log(ycats);
     // Report / hide the plot if we're hiding stuff
     var num_hidden = Math.max(xhidden, yhidden);
     // Some series hidden. Show a warning text string.


### PR DESCRIPTION
issue descibed in #1136 seem to originate from the x/y swap - i.e. `xcats` and `ycats` of the heatmap (rows and columns respectively) are referring to wrong indexes in the sparse-matrix variable `data` that stores all of the heatmap's data: `x` refers to `data[n][1]` and `y` refer to `data[n][0]`, but it should be `x` <-->`data[n][0]` and `y` <--> `data[n][1]` instead.

`data` - seem to be a sprase matrix in COO format and it seem to follow the `[row, col, value]` layout
![Screenshot from 2020-03-28 22-56-50](https://user-images.githubusercontent.com/6790270/77839765-bcab8800-714d-11ea-8f0a-c46103593f38.png)

In this PR i'll carefully flip/swap `x/y` `0/1` when needed , and add some comments to hopefully ease community-maintenance.

Just one commit for now, fixing the `hide` aspect of the toolbox
[to be continued]

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [x] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change