### PR TITLE
Fix bug in the samblaster module

### DIFF
--- a/multiqc/modules/samblaster/samblaster.py
+++ b/multiqc/modules/samblaster/samblaster.py
@@ -69,7 +69,12 @@ class MultiqcModule(BaseMultiqcModule):
         """ Go through log file looking for samblaster output.
         If the
         Grab the name from the RG tag of the preceding bwa command """
-        dups_regex = "samblaster: (Removed|Marked) (\d+) of (\d+) \((\d+.\d+)%\) read ids as duplicates"
+
+        # Should capture the following:
+        # samblaster: Marked     1134898 of   43791982 (2.592%) total read ids as duplicates using 753336k \
+        # memory in 1M1S(60.884S) CPU seconds and 3M53S(233S) wall time.
+        dups_regex = r"samblaster: (Removed|Marked)\s+(\d+)\s+of\s+(\d+) \((\d+.\d+)%\)\s*(total)?\s*read ids as duplicates"
+
         input_file_regex = "samblaster: Opening (\S+) for read."
         rgtag_name_regex = "\\\\tID:(\S*?)\\\\t"
         data = {}


### PR DESCRIPTION
The samblaster module tries to capture samblaster log files, and retrieve the mark duplicates statistics via regex pattern matching. However, sometimes the regex fails to capture certain samblaster logs, such as the example below:

(generated by samblaster 0.1.25 processing bam files aligned by `bwa mem`)

```
samblaster: Version 0.1.25(3.2 KiB/s) with 1 file(s) remaining
samblaster: Inputting from stdin
samblaster: Outputting to stdout
samblaster: Loaded 84 header sequence entries.
samblaster:
samblaster: Pair Type        Type_ID_Count   %Type/All_IDs Dup_ID_Count  %Dups/Type_ID_Count  %Dups/All_Dups  %Dups/All_IDs
samblaster: ---------------------------------------------------------------------------------------------------------------
samblaster: Both Unmapped            2645         0.077              0           0.000             0.000          0.000
samblaster: Orphan/Singleton        24303         0.706           1952           8.032             0.212          0.057
samblaster: Both Mapped           3416627        99.217         920794          26.950            99.788         26.739
samblaster: Total                 3443575       100.000         922746          26.796           100.000         26.796
samblaster:
samblaster: Marked      922746 of    3443575 (26.796%) total read ids as duplicates using 49304k memory in 4.779S CPU seconds and 14S wall time.
```

Previously the regex is: 

```
dups_regex = "samblaster: (Removed|Marked) (\d+) of (\d+) \((\d+.\d+)%\) read ids as duplicates"
```
It can't match the last line.

-----------

Many thanks to contributing to MultiQC!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things I request on pull requests (PRs).

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change
