### PR TITLE
Add additional samtools flagstat column 'Total Reads'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 * **Samtools**
     * Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
     * Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
+    * Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
 * **sortmerna**
     * Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
 

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -39,7 +39,7 @@ class FlagstatReportMixin():
             flagstats_headers = dict()
             flagstats_headers['flagstat_total'] = {
                 'title': '{} Total Reads'.format(config.read_count_prefix),
-                'description': 'Total Mapped in the bam file ({})'.format(config.read_count_desc),
+                'description': 'Total reads in the bam file ({})'.format(config.read_count_desc),
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -38,7 +38,7 @@ class FlagstatReportMixin():
             # General Stats Table
             flagstats_headers = dict()
             flagstats_headers['flagstat_total'] = {
-                'title': '{} Total Reads'.format(config.read_count_prefix),
+                'title': '{} Reads'.format(config.read_count_prefix),
                 'description': 'Total reads in the bam file ({})'.format(config.read_count_desc),
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -37,13 +37,23 @@ class FlagstatReportMixin():
 
             # General Stats Table
             flagstats_headers = dict()
+            flagstats_headers['flagstat_total'] = {
+                'title': '{} Total Reads'.format(config.read_count_prefix),
+                'description': 'Total Mapped in the bam file ({})'.format(config.read_count_desc),
+                'min': 0,
+                'modify': lambda x: x * config.read_count_multiplier,
+                'shared_key': 'read_count',
+                'placement' : 100.0,
+                'hidden': True
+
+            }
             flagstats_headers['mapped_passed'] = {
                 'title': '{} Reads Mapped'.format(config.read_count_prefix),
                 'description': 'Reads Mapped in the bam file ({})'.format(config.read_count_desc),
                 'min': 0,
                 'modify': lambda x: x * config.read_count_multiplier,
                 'shared_key': 'read_count',
-                'placement' : 100.0
+                'placement' : 101.0
             }
             self.general_stats_addcols(self.samtools_flagstat, flagstats_headers)
 


### PR DESCRIPTION
Inspired by newly added nf-core/eager functionality that allows lane merging prior mapping, this PR adds an optional additional column to the General Stats table of 'Total Reads' in BAM file. 

This allows comparison of a before/after with the 'Mapped Reads'

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work
