### PR TITLE
Fix the bug for the latest sortmerna version 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MultiQC Version History
 
+#### Module updates:
+* **sortmerna**
+    * Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
+
+
+
+
+
 ## MultiQC v1.9dev
 
 #### Dropped official support for Python 2

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -65,9 +65,9 @@ class MultiqcModule(BaseMultiqcModule):
 
         for l in f["f"]:
             if "Reads file" in l:
-                s_name = self.clean_s_name( l.split('=')[-1], f['root'] )
+                s_name = self.clean_s_name( l.split(':')[-1], f['root'] )
                 self.sortmerna[s_name] = dict()
-            if "Results:" in l and not post_results_start:
+            if "Total reads = " in l and not post_results_start:
                 post_results_start = True
             if not post_results_start:
                 continue
@@ -96,17 +96,17 @@ class MultiqcModule(BaseMultiqcModule):
                 if not l.strip():
                     break
                 db_number = db_number + 1
-                m = re.search("    .*\t", l)
+                m = re.search("    .*		", l)
                 if m:
                     db = m.group().strip()
                     db = os.path.splitext(os.path.basename(db))[0]
-                    pct = float(re.search("\d+\.\d+%", l).group().replace("%",""))
+                    pct = float(re.search("\d+\.\d+", l).group())
                     count = int(self.sortmerna[s_name]["total"]) * (pct / 100)
                     self.sortmerna[s_name][db + "_pct"] = pct
                     self.sortmerna[s_name][db + "_count"] = count
                 else:
                     err = True
-            if "By database:" in l and not post_database_start:
+            if "Coverage by database:" in l and not post_database_start:
                 post_database_start = True
         if err:
             log.warning("Error parsing data in: " + s_name)


### PR DESCRIPTION
Fix the bug for the latest sortmerna version 4.2.0 - see #1121

Example log in the new format: [`sortmerna.log`](https://github.com/ewels/MultiQC/files/4428524/sortmerna.log)

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [x] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change
