### PR TITLE
Hicup bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
     * Dropped Travis and AppVeyor, everything is now just on GitHub
     * Still testing on both Linux and Windows, with multiple versions of Python
     * CI tests should now run automatically for anyone who forks the MultiQC repository
-    
+
 #### Module updates:
 
 * **MTNucRatioCalculator**
     * Fixed misleading value suffix in general stats table
 * **bcl2fastq**
     * Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
+* **hicup**
+    * Fixed bug where sample names were incorrectly processed
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/multiqc/modules/hicup/hicup.py
+++ b/multiqc/modules/hicup/hicup.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 from collections import OrderedDict
 import logging
-
+import re
 from multiqc import config
 from multiqc.plots import bargraph
 from multiqc.modules.base_module import BaseMultiqcModule
@@ -88,7 +88,8 @@ class MultiqcModule(BaseMultiqcModule):
                     return None
                 header = s[1:]
             else:
-                s_name = self.clean_s_name(s[0], f['root']).lstrip('HiCUP_output/')
+                s_name = self.clean_s_name(s[0], f['root'])
+                s_name = re.sub('^HiCUP_output/','', s_name)
                 parsed_data = {}
                 for idx, num in enumerate(s[1:]):
                     try:


### PR DESCRIPTION
Previously, the sample name was cleaned with `.lstrip('HiCUP_output/')` which removes any of the individual characters from the left side of the same name. I discovered this bug when my sample names (which began with `H`) had the `H` removed. I think instead, `re.sub('^HiCUP_output/', '', s_name)` should be used to ensure the prefix is correctly removed.

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change