### PR TITLE
Replace deprecated logger.warn with logger.warning (Fixes #1138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 * Plot config `logswitch_active` now works as advertised
 * When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/ewels/MultiQC/issues/1175))
 * Fixed minor bug where tables could report negative numbers of columns in their header text
+* Replaced deprecated 'warn()' with 'warning()' of the logging module
 
 ## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 

--- a/multiqc/modules/afterqc/afterqc.py
+++ b/multiqc/modules/afterqc/afterqc.py
@@ -58,7 +58,7 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             parsed_json = json.load(f['f'])
         except:
-            log.warn("Could not parse AfterQC JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse AfterQC JSON: '{}'".format(f['fn']))
             return None
 
         # AfterQC changed the name of their summary key at some point
@@ -67,7 +67,7 @@ class MultiqcModule(BaseMultiqcModule):
         elif 'afterqc_main_summary' in parsed_json:
             summaryk = 'afterqc_main_summary'
         else:
-            log.warn("AfterQC JSON did not have a 'summary' or 'afterqc_main_summary' key, skipping: '{}'".format(f['fn']))
+            log.warning("AfterQC JSON did not have a 'summary' or 'afterqc_main_summary' key, skipping: '{}'".format(f['fn']))
             return None
 
         s_name = f['s_name']

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -86,11 +86,11 @@ class BaseMultiqcModule(object):
             sp_key = self.name
             logwarn = "Depreciation Warning: {} - Please use new style for find_log_files()".format(self.name)
             if len(report.files[self.name]) > 0:
-                logger.warn(logwarn)
+                logger.warning(logwarn)
             else:
                 logger.debug(logwarn)
         elif not isinstance(sp_key, str):
-            logger.warn("Did not understand find_log_files() search key")
+            logger.warning("Did not understand find_log_files() search key")
             return
 
         for f in report.files[sp_key]:

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -143,7 +143,7 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             content = json.loads(myfile["f"])
         except ValueError:
-            log.warn('Could not parse file as json: {}'.format(myfile["fn"]))
+            log.warning('Could not parse file as json: {}'.format(myfile["fn"]))
             return
         runId = content["RunId"]
         if runId not in self.bcl2fastq_data:

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -74,7 +74,7 @@ def custom_module_classes():
             continue
 
         # We should have had something by now
-        log.warn("Found section '{}' in config for under custom_data, but no data or search patterns.".format(c_id))
+        log.warning("Found section '{}' in config for under custom_data, but no data or search patterns.".format(c_id))
 
     # Now go through each of the file search patterns
     bm = BaseMultiqcModule()
@@ -330,7 +330,7 @@ def _find_file_header(f):
         hconfig = yaml.safe_load("\n".join(hlines))
         assert(isinstance(hconfig, dict))
     except yaml.YAMLError as e:
-        log.warn("Could not parse comment file header for MultiQC custom content: {}".format(f['fn']))
+        log.warning("Could not parse comment file header for MultiQC custom content: {}".format(f['fn']))
         log.debug(e)
     except AssertionError:
         log.debug("Custom Content comment file header looked wrong: {}".format(hconfig))
@@ -410,7 +410,7 @@ def _parse_txt(f, conf):
             if ncols is None:
                 ncols = len(sections)
             elif ncols != len(sections):
-                log.warn("Inconsistent number of columns found in {}! Skipping..".format(f['fn']))
+                log.warning("Inconsistent number of columns found in {}! Skipping..".format(f['fn']))
                 return (None, conf)
 
     # Convert values to floats if we can

--- a/multiqc/modules/damageprofiler/damageprofiler.py
+++ b/multiqc/modules/damageprofiler/damageprofiler.py
@@ -103,7 +103,7 @@ class MultiqcModule(BaseMultiqcModule):
             parsed_json = json.load(f['f'])
         except Exception as e:
             print(e)
-            log.warn("Could not parse DamageProfiler JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse DamageProfiler JSON: '{}'".format(f['fn']))
             return None
 
         #Get sample name from JSON first

--- a/multiqc/modules/dedup/dedup.py
+++ b/multiqc/modules/dedup/dedup.py
@@ -31,7 +31,7 @@ class MultiqcModule(BaseMultiqcModule):
             try:
                 self.parseJSON(f)
             except KeyError:
-                logging.warn("Error loading file {}".format(f['fn']))
+                logging.warning("Error loading file {}".format(f['fn']))
 
         # Filter to strip out ignored sample names
         self.dedup_data = self.ignore_samples(self.dedup_data)

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -141,7 +141,7 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             parsed_json = json.load(f['f'])
         except:
-            log.warn("Could not parse fastp JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse fastp JSON: '{}'".format(f['fn']))
             return None
 
         # Fetch a sample name from the command
@@ -151,7 +151,7 @@ class MultiqcModule(BaseMultiqcModule):
             if v == '-i':
                 s_name = self.clean_s_name(cmd[i+1], f['root'])
         if s_name == 'fastp':
-            log.warn('Could not parse sample name from fastp command: {}'.format(f['fn']))
+            log.warning('Could not parse sample name from fastp command: {}'.format(f['fn']))
 
         self.add_data_source(f, s_name)
         self.fastp_data[s_name] = {}

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -94,7 +94,7 @@ class MultiqcModule(BaseMultiqcModule):
         if reads_processed and nohits_pct:
             parsed_data['No hits']['counts'] = {'one_hit_one_library': int((nohits_pct/100.0) * float(reads_processed)) }
         else:
-            log.warn("Couldn't find number of reads with no hits for '{}'".format(f['s_name']))
+            log.warning("Couldn't find number of reads with no hits for '{}'".format(f['s_name']))
 
         self.num_orgs = max(len(parsed_data), self.num_orgs)
         return parsed_data

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -56,7 +56,7 @@ class MultiqcModule(BaseMultiqcModule):
             try:
                 fqc_zip = zipfile.ZipFile(os.path.join(f['root'], f['fn']))
             except Exception as e:
-                log.warn("Couldn't read '{}' - Bad zip file".format(f['fn']))
+                log.warning("Couldn't read '{}' - Bad zip file".format(f['fn']))
                 log.debug("Bad zip file error:\n{}".format(e))
                 continue
             # FastQC zip files should have just one directory inside, containing report
@@ -547,7 +547,7 @@ class MultiqcModule(BaseMultiqcModule):
         theoretical_gc_name = None
         for f in self.find_log_files('fastqc/theoretical_gc'):
             if theoretical_gc_raw is not None:
-                log.warn("Multiple FastQC Theoretical GC Content files found, now using {}".format(f['fn']))
+                log.warning("Multiple FastQC Theoretical GC Content files found, now using {}".format(f['fn']))
             theoretical_gc_raw = f['f']
             theoretical_gc_name = f['fn']
         if theoretical_gc_raw is None:
@@ -562,7 +562,7 @@ class MultiqcModule(BaseMultiqcModule):
                     with io.open (tgc_path, "r", encoding='utf-8') as f:
                         theoretical_gc_raw = f.read()
                 except IOError:
-                    log.warn("Couldn't open FastQC Theoretical GC Content file {}".format(tgc_path))
+                    log.warning("Couldn't open FastQC Theoretical GC Content file {}".format(tgc_path))
                     theoretical_gc_raw = None
         if theoretical_gc_raw is not None:
             theoretical_gc = list()

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -63,7 +63,7 @@ class MultiqcModule(BaseMultiqcModule):
     def parse_log(self, f):
         filecount = 1
         if f['s_name'] in self.happy_seen:
-            log.warn("Duplicate sample name found in {}! Overwriting: {}".format(f['root'], f['s_name']))
+            log.warning("Duplicate sample name found in {}! Overwriting: {}".format(f['root'], f['s_name']))
             filecount = 0
         else:
             self.happy_seen.add(f['s_name'])

--- a/multiqc/modules/mtnucratio/mtnucratio.py
+++ b/multiqc/modules/mtnucratio/mtnucratio.py
@@ -50,10 +50,10 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             parsed_json = json.load(f['f'])
             if 'metrics' not in parsed_json and 'metadata' not in parsed_json:
-                log.warn("No MTNUCRATIO JSON: '{}'".format(f['fn']))
+                log.warning("No MTNUCRATIO JSON: '{}'".format(f['fn']))
                 return None
         except JSONDecodeError as e:
-            log.warn("Could not parse mtnucratio JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse mtnucratio JSON: '{}'".format(f['fn']))
             log.debug(e)
             return None
 

--- a/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
+++ b/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
@@ -82,7 +82,7 @@ class MultiqcModule(BaseMultiqcModule):
             data = json.load(f['f'])
         except Exception as e:
             log.debug(e)
-            log.warn("Could not parse MultiVCFAnalyzer JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse MultiVCFAnalyzer JSON: '{}'".format(f['fn']))
             return
 
         # Parse JSON data to a dict

--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -130,7 +130,7 @@ class MultiqcModule(BaseMultiqcModule):
                     try:
                         s_name_idx = [headers.index("sample_a"), headers.index("sample_b")]
                     except ValueError:
-                        log.warn("Could not find sample name in Peddy output: {}".format(f['fn']))
+                        log.warning("Could not find sample name in Peddy output: {}".format(f['fn']))
                         return None
             else:
                 s_name = '-'.join([s[idx] for idx in s_name_idx])

--- a/multiqc/modules/picard/MarkDuplicates.py
+++ b/multiqc/modules/picard/MarkDuplicates.py
@@ -87,11 +87,11 @@ def parse_reports(self,
                     # Skip - No reads
                     try:
                         if parsed_data['READ_PAIRS_EXAMINED'] == 0 and parsed_data['UNPAIRED_READS_EXAMINED'] == 0:
-                            log.warn("Skipping MarkDuplicates sample '{}' as log contained no reads".format(s_name))
+                            log.warning("Skipping MarkDuplicates sample '{}' as log contained no reads".format(s_name))
                             continue
                     # Skip - Missing essential fields
                     except KeyError:
-                        log.warn("Skipping MarkDuplicates sample '{}' as missing essential fields".format(s_name))
+                        log.warning("Skipping MarkDuplicates sample '{}' as missing essential fields".format(s_name))
                         continue
 
                     # Recompute PERCENT_DUPLICATION and ESTIMATED_LIBRARY_SIZE
@@ -271,7 +271,7 @@ def estimateLibrarySize(d):
         M = 100.0;
 
         if uniqueReadPairs >= readPairs or f(m * uniqueReadPairs, uniqueReadPairs, readPairs) < 0:
-            logging.warn("Picard recalculation of ESTIMATED_LIBRARY_SIZE skipped - metrics look wrong")
+            logging.warning("Picard recalculation of ESTIMATED_LIBRARY_SIZE skipped - metrics look wrong")
             return None
 
         # find value of M, large enough to act as other side for bisection method

--- a/multiqc/modules/picard/OxoGMetrics.py
+++ b/multiqc/modules/picard/OxoGMetrics.py
@@ -91,7 +91,7 @@ def parse_reports(self):
             try:
                 data[s_name]['CCG_OXIDATION_ERROR_RATE'] = self.picard_OxoGMetrics_data[s_name]['CCG']['OXIDATION_ERROR_RATE']
             except KeyError:
-                log.warn("Couldn't find picard CCG oxidation error rate for {}".format(s_name))
+                log.warning("Couldn't find picard CCG oxidation error rate for {}".format(s_name))
 
         self.general_stats_headers['CCG_OXIDATION_ERROR_RATE'] = {
             'title': 'CCG Oxidation',

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -263,7 +263,7 @@ def _get_counts_in_1x(data_is_basepairs):
             if genome_size in presets:
                 genome_size = presets[genome_size]
             else:
-                log.warn('The size for genome ' + genome_size + ' is unknown to MultiQC, ' +
+                log.warning('The size for genome ' + genome_size + ' is unknown to MultiQC, ' +
                          'please specify it explicitly or choose one of the following: ' +
                          ', '.join(presets.keys()) + '. Falling back to molecule counts.')
                 genome_size = None

--- a/multiqc/modules/pycoqc/pycoqc.py
+++ b/multiqc/modules/pycoqc/pycoqc.py
@@ -54,7 +54,7 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             return yaml.load(f, Loader=yaml.FullLoader)
         except Exception as e:
-            log.warn("Could not parse YAML for '{}': \n  {}".format(f, e))
+            log.warning("Could not parse YAML for '{}': \n  {}".format(f, e))
             return None
 
     def parse_data(self):

--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -39,7 +39,7 @@ def parse_reports(self):
             d['bam_file'] = s_name_regex.group(1)
             s_name = self.clean_s_name(d['bam_file'], f['root'])
         else:
-            log.warn("Couldn't find an input filename in genome_results file {}/{}".format(f['root'], f['fn']))
+            log.warning("Couldn't find an input filename in genome_results file {}/{}".format(f['root'], f['fn']))
             return None
 
         # Check for and 'fix' European style decimal places / thousand separators

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -95,10 +95,10 @@ class MultiqcModule(BaseMultiqcModule):
         try:
             assert data['Unique'] + data['Multi'] == data['Alignable']
         except AssertionError:
-            log.warn("Unique + Multimapping read counts != alignable reads! '{}'".format(f['fn']))
+            log.warning("Unique + Multimapping read counts != alignable reads! '{}'".format(f['fn']))
             return None
         except KeyError:
-            log.warn("Error parsing RSEM counts file '{}'".format(f['fn']))
+            log.warning("Error parsing RSEM counts file '{}'".format(f['fn']))
             return None
 
         # Save parsed data

--- a/multiqc/modules/rseqc/junction_saturation.py
+++ b/multiqc/modules/rseqc/junction_saturation.py
@@ -30,7 +30,7 @@ def parse_reports(self):
                 parsed[r.group(1)] = [float(i) for i in r.group(2).split(',')]
         if len(parsed) == 4:
             if parsed['z'][-1] == 0:
-                log.warn("Junction saturation data all zeroes, skipping: '{}'".format(f['s_name']))
+                log.warning("Junction saturation data all zeroes, skipping: '{}'".format(f['s_name']))
             else:
                 if f['s_name'] in self.junction_saturation_all:
                     log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))

--- a/multiqc/modules/rseqc/rseqc.py
+++ b/multiqc/modules/rseqc/rseqc.py
@@ -59,7 +59,7 @@ class MultiqcModule(BaseMultiqcModule):
                 if n[sm] > 0:
                     log.info("Found {} {} reports".format(n[sm], sm))
             except (ImportError, AttributeError):
-                log.warn("Could not find RSeQC Section '{}'".format(sm))
+                log.warning("Could not find RSeQC Section '{}'".format(sm))
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -165,7 +165,7 @@ class StatsReportMixin():
             if read_sum == expected_total:
                 bedgraph_data[sample_id] = data
             else:
-                log.warn("sum of mapped/unmapped reads not matching total, "
+                log.warning("sum of mapped/unmapped reads not matching total, "
                          "skipping samtools plot for: {}".format(sample_id))
         self.add_section (
             name = 'Percent Mapped',

--- a/multiqc/modules/sexdeterrmine/sexdeterrmine.py
+++ b/multiqc/modules/sexdeterrmine/sexdeterrmine.py
@@ -54,7 +54,7 @@ class MultiqcModule(BaseMultiqcModule):
             data = json.load(f['f'])
         except Exception as e:
             log.debug(e)
-            log.warn("Could not parse SexDeterrmine JSON: '{}'".format(f['fn']))
+            log.warning("Could not parse SexDeterrmine JSON: '{}'".format(f['fn']))
             return
 
         # Parse JSON data to a dict

--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -134,7 +134,7 @@ class MultiqcModule(BaseMultiqcModule):
                 try:
                     s_name_idx = [headers.index("sample_a"), headers.index("sample_b")]
                 except ValueError:
-                    log.warn("Could not find sample name in somalier output: {}".format(f['fn']))
+                    log.warning("Could not find sample name in somalier output: {}".format(f['fn']))
                     return None
             else:
                 s_name = '*'.join([s[idx] for idx in s_name_idx]) # not safe to hard code, but works
@@ -227,7 +227,7 @@ class MultiqcModule(BaseMultiqcModule):
                     except KeyError:
                         self.somalier_data[s_name] = parsed_data[s_name]
         else:
-            log.warn("Detected empty file: {}".format(f['fn']))
+            log.warning("Detected empty file: {}".format(f['fn']))
 
     def somalier_general_stats_table(self):
         """Add data to general stats table

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -323,7 +323,7 @@ def run(
             response = urlopen('http://multiqc.info/version.php?v={}'.format(config.short_version), timeout=5)
             remote_version = response.read().decode('utf-8').strip()
             if version.StrictVersion(re.sub('[^0-9\.]','', remote_version)) > version.StrictVersion(re.sub('[^0-9\.]','', config.short_version)):
-                logger.warn('MultiQC Version {} now available!'.format(remote_version))
+                logger.warning('MultiQC Version {} now available!'.format(remote_version))
             else:
                 logger.debug('Latest MultiQC version is {}'.format(remote_version))
         except Exception as e:
@@ -402,8 +402,8 @@ def run(
 
     # Throw a warning if we are running on Python 2
     if sys.version_info[0] < 3:
-        logger.warn("You are running MultiQC with Python {}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))
-        logger.warn("Please upgrade! MultiQC will soon drop support for Python < 3.6")
+        logger.warning("You are running MultiQC with Python {}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+        logger.warning("Please upgrade! MultiQC will soon drop support for Python < 3.6")
     else:
         logger.debug("Running Python {}".format(sys.version.replace("\n", ' ')))
 
@@ -608,7 +608,7 @@ def run(
 
     # Did we find anything?
     if len(report.modules_output) == 0:
-        logger.warn("No analysis results found. Cleaning up..")
+        logger.warning("No analysis results found. Cleaning up..")
         shutil.rmtree(tmp_dir)
         logger.info("MultiQC complete")
         # Exit with an error code if a module broke

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -194,7 +194,7 @@ def make_table (dt):
                                     if 'lt' in cmp and float(cmp['lt']) > float(val):
                                         cmatches[ftype] = True
                                 except:
-                                    logger.warn("Not able to apply table conditional formatting to '{}' ({})".format(val, cmp))
+                                    logger.warning("Not able to apply table conditional formatting to '{}' ({})".format(val, cmp))
                 # Apply HTML in order of config keys
                 bgcol = None
                 for cfc in config.table_cond_formatting_colours:

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -194,14 +194,14 @@ def load_sample_names(snames_file):
                     if num_cols is None:
                         num_cols = len(s)
                     elif num_cols != len(s):
-                        logger.warn("Inconsistent number of columns found in sample names file (skipping line): '{}'".format(l.strip()))
+                        logger.warning("Inconsistent number of columns found in sample names file (skipping line): '{}'".format(l.strip()))
                     # Parse the line
                     if len(sample_names_rename_buttons) == 0:
                         sample_names_rename_buttons = s
                     else:
                         sample_names_rename.append(s)
                 elif len(l.strip()) > 0:
-                    logger.warn("Sample names file line did not have columns (must use tabs): {}".format(l.strip()))
+                    logger.warning("Sample names file line did not have columns (must use tabs): {}".format(l.strip()))
     except (IOError, AttributeError) as e:
         logger.error("Error loading sample names file: {}".format(e))
     logger.debug("Found {} sample renaming patterns".format(len(sample_names_rename_buttons)))

--- a/multiqc/utils/lint_helpers.py
+++ b/multiqc/utils/lint_helpers.py
@@ -27,7 +27,7 @@ def check_mods_docs_readme():
         if os.environ.get('GITHUB_WORKSPACE') is not None:
             readme_fn = os.path.join( os.environ.get('GITHUB_WORKSPACE'), 'MultiQC', 'docs', 'README.md')
         if not os.path.isfile(readme_fn):
-            logger.warn("Can't check docs readme in lint test as file doesn't exist: {}".format(readme_fn))
+            logger.warning("Can't check docs readme in lint test as file doesn't exist: {}".format(readme_fn))
             return None
     with open(readme_fn) as f:
         fm = next(yaml.load_all(f, Loader=yaml.SafeLoader))

--- a/multiqc/utils/megaqc.py
+++ b/multiqc/utils/megaqc.py
@@ -57,7 +57,7 @@ def multiqc_dump_json(report):
                 json.dumps(d, cls=MQCJSONEncoder, ensure_ascii=False) # Test that exporting to JSON works
                 exported_data.update(d)
             except (TypeError, KeyError, AttributeError):
-                log.warn("Couldn't export data key '{}.{}'".format(s, k))
+                log.warning("Couldn't export data key '{}.{}'".format(s, k))
         # Get the absolute paths of analysis directories
         exported_data['config_analysis_dir_abs'] = list()
         for d in exported_data.get('config_analysis_dir', []):

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -79,7 +79,7 @@ def get_filelist(run_module_names):
         ]
         unrecognised_keys = [y for x in sps for y in x.keys() if y not in expected_sp_keys]
         if len(unrecognised_keys) > 0:
-            logger.warn("Unrecognised search pattern keys for '{}': {}".format(key, ', '.join(unrecognised_keys)))
+            logger.warning("Unrecognised search pattern keys for '{}': {}".format(key, ', '.join(unrecognised_keys)))
 
         # Split search patterns according to speed of execution.
         if any([x for x in sps if 'contents_re' in x]):
@@ -183,7 +183,7 @@ def get_filelist(run_module_names):
                 # Sanity check - make sure that we're not just running in the installation directory
                 if len(filenames) > 0 and all([fn in filenames for fn in multiqc_installation_dir_files]):
                     logger.error("Error: MultiQC is running in source code directory! {}".format(root))
-                    logger.warn("Please see the docs for how to use MultiQC: https://multiqc.info/docs/#running-multiqc")
+                    logger.warning("Please see the docs for how to use MultiQC: https://multiqc.info/docs/#running-multiqc")
                     dirnames[:] = []
                     filenames[:] = []
                     continue


### PR DESCRIPTION
Fixes #1138 via:

```bash
grep -irl 'logger.warn(' * | xargs sed -i 's/logger.warn(/logger.warning(/g'
```

## If this PR is _not_ a new module

 - [ ] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change
