### PR TITLE
Fix typo of Watson in Mapping Strand Distribution

### DIFF
--- a/multiqc/modules/biscuit/biscuit.py
+++ b/multiqc/modules/biscuit/biscuit.py
@@ -372,9 +372,9 @@ class MultiqcModule(BaseMultiqcModule):
                 pd2[s_name] = dd['read2']
 
         pheader = OrderedDict([
-            ('ff', {'color': '#F53855', 'name': 'ff: Waston-Aligned, Waston-Bisulfite Conversion'}),
-            ('fr', {'color': '#E37B40', 'name': 'fr: Waston-Aligned, Crick-Bisulfite Conversion' }),
-            ('rf', {'color': '#46B29D', 'name': 'rf: Crick-Aligned, Waston-Bisulfite Conversion' }),
+            ('ff', {'color': '#F53855', 'name': 'ff: Watson-Aligned, Watson-Bisulfite Conversion'}),
+            ('fr', {'color': '#E37B40', 'name': 'fr: Watson-Aligned, Crick-Bisulfite Conversion' }),
+            ('rf', {'color': '#46B29D', 'name': 'rf: Crick-Aligned, Watson-Bisulfite Conversion' }),
             ('rr', {'color': '#324D5C', 'name': 'rr: Crick-Aligned, Crick-Bisulfite Conversion'  })
         ])
 


### PR DESCRIPTION
Many thanks to contributing to MultiQC!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things I request on pull requests (PRs).

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

"Watson" had been misspelled in the Mapping Strand Distribution legend. No CHANGELOG update was included as I would say the "Major rewrite" comment already included about the BISCUIT module covers a minor change like this.
