### PR TITLE
Update DamageProfiler with small Typo fix in 3P plot typo

### DIFF
--- a/multiqc/modules/damageprofiler/damageprofiler.py
+++ b/multiqc/modules/damageprofiler/damageprofiler.py
@@ -260,7 +260,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         config = {
             'id': 'threeprime_misinc_plot',
-            'title': 'DamageProfiler: 3P G>A misincorporation plot',
+            'title': 'DamageProfiler: 3\' G>A misincorporation plot',
             'ylab': '% G to A substituted',
             'xlab': 'Nucleotide position from 3\'',
             'tt_label': '{point.y:.2f} % G>A misincorporations at nucleotide position {point.x}',


### PR DESCRIPTION
Very small typo fix to make sure plot names are consistent in 5' and 3' C>T/G>A plots for DamagProfiler

## If this PR is _not_ a new module
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated (not necessary)
 - [ ] (optional but recommended): https://github.com/ewels/MultiQC_TestData contains test data for this change

## If this PR is for a new module
 - [ ] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository
 - [ ] Code is tested and works locally (including with `--lint` flag)
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created
 - [ ] Everything that can be represented with a plot instead of a table is a plot
 - [ ] Report sections have a description and help text (with `self.add_section`)
 - [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [ ] Module does not do any significant computational work
