### PR TITLE
Test --ignore-samples

### DIFF
--- a/.github/workflows/multiqc_linux.yml
+++ b/.github/workflows/multiqc_linux.yml
@@ -41,6 +41,11 @@ jobs:
     - name: All modules / Custom report filename
       run: multiqc --lint test_data/data/modules/ --filename full_report.html
 
+    - name: Filter out all filenames (confirm no report)
+      run: |
+        multiqc test_data/data/modules/ --filename all_ignored.html --ignore-samples '*'
+        [[ ! -f all_ignored.html ]]
+
     - name: File-list input of dirs
       run: |
         cd test_data

--- a/.github/workflows/multiqc_windows.yml
+++ b/.github/workflows/multiqc_windows.yml
@@ -63,8 +63,3 @@ jobs:
       run: |
         cd test_data\MultiQC_TestData-master
         multiqc -m star -o testsmultiqc_report_dev -t default_dev -k json --file-list data\special_cases\file_list.txt
-
-    - name: Empty directory
-      run: |
-        mkdir empty_dir
-        multiqc -f empty_dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,9 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 
 #### Bug Fixes:
 
+* Added a new test to check that modules work correctly with `--ignore-samples`. A lot of them didn't:
+    * `Mosdepth`, `conpair`, `Qualimap BamQC`, `Mosdepth`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
+    * These modules have now all been fixed and `--ignore-samples` should work as you expect for whatever data you have.
 * Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/ewels/MultiQC/issues/1130))
 * Made folder naming behaviour of `multiqc_plots` consistent with `multiqc_data`
     * Incremental numeric suffixes now added if folder already exists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 #### Bug Fixes:
 
 * Added a new test to check that modules work correctly with `--ignore-samples`. A lot of them didn't:
-    * `Mosdepth`, `conpair`, `Qualimap BamQC`, `Mosdepth`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
+    * `Mosdepth`, `conpair`, `Qualimap BamQC`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
     * These modules have now all been fixed and `--ignore-samples` should work as you expect for whatever data you have.
 * Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/ewels/MultiQC/issues/1130))
 * Made folder naming behaviour of `multiqc_plots` consistent with `multiqc_data`

--- a/docs/modules/goleft_indexcov.md
+++ b/docs/modules/goleft_indexcov.md
@@ -22,3 +22,10 @@ goleft_indexcov_config:
     - II
     - III
 ```
+
+The number of plotted chromosomes is limited to 50 by default, you can customise this with the following:
+
+```yaml
+goleft_indexcov_config:
+  max_chroms: 80
+```

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -273,15 +273,18 @@ class BaseMultiqcModule(object):
                 newdata = dict()
             else:
                 return data
-            for k,v in data.items():
-                # Match ignore glob patterns
-                glob_match = any( fnmatch.fnmatch(k, sn) for sn in config.sample_names_ignore )
-                re_match = any( re.match(sn, k) for sn in config.sample_names_ignore_re )
-                if not glob_match and not re_match:
-                    newdata[k] = v
+            for s_name,v in data.items():
+                if not self.is_ignore_sample(s_name):
+                    newdata[s_name] = v
             return newdata
         except (TypeError, AttributeError):
             return data
+
+    def is_ignore_sample(self, s_name):
+        """ Should a sample name be ignored? """
+        glob_match = any( fnmatch.fnmatch(s_name, sn) for sn in config.sample_names_ignore )
+        re_match = any( re.match(sn, s_name) for sn in config.sample_names_ignore_re )
+        return glob_match or re_match
 
     def general_stats_addcols(self, data, headers=None, namespace=None):
         """ Helper function to add to the General Statistics variable.

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -71,6 +71,10 @@ class MultiqcModule(BaseMultiqcModule):
 
 
     def parse_logs(self, file_type, root, s_name, fn, f, **kw):
+
+        if self.is_ignore_sample(s_name):
+            return False
+
         log.debug("Parsing %s/%s", root, fn)
         if not file_type in file_types:
             log.error("Unknown output type '%s'. Error in config?", file_type)

--- a/multiqc/modules/conpair/conpair.py
+++ b/multiqc/modules/conpair/conpair.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_conpair_logs(f)
 
         # Filter to strip out ignored sample names
-        self.conpair_concordance_data = self.ignore_samples(self.conpair_data)
+        self.conpair_data = self.ignore_samples(self.conpair_data)
 
         if len(self.conpair_data) == 0:
             raise UserWarning

--- a/multiqc/modules/deeptools/bamPEFragmentSizeDistribution.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSizeDistribution.py
@@ -22,6 +22,8 @@ class bamPEFragmentSizeDistributionMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='bamPEFragmentSizeDistribution')
 
+        self.deeptools_bamPEFragmentSizeDistribution = self.ignore_samples(self.deeptools_bamPEFragmentSizeDistribution)
+
         if len(self.deeptools_bamPEFragmentSizeDistribution) > 0:
             config = {
                 'id': 'fragment_size_distribution_plot',

--- a/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
@@ -23,6 +23,9 @@ class bamPEFragmentSizeTableMixin():
 
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='bamPEFragmentSize')
+
+        self.deeptools_bamPEFragmentSize = self.ignore_samples(self.deeptools_bamPEFragmentSize)
+
         if len(self.deeptools_bamPEFragmentSize) > 0:
             headersSE = OrderedDict()
             headersSE["Reads Sampled"] = {

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -24,6 +24,8 @@ class estimateReadFilteringMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='estimateReadFiltering')
 
+        self.deeptools_estimateReadFiltering = self.ignore_samples(self.deeptools_estimateReadFiltering)
+
         if len(self.deeptools_estimateReadFiltering) > 0:
             header = OrderedDict()
             header["M Entries"] = {

--- a/multiqc/modules/deeptools/plotCorrelation.py
+++ b/multiqc/modules/deeptools/plotCorrelation.py
@@ -22,6 +22,8 @@ class plotCorrelationMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotCorrelation')
 
+        self.deeptools_plotCorrelationData = self.ignore_samples(self.deeptools_plotCorrelationData)
+
         if len(self.deeptools_plotCorrelationData) > 0:
             config = {
                 'id': 'deeptools_correlation_plot',

--- a/multiqc/modules/deeptools/plotCoverage.py
+++ b/multiqc/modules/deeptools/plotCoverage.py
@@ -35,6 +35,9 @@ class plotCoverageMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotCoverage')
 
+        self.deeptools_plotCoverageStdout = self.ignore_samples(self.deeptools_plotCoverageStdout)
+        self.deeptools_plotCoverageOutRawCounts = self.ignore_samples(self.deeptools_plotCoverageOutRawCounts)
+
         if len(self.deeptools_plotCoverageStdout) > 0:
             header = OrderedDict()
             header["min"] = {

--- a/multiqc/modules/deeptools/plotEnrichment.py
+++ b/multiqc/modules/deeptools/plotEnrichment.py
@@ -24,6 +24,8 @@ class plotEnrichmentMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotEnrichment')
 
+        self.deeptools_plotEnrichment = self.ignore_samples(self.deeptools_plotEnrichment)
+
         if len(self.deeptools_plotEnrichment) > 0:
             dCounts = OrderedDict()
             dPercents = OrderedDict()

--- a/multiqc/modules/deeptools/plotFingerprint.py
+++ b/multiqc/modules/deeptools/plotFingerprint.py
@@ -37,6 +37,9 @@ class plotFingerprintMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotFingerprint')
 
+        self.deeptools_plotFingerprintOutRawCounts = self.ignore_samples(self.deeptools_plotFingerprintOutRawCounts)
+        self.deeptools_plotFingerprintOutQualityMetrics = self.ignore_samples(self.deeptools_plotFingerprintOutQualityMetrics)
+
         if len(self.deeptools_plotFingerprintOutRawCounts) > 0:
             self.add_section(name="Fingerprint plot",
                              anchor="deeptools_fingerprint",

--- a/multiqc/modules/deeptools/plotPCA.py
+++ b/multiqc/modules/deeptools/plotPCA.py
@@ -22,6 +22,8 @@ class plotPCAMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotPCA')
 
+        self.deeptools_plotPCAData = self.ignore_samples(self.deeptools_plotPCAData)
+
         if len(self.deeptools_plotPCAData) > 0:
             config = {
                 'id': 'deeptools_pca_plot',

--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -22,6 +22,8 @@ class plotProfileMixin():
             if len(parsed_data) > 0:
                 self.add_data_source(f, section='plotProfile')
 
+        self.deeptools_plotProfile = self.ignore_samples(self.deeptools_plotProfile)
+
         if len(self.deeptools_plotProfile) > 0:
 
             # Try to do plot bands but don't crash if the labels aren't as we expect

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -25,27 +25,30 @@ class BaseRecalibratorMixin():
             '#:GATKTable:RecalTable2:': 'recal_table_2',
         }
         samples_kept = {rt_type: set() for rt_type in recal_table_type}
-        self.gatk_base_recalibrator = {recal_type:
-                                           {table_name: {}
-                                            for table_name
-                                            in report_table_headers.values()}
-                                       for recal_type in recal_table_type}
+        self.gatk_base_recalibrator = {
+            recal_type: {
+                table_name: {} for table_name in report_table_headers.values()
+            } for recal_type in recal_table_type
+        }
 
         for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
+
+            # Check that we're not ignoring this sample name
+            if self.is_ignore_sample(f['s_name']):
+                continue
+
             parsed_data = self.parse_report(f['f'].readlines(), report_table_headers)
             rt_type = determine_recal_table_type(parsed_data)
             if len(parsed_data) > 0:
                 if f['s_name'] in samples_kept[rt_type]:
                     log.debug("Duplicate sample name found! Overwriting: {}".format(f['s_name']))
-                else:
-                    samples_kept[rt_type].add(f['s_name'])
+                samples_kept[rt_type].add(f['s_name'])
 
                 self.add_data_source(f, section='base_recalibrator')
                 for table_name, sample_tables in parsed_data.items():
-                    self.gatk_base_recalibrator[rt_type][table_name][
-                        f['s_name']] = sample_tables
+                    self.gatk_base_recalibrator[rt_type][table_name][f['s_name']] = sample_tables
 
-        # Filter to strip out ignored sample names
+        # Filter to strip out ignored sample names. Again.
         for rt_type in recal_table_type:
             for table_name, sample_tables in self.gatk_base_recalibrator[rt_type].items():
                 self.gatk_base_recalibrator[rt_type][table_name] = self.ignore_samples(

--- a/multiqc/modules/gatk/gatk.py
+++ b/multiqc/modules/gatk/gatk.py
@@ -25,10 +25,12 @@ class MultiqcModule(BaseMultiqcModule, BaseRecalibratorMixin, VariantEvalMixin):
 
         # Initialise the parent object
         super(MultiqcModule, self).__init__(
-            name='GATK', anchor='gatk', target='GATK',
+            name='GATK',
+            anchor='gatk',
+            target='GATK',
             href='https://www.broadinstitute.org/gatk/',
-            info=(" is a toolkit offering a wide variety of tools with a "
-                  "primary focus on variant discovery and genotyping."))
+            info=" is a toolkit offering a wide variety of tools with a primary focus on variant discovery and genotyping."
+        )
 
         # Set up class objects to hold parsed data
         self.general_stats_headers = OrderedDict()

--- a/multiqc/modules/goleft_indexcov/goleft_indexcov.py
+++ b/multiqc/modules/goleft_indexcov/goleft_indexcov.py
@@ -18,10 +18,34 @@ class MultiqcModule(BaseMultiqcModule):
         super(MultiqcModule, self).__init__(name='goleft indexcov', anchor='goleft_indexcov',
                                             href='https://github.com/brentp/goleft/tree/master/indexcov',
                                             info="quickly estimates coverage from a whole-genome bam index.")
-        roc_plot = self.roc_plot()
-        bin_plot = self.bin_plot()
-        if not roc_plot and not bin_plot:
+
+        # Parse ROC data
+        self.roc_plot_data = collections.defaultdict(lambda: collections.defaultdict(dict))
+        for f in self.find_log_files('goleft_indexcov/roc', filehandles=True):
+            self.parse_roc_plot_data(f)
+        # Filter to strip out ignored sample names
+        num_roc_samples = 0
+        for chrom in self.roc_plot_data:
+            self.roc_plot_data[chrom] = self.ignore_samples(self.roc_plot_data[chrom])
+            num_roc_samples = max(len(self.roc_plot_data[chrom]), num_roc_samples)
+
+        # Parse BIN data
+        self.bin_plot_data = {}
+        for f in self.find_log_files('goleft_indexcov/ped', filehandles=True):
+            self.parse_bin_plot_data(f)
+        # Filter to strip out ignored sample names
+        self.bin_plot_data = self.ignore_samples(self.bin_plot_data)
+
+        # Stop execution if no samples
+        num_samples = max(len(self.bin_plot_data), num_roc_samples)
+        if num_samples == 0:
             raise UserWarning
+
+        log.info("Found {} samples".format(num_samples))
+
+        # Add sections to the report
+        self.roc_plot()
+        self.bin_plot()
 
     def _short_chrom(self, chrom):
         """Plot standard chromosomes + X, sorted numerically.
@@ -45,95 +69,88 @@ class MultiqcModule(BaseMultiqcModule):
         elif isinstance(chrom_clean, int) or chrom_clean in default_allowed:
             return chrom_clean
 
+    def parse_roc_plot_data(self, f):
+
+        header = f['f'].readline()
+        sample_names = [self.clean_s_name(x, f["root"]) for x in header.strip().split()[2:]]
+        for parts in (l.rstrip().split() for l in f['f']):
+            if len(parts) > 2:
+                chrom, cov = parts[:2]
+                sample_vals = parts[2:]
+                if self._short_chrom(chrom) is not None:
+                    for val, sample in zip(sample_vals, sample_names):
+                        if not self.is_ignore_sample(sample):
+                            self.roc_plot_data[chrom][sample][float(cov)] = float(val)
+
     def roc_plot(self):
-        helptext = 'Lower coverage samples have shorter curves where the proportion of regions covered \n\
-        drops off more quickly. This indicates a higher fraction of low coverage regions.'
-        max_chroms = 50
-        data = collections.defaultdict(lambda: collections.defaultdict(dict))
-        for fn in self.find_log_files('goleft_indexcov/roc', filehandles=True):
-            header = fn['f'].readline()
-            sample_names = [self.clean_s_name(x, fn["root"]) for x in header.strip().split()[2:]]
-            for parts in (l.rstrip().split() for l in fn['f']):
-                if len(parts) > 2:
-                    chrom, cov = parts[:2]
-                    sample_vals = parts[2:]
-                    if self._short_chrom(chrom) is not None:
-                        for val, sample in zip(sample_vals, sample_names):
-                            data[chrom][sample][float(cov)] = float(val)
 
-        # Filter to strip out ignored sample names
-        for chrom in data:
-            data[chrom] = self.ignore_samples(data[chrom])
+        def to_padded_str(x):
+            x = self._short_chrom(x)
+            try:
+                return "%06d" % x
+            except TypeError:
+                return x
+        chroms = sorted(self.roc_plot_data.keys(), key=to_padded_str)
 
-        if data:
-            def to_padded_str(x):
-                x = self._short_chrom(x)
-                try:
-                    return "%06d" % x
-                except TypeError:
-                    return x
-            chroms = sorted(data.keys(), key=to_padded_str)
-            log.info("Found goleft indexcov ROC reports for %s samples" % (len(data[chroms[0]])))
-            if len(chroms) > max_chroms:
-                log.info("Too many chromosomes found: %s, limiting to %s" % (len(chroms), max_chroms))
-                chroms = chroms[:max_chroms]
-            pconfig = {
-                'id': 'goleft_indexcov-roc-plot',
-                'title': 'goleft indexcov: ROC - genome coverage per scaled depth by chromosome',
-                'xlab': 'Scaled coverage',
-                'ylab': 'Proportion of regions covered',
-                'ymin': 0, 'ymax': 1.0,
-                'xmin': 0, 'xmax': 1.5,
-                'data_labels': [{"name": self._short_chrom(c)} for c in chroms]}
-            self.add_section (
-                name = 'Scaled coverage ROC plot',
-                anchor = 'goleft_indexcov-roc',
-                description = 'Coverage (ROC) plot that shows genome coverage at at given (scaled) depth.',
-                helptext = helptext,
-                plot = linegraph.plot([data[c] for c in chroms], pconfig)
-            )
-            return True
-        else:
-            return False
+        max_chroms = getattr(config, 'goleft_indexcov_config', {}).get('max_chroms', 50)
+        if len(chroms) > max_chroms:
+            log.warning("Too many chromosomes found: %s, limiting to %s" % (len(chroms), max_chroms))
+            chroms = chroms[:max_chroms]
+
+        pconfig = {
+            'id': 'goleft_indexcov-roc-plot',
+            'title': 'goleft indexcov: ROC - genome coverage per scaled depth by chromosome',
+            'xlab': 'Scaled coverage',
+            'ylab': 'Proportion of regions covered',
+            'ymin': 0, 'ymax': 1.0,
+            'xmin': 0, 'xmax': 1.5,
+            'data_labels': [{"name": self._short_chrom(c)} for c in chroms]
+        }
+        self.add_section (
+            name = 'Scaled coverage ROC plot',
+            anchor = 'goleft_indexcov-roc',
+            description = 'Coverage (ROC) plot that shows genome coverage at at given (scaled) depth.',
+            helptext = '''
+                Lower coverage samples have shorter curves where the proportion of regions covered
+                drops off more quickly. This indicates a higher fraction of low coverage regions.
+            ''',
+            plot = linegraph.plot([self.roc_plot_data[c] for c in chroms], pconfig)
+        )
+
+    def parse_bin_plot_data(self, f):
+        header = f['f'].readline()[1:].strip().split("\t")
+        for sample_parts in (l.split("\t") for l in f['f']):
+            cur = dict(zip(header, sample_parts))
+            cur["sample_id"] = self.clean_s_name(cur["sample_id"], f["root"])
+            total = float(cur["bins.in"]) + float(cur["bins.out"])
+            self.bin_plot_data[cur["sample_id"]] = {
+                "x": float(cur["bins.lo"]) / total,
+                "y": float(cur["bins.out"]) / total
+            }
 
     def bin_plot(self):
-        helptext = 'We expect bins to be around 1, so deviations from this indicate problems. \n\
-        Low coverage bins (< 0.15) on the x-axis have regions with low or missing coverage. \n\
-        Higher values indicate truncated BAM files or missing data. \n\
-        Bins with skewed distributions (<0.85 or >1.15) on the y-axis detect dosage bias. \n\
-        Large values on the y-axis are likely to impact CNV and structural variant calling. \n\
-        See the \n\
-        <a href="https://github.com/brentp/goleft/blob/master/docs/indexcov/help-bin.md" target="_blank">goleft indexcov bin documentation</a> \n\
-        for more details.'
-
-        data = {}
-        for fn in self.find_log_files('goleft_indexcov/ped', filehandles=True):
-            header = fn['f'].readline()[1:].strip().split("\t")
-            for sample_parts in (l.split("\t") for l in fn['f']):
-                cur = dict(zip(header, sample_parts))
-                cur["sample_id"] = self.clean_s_name(cur["sample_id"], fn["root"])
-                total = float(cur["bins.in"]) + float(cur["bins.out"])
-                data[cur["sample_id"]] = {"x": float(cur["bins.lo"]) / total,
-                                          "y": float(cur["bins.out"]) / total}
-
-        # Filter to strip out ignored sample names
-        data = self.ignore_samples(data)
-
-        if data:
-            log.info("Found goleft indexcov bin reports for %s samples" % (len(data)))
-            pconfig = {
-                'id': 'goleft_indexcov-bin-plot',
-                'title': 'goleft indexcov: Problematic low and non-uniform coverage bins',
-                'xlab': 'Proportion of bins with depth < 0.15',
-                'ylab': 'Proportion of bins with depth outside of (0.85, 1.15)',
-                'yCeiling': 1.0, 'yFloor': 0.0, 'xCeiling': 1.0, 'xFloor': 0.0}
-            self.add_section (
-                name = 'Problem coverage bins',
-                anchor = 'goleft_indexcov-bin',
-                description = 'This plot identifies problematic samples using binned coverage distributions.',
-                helptext = helptext,
-                plot = scatter.plot(data, pconfig)
-            )
-            return True
-        else:
-            return False
+        pconfig = {
+            'id': 'goleft_indexcov-bin-plot',
+            'title': 'goleft indexcov: Problematic low and non-uniform coverage bins',
+            'xlab': 'Proportion of bins with depth < 0.15',
+            'ylab': 'Proportion of bins with depth outside of (0.85, 1.15)',
+            'yCeiling': 1.0,
+            'yFloor': 0.0,
+            'xCeiling': 1.0,
+            'xFloor': 0.0
+        }
+        self.add_section (
+            name = 'Problem coverage bins',
+            anchor = 'goleft_indexcov-bin',
+            description = 'This plot identifies problematic samples using binned coverage distributions.',
+            helptext = '''
+                We expect bins to be around 1, so deviations from this indicate problems.
+                Low coverage bins (`< 0.15`) on the x-axis have regions with low or missing coverage.
+                Higher values indicate truncated BAM files or missing data.
+                Bins with skewed distributions (`<0.85` or `>1.15`) on the y-axis detect dosage bias.
+                Large values on the y-axis are likely to impact CNV and structural variant calling.
+                See the [goleft indexcov bin documentation](https://github.com/brentp/goleft/blob/master/docs/indexcov/help-bin.md)
+                for more details.
+            ''',
+            plot = scatter.plot(self.bin_plot_data, pconfig)
+        )

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -29,44 +29,43 @@ class MultiqcModule(BaseMultiqcModule):
             name='hap.py',
             anchor='happy',
             href='https://github.com/Illumina/hap.py',
-            info=""" is a set of programs based on htslib to benchmark variant calls against gold standard truth datasets. """ +
-                 """The default shown fields should give the best overview of quality, but there are many other hidden """ +
-                 """fields available. No plots are generated, as hap.py is generally run on single control samples (NA12878, etc.)""" +
-                 """<br/><br/>""" +
-                 """Ideally, precision, recall and F1 Score should all be as close to 1 as possible."""
+            info="is a set of programs based on htslib to benchmark variant calls against gold standard truth datasets."
         )
 
-        self.happy_seen = set()
+        self.happy_raw_sample_names = set()
         self.happy_data = dict()
 
-        n_files = 0
         for f in self.find_log_files("happy", filehandles=True):
-            f['s_name'] = self.clean_s_name(f['s_name'], f['root'])
-
-            n_files += self.parse_log(f)
+            self.parse_log(f)
             self.add_data_source(f)
 
-        if n_files == 0:
+        if len(self.happy_raw_sample_names) == 0:
             raise UserWarning
 
-        log.info("Found {} reports".format(n_files))
+        log.info("Found {} reports".format(len(self.happy_raw_sample_names)))
 
-        if len(self.happy_data) > 0:
-            self.write_data_file(self.happy_data, 'multiqc_happy_data', data_format="json")
+        self.write_data_file(self.happy_data, 'multiqc_happy_data', data_format="json")
 
-            self.add_section(
-                name = "hap.py",
-                anchor = "happy-plot",
-                plot = table.plot(self.happy_data, gen_headers())
-            )
+        self.add_section(
+            name = "hap.py",
+            anchor = "happy-plot",
+            description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
+            helptext = '''
+                No plots are generated, as hap.py is generally run on single control samples (NA12878, etc.)
+
+                Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
+            ''',
+            plot = table.plot(self.happy_data, self.gen_headers())
+        )
 
     def parse_log(self, f):
-        filecount = 1
-        if f['s_name'] in self.happy_seen:
+        # Check that we're not ignoring this sample name
+        if self.is_ignore_sample(f['s_name']):
+            return
+
+        if f['s_name'] in self.happy_raw_sample_names:
             log.warning("Duplicate sample name found in {}! Overwriting: {}".format(f['root'], f['s_name']))
-            filecount = 0
-        else:
-            self.happy_seen.add(f['s_name'])
+        self.happy_raw_sample_names.add(f['s_name'])
 
         rdr = csv.DictReader(f['f'])
         for row in rdr:
@@ -76,214 +75,211 @@ class MultiqcModule(BaseMultiqcModule):
             for fn in rdr.fieldnames:
                 self.happy_data[row_id][fn] = row[fn]
 
-        return filecount
+    def gen_headers(self):
+        h = OrderedDict()
+        h["METRIC.Recall"] = {
+            "title": "Recall",
+            "description": "Recall for truth variant representation = TRUTH.TP / (TRUTH.TP + TRUTH.FN)",
+            "min": 0,
+            "max": 1,
+            "format": "{:.4f}",
+        }
 
+        h["METRIC.Precision"] = {
+            "title": "Precision",
+            "description": "Precision of query variants = QUERY.TP / (QUERY.TP + QUERY.FP)",
+            "min": 0,
+            "max": 1,
+            "format": "{:.4f}",
+        }
 
-def gen_headers():
-    h = OrderedDict()
-    h["METRIC.Recall"] = {
-        "title": "Recall",
-        "description": "Recall for truth variant representation = TRUTH.TP / (TRUTH.TP + TRUTH.FN)",
-        "min": 0,
-        "max": 1,
-        "format": "{:.4f}",
-    }
+        h["METRIC.Frac_NA"] = {
+            "title": "Fraction NA",
+            "description": "Fraction of non-assessed query calls = QUERY.UNK / QUERY.TOTAL",
+            "min": 0,
+            "max": 1,
+            "format": "{:.4f}",
+        }
 
-    h["METRIC.Precision"] = {
-        "title": "Precision",
-        "description": "Precision of query variants = QUERY.TP / (QUERY.TP + QUERY.FP)",
-        "min": 0,
-        "max": 1,
-        "format": "{:.4f}",
-    }
+        h["METRIC.F1_Score"] = {
+            "title": "F1 Score",
+            "description": "Harmonic mean of precision and recall = 2METRIC.RecallMetric.Precision/(METRIC.Recall + METRIC.Precision)",
+            "min": 0,
+            "max": 1,
+            "format": "{:.4f}",
+        }
 
-    h["METRIC.Frac_NA"] = {
-        "title": "Fraction NA",
-        "description": "Fraction of non-assessed query calls = QUERY.UNK / QUERY.TOTAL",
-        "min": 0,
-        "max": 1,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.TOTAL"] = {
+            "title": "Truth: Total",
+            "description": "Total number of truth variants",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["METRIC.F1_Score"] = {
-        "title": "F1 Score",
-        "description": "Harmonic mean of precision and recall = 2METRIC.RecallMetric.Precision/(METRIC.Recall + METRIC.Precision)",
-        "min": 0,
-        "max": 1,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.TP"] = {
+            "title": "Truth: True Positive",
+            "description": "Number of true-positive calls in truth representation (counted via the truth sample column)",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["TRUTH.TOTAL"] = {
-        "title": "Truth: Total",
-        "description": "Total number of truth variants",
-        "format": None,
-        "hidden": True,
-    }
+        h["TRUTH.FN"] = {
+            "title": "Truth: False Negative",
+            "description": "Number of false-negative calls = calls in truth without matching query call",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["TRUTH.TP"] = {
-        "title": "Truth: True Positive",
-        "description": "Number of true-positive calls in truth representation (counted via the truth sample column)",
-        "format": None,
-        "hidden": True,
-    }
+        h["QUERY.TOTAL"] = {
+            "title": "Query: Total",
+            "description": "Total number of query calls",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["TRUTH.FN"] = {
-        "title": "Truth: False Negative",
-        "description": "Number of false-negative calls = calls in truth without matching query call",
-        "format": None,
-        "hidden": True,
-    }
+        h["QUERY.TP"] = {
+            "title": "Query: True Positive",
+            "description": "Number of true positive calls in query representation (counted via the query sample column)",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["QUERY.TOTAL"] = {
-        "title": "Query: Total",
-        "description": "Total number of query calls",
-        "format": None,
-        "hidden": True,
-    }
+        h["QUERY.FP"] = {
+            "title": "Query: False Positive",
+            "description": "Number of false-positive calls in the query file (mismatched query calls within the confident regions)",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["QUERY.TP"] = {
-        "title": "Query: True Positive",
-        "description": "Number of true positive calls in query representation (counted via the query sample column)",
-        "format": None,
-        "hidden": True,
-    }
+        h["QUERY.UNK"] = {
+            "title": "Query: Unknown",
+            "description": "Number of query calls outside the confident regions",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["QUERY.FP"] = {
-        "title": "Query: False Positive",
-        "description": "Number of false-positive calls in the query file (mismatched query calls within the confident regions)",
-        "format": None,
-        "hidden": True,
-    }
+        h["FP.gt"] = {
+            "title": "False Positive genotype",
+            "description": "Number of genotype mismatches (alleles match, but different zygosity)",
+            "hidden": True,
+        }
 
-    h["QUERY.UNK"] = {
-        "title": "Query: Unknown",
-        "description": "Number of query calls outside the confident regions",
-        "format": None,
-        "hidden": True,
-    }
+        h["FP.al"] = {
+            "title": "False Positive allele",
+            "description": "Number of allele mismatches (variants matched by position and not by haplotype)",
+            "hidden": True,
+        }
 
-    h["FP.gt"] = {
-        "title": "False Positive genotype",
-        "description": "Number of genotype mismatches (alleles match, but different zygosity)",
-        "hidden": True,
-    }
+        h["TRUTH.TOTAL.TiTv_ratio"] = {
+            "title": "Truth: Total TiTv ratio",
+            "description": "Transition / Transversion ratio for all truth variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["FP.al"] = {
-        "title": "False Positive allele",
-        "description": "Number of allele mismatches (variants matched by position and not by haplotype)",
-        "hidden": True,
-    }
+        h["TRUTH.TOTAL.het_hom_ratio"] = {
+            "title": "Truth: Total het/hom ratio",
+            "description": "Het/Hom ratio for all truth variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.TOTAL.TiTv_ratio"] = {
-        "title": "Truth: Total TiTv ratio",
-        "description": "Transition / Transversion ratio for all truth variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.FN.TiTv_ratio"] = {
+            "title": "Truth: False Negative TiTv ratio",
+            "description": "Transition / Transversion ratio for false-negative variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.TOTAL.het_hom_ratio"] = {
-        "title": "Truth: Total het/hom ratio",
-        "description": "Het/Hom ratio for all truth variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.FN.het_hom_ratio"] = {
+            "title": "Truth: False Negative het/hom ratio",
+            "description": "Het/Hom ratio for false-negative variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.FN.TiTv_ratio"] = {
-        "title": "Truth: False Negative TiTv ratio",
-        "description": "Transition / Transversion ratio for false-negative variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.TP.TiTv_ratio"] = {
+            "title": "Truth: True Positive TiTv ratio",
+            "description": "Transition / Transversion ratio for true positive variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.FN.het_hom_ratio"] = {
-        "title": "Truth: False Negative het/hom ratio",
-        "description": "Het/Hom ratio for false-negative variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["TRUTH.TP.het_hom_ratio"] = {
+            "title": "Truth: True Positive het/hom ratio",
+            "description": "Het/Hom ratio for true positive variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.TP.TiTv_ratio"] = {
-        "title": "Truth: True Positive TiTv ratio",
-        "description": "Transition / Transversion ratio for true positive variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.FP.TiTv_ratio"] = {
+            "title": "Query: False Positive TiTv ratio",
+            "description": "Transition / Transversion ratio for false positive variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["TRUTH.TP.het_hom_ratio"] = {
-        "title": "Truth: True Positive het/hom ratio",
-        "description": "Het/Hom ratio for true positive variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.FP.het_hom_ratio"] = {
+            "title": "Query: False Positive het/hom ratio",
+            "description": "Het/Hom ratio for false-positive variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.FP.TiTv_ratio"] = {
-        "title": "Query: False Positive TiTv ratio",
-        "description": "Transition / Transversion ratio for false positive variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.TOTAL.TiTv_ratio"] = {
+            "title": "Query: total TiTv ratio",
+            "description": "Transition / Transversion ratio for all query variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.FP.het_hom_ratio"] = {
-        "title": "Query: False Positive het/hom ratio",
-        "description": "Het/Hom ratio for false-positive variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.TOTAL.het_hom_ratio"] = {
+            "title": "Query: Total het/hom ratio",
+            "description": "Het/Hom ratio for all query variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.TOTAL.TiTv_ratio"] = {
-        "title": "Query: total TiTv ratio",
-        "description": "Transition / Transversion ratio for all query variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.TP.TiTv_ratio"] = {
+            "title": "Query: True Positive TiTv ratio",
+            "description": "Transition / Transversion ratio for true positive variants (query representation)",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.TOTAL.het_hom_ratio"] = {
-        "title": "Query: Total het/hom ratio",
-        "description": "Het/Hom ratio for all query variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.TP.het_hom_ratio"] = {
+            "title": "Query: True Positive het/hom ratio",
+            "description": "Het/Hom ratio for true positive variants (query representation)",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.TP.TiTv_ratio"] = {
-        "title": "Query: True Positive TiTv ratio",
-        "description": "Transition / Transversion ratio for true positive variants (query representation)",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.UNK.TiTv_ratio"] = {
+            "title": "Query: Uknown TiTv ratio",
+            "description": "Transition / Transversion ratio for unknown variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.TP.het_hom_ratio"] = {
-        "title": "Query: True Positive het/hom ratio",
-        "description": "Het/Hom ratio for true positive variants (query representation)",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["QUERY.UNK.het_hom_ratio"] = {
+            "title": "Query: Unknown het/hom ratio",
+            "description": "Het/Hom ratio for unknown variants",
+            "hidden": True,
+            "format": "{:.4f}",
+        }
 
-    h["QUERY.UNK.TiTv_ratio"] = {
-        "title": "Query: Uknown TiTv ratio",
-        "description": "Transition / Transversion ratio for unknown variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["Subset.Size"] = {
+            "title": "Subset Size",
+            "description": "the number of nucleotides contained in the current subset",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["QUERY.UNK.het_hom_ratio"] = {
-        "title": "Query: Unknown het/hom ratio",
-        "description": "Het/Hom ratio for unknown variants",
-        "hidden": True,
-        "format": "{:.4f}",
-    }
+        h["Subset.IS_CONF.Size"] = {
+            "title": "Subset Confident Size",
+            "description": "This gives the number of confident bases (-f regions) in the current subset",
+            "format": None,
+            "hidden": True,
+        }
 
-    h["Subset.Size"] = {
-        "title": "Subset Size",
-        "description": "the number of nucleotides contained in the current subset",
-        "format": None,
-        "hidden": True,
-    }
-
-    h["Subset.IS_CONF.Size"] = {
-        "title": "Subset Confident Size",
-        "description": "This gives the number of confident bases (-f regions) in the current subset",
-        "format": None,
-        "hidden": True,
-    }
-
-    return h
+        return h

--- a/multiqc/modules/hicexplorer/hicexplorer.py
+++ b/multiqc/modules/hicexplorer/hicexplorer.py
@@ -35,8 +35,12 @@ class MultiqcModule(BaseMultiqcModule):
                 self.hicexplorer_data[s_name] = parsed_data
                 self.add_data_source(f, s_name=s_name)
 
+        self.hicexplorer_data = self.ignore_samples(self.hicexplorer_data)
+
         if len(self.hicexplorer_data) == 0:
             raise UserWarning
+
+        log.info("Found {} reports".format(len(self.hicexplorer_data)))
 
         self.write_data_file(self.hicexplorer_data, 'multiqc_hicexplorer')
 

--- a/multiqc/modules/homer/homer.py
+++ b/multiqc/modules/homer/homer.py
@@ -49,16 +49,16 @@ class MultiqcModule(BaseMultiqcModule, FindPeaksReportMixin, TagDirReportMixin):
 
         }
         # Call submodule functions
-        
+
 
         n['findpeaks'] = self.parse_homer_findpeaks()
         if n['findpeaks'] > 0:
             log.info("Found {} findPeaks reports".format(n['findpeaks']))
 
-    
-        n['Homer_tagDir'] = self.homer_tagdirectory()
-        if n['Homer_tagDir'] > 0:
-            log.info("Found {} reports".format(n['Homer_tagDir']))
+
+        n['tagDir'] = self.homer_tagdirectory()
+        if n['tagDir'] > 0:
+            log.info("Found {} tagDir reports".format(n['tagDir']))
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:

--- a/multiqc/modules/homer/tagdirectory.py
+++ b/multiqc/modules/homer/tagdirectory.py
@@ -25,7 +25,7 @@ class TagDirReportMixin():
         self.parse_FreqDistribution_data()
         self.homer_stats_table_tagInfo()
 
-        return sum([len(v) for v in self.tagdir_data.values()])
+        return sum([len(v) for k, v in self.tagdir_data.items() if k != 'header'])
 
 
     def parse_gc_content(self):

--- a/multiqc/modules/interop/interop.py
+++ b/multiqc/modules/interop/interop.py
@@ -28,9 +28,15 @@ class MultiqcModule(BaseMultiqcModule):
             if max(len(parsed_data['summary']), len(parsed_data['details'])) > 0:
                 self.indexSummary[f['s_name']] = parsed_data
 
+        self.runSummary = self.ignore_samples(self.runSummary)
+        self.indexSummary = self.ignore_samples(self.indexSummary)
+
         # No samples
-        if max(len(self.runSummary), len(self.indexSummary)) == 0:
+        num_samples = max(len(self.runSummary), len(self.indexSummary))
+        if num_samples == 0:
             raise UserWarning
+
+        log.info("Found {} reports".format(num_samples))
 
         # Create report Sections
         if len(self.runSummary) > 0:

--- a/multiqc/modules/jellyfish/jellyfish.py
+++ b/multiqc/modules/jellyfish/jellyfish.py
@@ -14,19 +14,26 @@ log = logging.getLogger(__name__)
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(name='Jellyfish', anchor='jellyfish',
-        href="http://www.cbcb.umd.edu/software/jellyfish/",
-        info="is a tool for fast, memory-efficient counting of k-mers in DNA.")
+        super(MultiqcModule, self).__init__(
+            name='Jellyfish',
+            anchor='jellyfish',
+            href="http://www.cbcb.umd.edu/software/jellyfish/",
+            info="is a tool for fast, memory-efficient counting of k-mers in DNA."
+        )
 
-        self.jellyfish_data  = dict()
+        self.jellyfish_data = dict()
         self.jellyfish_max_x = 0
         for f in self.find_log_files('jellyfish', filehandles=True):
             self.parse_jellyfish_data(f)
 
         if self.jellyfish_max_x < 100:
-            self.jellyfish_max_x = 200 # the maximum is below 100, we display anyway up to 200
+            # the maximum is below 100, we display anyway up to 200
+            self.jellyfish_max_x = 200
         else:
-            self.jellyfish_max_x = 2*self.max_key #in this case the area plotted is a function of the maximum x
+            # in this case the area plotted is a function of the maximum x
+            self.jellyfish_max_x = 2 * self.max_key
+
+        self.jellyfish_data = self.ignore_samples(self.jellyfish_data)
 
         if len(self.jellyfish_data) == 0:
             raise UserWarning

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -75,6 +75,11 @@ class MultiqcModule(BaseMultiqcModule):
 
         dist_data, cov_data, xmax, perchrom_avg_data = self.parse_cov_dist()
 
+        # Filter out any samples from --ignore-samples
+        dist_data = self.ignore_samples(dist_data)
+        cov_data = self.ignore_samples(cov_data)
+        perchrom_avg_data = self.ignore_samples(perchrom_avg_data)
+
         # No samples found
         num_samples = max(
             len(dist_data),

--- a/multiqc/modules/pycoqc/pycoqc.py
+++ b/multiqc/modules/pycoqc/pycoqc.py
@@ -32,9 +32,13 @@ class MultiqcModule(BaseMultiqcModule):
             if data:
                 self.pycoqc_data[f['s_name']] = data
 
+        self.pycoqc_data = self.ignore_samples(self.pycoqc_data)
+
         # Stop if we didn't find anything
         if len(self.pycoqc_data) == 0:
             raise UserWarning
+
+        log.info("Found {} reports".format(len(self.pycoqc_data)))
 
         self.parse_data()
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -42,6 +42,7 @@ def parse_reports(self):
     self.qualimap_bamqc_gc_by_species = dict()  # {'HUMAN': data_dict, 'MOUSE': data_dict}
     for f in self.find_log_files('qualimap/bamqc/gc_dist', filehandles=True):
         parse_gc_dist(self, f)
+    self.qualimap_bamqc_gc_content_dist = self.ignore_samples(self.qualimap_bamqc_gc_content_dist)
     self.qualimap_bamqc_gc_by_species = self.ignore_samples(self.qualimap_bamqc_gc_by_species)
 
     num_parsed = max(

--- a/multiqc/modules/seqyclean/seqyclean.py
+++ b/multiqc/modules/seqyclean/seqyclean.py
@@ -42,6 +42,9 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.seqyclean_data = self.ignore_samples(self.seqyclean_data)
 
+        if len(self.seqyclean_data) == 0:
+            raise UserWarning
+
         log.info("Found {} logs".format(len(self.seqyclean_data)))
 
         # Adding the bar plots

--- a/multiqc/modules/snpsplit/snpsplit.py
+++ b/multiqc/modules/snpsplit/snpsplit.py
@@ -34,6 +34,9 @@ class MultiqcModule(BaseMultiqcModule):
             parsed_log = self.parse_old_snpsplit_log(f)
             self._save_parsed(parsed_log, f)
 
+        # Filter --ignore-samples
+        self.snpsplit_data = self.ignore_samples(self.snpsplit_data)
+
         if len(self.snpsplit_data) == 0:
             raise UserWarning
         log.info("Found {} reports".format(len(self.snpsplit_data)))
@@ -47,7 +50,7 @@ class MultiqcModule(BaseMultiqcModule):
     def _save_parsed(self, parsed, f):
         s_name = self.clean_s_name(parsed[0], f['root'])
         if s_name in self.snpsplit_data:
-            log.warning("Replacing duplicate sample {}".format(s_name))
+            log.debug("Replacing duplicate sample {}".format(s_name))
         self.snpsplit_data[s_name] = parsed[1]
         self.add_data_source(f, s_name=s_name)
 


### PR DESCRIPTION
I realised that it should be fairly easy to test whether modules are properly using `self.ignore_samples()` to filter out samples with `--ignore-samples`. So this adds a new GitHub action test to ignore _all_ samples with a universal glob: `--ignore-samples '*'`

The downside is that this of course finds lots of MultiQC modules that aren't doing this properly. So now I need to go through them all to make the new test pass.