### PR TITLE
Sample filters with regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## MultiQC v1.10dev
 
 #### New MultiQC Features
+* `--sample-filters` now also accepts `show_re` and `hide_re` in addition to `show` and `hide`. The `_re` options use regex, while the "normal" options use globbing.
 
 #### New Modules
 

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -120,13 +120,21 @@ quality metrics overlap between these batches.
 It's possible to supply a file with one or more patterns to filter samples on using the
 `--sample-filters` command line option. This file should be a tab-delimited file with each
 row containing the button name, whether the pattern should be hidden (`hide`) or shown (`show`)
-and the patterns to be applied (all subsequent columns).
+and the patterns to be applied (all subsequent columns). If you want to use a regular expression 
+pattern, opposed to the default globbing, you can use `hide_re` and `show_re`.
 
 For example, to filter on read pair groups, you could use the following file:
 
 ```tsv
 Read Group 1	show	_R1
 Read Group 2	show	_R2
+```
+
+Or in regex mode:
+
+```tsv
+Read Group 1	show_re	.*_R1
+Read Group 2	show_re	.*_R2
 ```
 
 To filter on controls and sample groups you could use:

--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -53,11 +53,21 @@ $(function () {
     var j = $(this).data('index');
     var pattern = mqc_config['show_hide_patterns'][j];
     var show_hide_mode = mqc_config['show_hide_mode'][j];
+    var regex = mqc_config['show_hide_regex'][j];
     if(!Array.isArray(pattern)){
       pattern = [pattern];
     }
     if(show_hide_mode === undefined){
       show_hide_mode = 'show';
+    }
+
+    // click the regex button if we want it turned on/off
+    var button = document.getElementsByClassName("mqc_switch re_mode")[2]
+    if (button.className.includes(" on") && !regex){
+      button.click()
+    }
+    if (button.className.includes(" off") && regex){
+      button.click()
     }
 
     // Apply the changes

--- a/multiqc/templates/default/head.html
+++ b/multiqc/templates/default/head.html
@@ -23,6 +23,7 @@ page contents, it's machine-readable tags for browsers and search engines.
     "num_datasets_plot_limit": config.num_datasets_plot_limit,
     "sample_names_rename": config.sample_names_rename,
     "show_hide_patterns": config.show_hide_patterns,
+    "show_hide_regex": config.show_hide_regex,
     "show_hide_mode": config.show_hide_mode,
     "decimalPoint_format": config.decimalPoint_format,
     "thousandsSep_format": config.thousandsSep_format,

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -214,10 +214,11 @@ def load_show_hide(sh_file):
                 logger.debug("Loading sample renaming config settings from: {}".format(sh_file))
                 for l in f:
                     s = l.strip().split("\t")
-                    if len(s) >= 3 and s[1] in ["show", "hide"]:
+                    if len(s) >= 3 and s[1] in ["show", "hide", "show_re", "hide_re"]:
                         show_hide_buttons.append(s[0])
                         show_hide_mode.append(s[1])
                         show_hide_patterns.append(s[2:])
+                        show_hide_regex.append(s[1] not in ["show", "hide"])  # flag whether or not regex is turned on
         except (AttributeError) as e:
             logger.error("Error loading show patterns file: {}".format(e))
 
@@ -228,6 +229,7 @@ def load_show_hide(sh_file):
         show_hide_buttons.insert(0, 'Show all')
         show_hide_mode.insert(0, 'hide')
         show_hide_patterns.insert(0, [])
+        show_hide_regex.insert(0, False)
 
 def update(u):
     return update_dict(globals(), u)

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -101,6 +101,7 @@ sample_names_rename_buttons: []
 sample_names_rename: []
 show_hide_buttons: []
 show_hide_patterns: []
+show_hide_regex: []
 show_hide_mode: []
 no_version_check: false
 log_filesize_limit: 10000000


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated

As discussed in on gitter. I added the option to have regex buttons. I kinda lazily just added another variable which keeps track of whether or not regex is required. 

I am not entirely sure if the way I grab the regex button is robust, I am not a javascript person :). 

Pinging @karl616 as he might be interested + willing to test? 