### PR TITLE
Split happy data into INDEL and SNP tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
     * Fix issue where missing out fields could crash the module ([#1223](https://github.com/ewels/MultiQC/issues/1223))
 * **featureCounts**
     * Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/ewels/MultiQC/issues/1022))
+* **hap.py**
+    * Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/ewels/MultiQC/issues/1241))
 * **Kaiju**
     * Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/ewels/MultiQC/issues/1217))
 * **MALT**

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         """ MultiQC module for processing hap.py output logs """
         super(MultiqcModule, self).__init__(
-            name='Hap.py',
+            name='hap.py',
             anchor='happy',
             href='https://github.com/Illumina/hap.py',
             info="is a set of programs based on htslib to benchmark variant calls against gold standard truth datasets."
@@ -50,7 +50,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.happy_snp_data, 'multiqc_happy_snp_data', data_format="json")
 
         self.add_section(
-            name = "Happy INDEL",
+            name = "INDEL",
             anchor = "happy-indel-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''
@@ -62,7 +62,7 @@ class MultiqcModule(BaseMultiqcModule):
         )
         
         self.add_section(
-            name = "Happy SNP",
+            name = "SNP",
             anchor = "happy-snp-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 """MultiQC module to parse output from OUS variant calling pipeline"""
-# C:\Users\ratka\Documents\STP\Addenbrookes\DNAnexus\MultiQC\happy_multiqc.py
 
 from __future__ import print_function
 from collections import OrderedDict

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -50,16 +50,27 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.happy_snv_data, 'multiqc_happy_snv_data', data_format="json")
 
         self.add_section(
-            name = "hap.py",
-            anchor = "happy-plot",
+            name = "Hap.py indel",
+            anchor = "happy-indel-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''
                 No plots are generated, as hap.py is generally run on single control samples (NA12878, etc.)
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot_indel = table.plot(self.happy_indel_data, self.gen_headers())
-#             plot_snv = table.plot(self.happy_snv_data, self.gen_headers())
+            plot = table.plot(self.happy_indel_data, self.gen_headers())
+        )
+        
+        self.add_section(
+            name = "Hap.py SNV",
+            anchor = "happy-snv-plot",
+            description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
+            helptext = '''
+                No plots are generated, as hap.py is generally run on single control samples (NA12878, etc.)
+
+                Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
+            ''',
+            plot = table.plot(self.happy_snv_data, self.gen_headers())
         )
 
     def parse_log(self, f):

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -48,6 +48,9 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.happy_indel_data, 'multiqc_happy_indel_data', data_format="json")
         self.write_data_file(self.happy_snp_data, 'multiqc_happy_snp_data', data_format="json")
 
+        indel_headers = {k+'_indel': v for k, v in self.gen_headers().items()}
+        snp_headers = {k+'_snp': v for k, v in self.gen_headers().items()}
+
         self.add_section(
             name = "INDEL",
             anchor = "happy-indel-plot",
@@ -57,7 +60,7 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_indel_data, self.gen_headers())
+            plot = table.plot(self.happy_indel_data, indel_headers())
         )
         
         self.add_section(
@@ -69,7 +72,7 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_snp_data, self.gen_headers())
+            plot = table.plot(self.happy_snp_data, snp_headers())
         )
 
     def parse_log(self, f):

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -58,8 +58,8 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_indel_data, self.gen_headers())
-            plot = table.plot(self.happy_snv_data, self.gen_headers())
+            plot_indel = table.plot(self.happy_indel_data, self.gen_headers())
+            plot_snv = table.plot(self.happy_snv_data, self.gen_headers())
         )
 
     def parse_log(self, f):

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         self.happy_raw_sample_names = set()
         self.happy_indel_data = dict()
-        self.happy_snv_data = dict()
+        self.happy_snp_data = dict()
 
         for f in self.find_log_files("happy", filehandles=True):
             self.parse_log(f)
@@ -47,7 +47,7 @@ class MultiqcModule(BaseMultiqcModule):
         log.info("Found {} reports".format(len(self.happy_raw_sample_names)))
 
         self.write_data_file(self.happy_indel_data, 'multiqc_happy_indel_data', data_format="json")
-        self.write_data_file(self.happy_snv_data, 'multiqc_happy_snv_data', data_format="json")
+        self.write_data_file(self.happy_snp_data, 'multiqc_happy_snp_data', data_format="json")
 
         self.add_section(
             name = "Hap.py indel",
@@ -62,15 +62,15 @@ class MultiqcModule(BaseMultiqcModule):
         )
         
         self.add_section(
-            name = "Hap.py SNV",
-            anchor = "happy-snv-plot",
+            name = "Hap.py SNP",
+            anchor = "happy-snp-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''
                 No plots are generated, as hap.py is generally run on single control samples (NA12878, etc.)
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_snv_data, self.gen_headers())
+            plot = table.plot(self.happy_snp_data, self.gen_headers())
         )
 
     def parse_log(self, f):
@@ -90,11 +90,11 @@ class MultiqcModule(BaseMultiqcModule):
                     self.happy_indel_data[row_id] = {"sample_id": f['s_name']}
                 for fn in rdr.fieldnames:
                     self.happy_indel_data[row_id][fn] = row[fn]
-            elif row["Type"] == 'SNV':
-                if row_id not in self.happy_snv_data:
-                    self.happy_snv_data[row_id] = {"sample_id": f['s_name']}
+            elif row["Type"] == 'SNP':
+                if row_id not in self.happy_snp_data:
+                    self.happy_snp_data[row_id] = {"sample_id": f['s_name']}
                 for fn in rdr.fieldnames:
-                    self.happy_snv_data[row_id][fn] = row[fn]
+                    self.happy_snp_data[row_id][fn] = row[fn]
 
     def gen_headers(self):
         h = OrderedDict()

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         """ MultiQC module for processing hap.py output logs """
         super(MultiqcModule, self).__init__(
-            name='hap.py',
+            name='Hap.py',
             anchor='happy',
             href='https://github.com/Illumina/hap.py',
             info="is a set of programs based on htslib to benchmark variant calls against gold standard truth datasets."
@@ -50,7 +50,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.happy_snp_data, 'multiqc_happy_snp_data', data_format="json")
 
         self.add_section(
-            name = "Hap.py indel",
+            name = "Happy INDEL",
             anchor = "happy-indel-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''
@@ -62,7 +62,7 @@ class MultiqcModule(BaseMultiqcModule):
         )
         
         self.add_section(
-            name = "Hap.py SNP",
+            name = "Happy SNP",
             anchor = "happy-snp-plot",
             description = 'The default shown fields should give the best overview of quality, but there are many other hidden fields available.',
             helptext = '''

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -60,7 +60,7 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_indel_data, indel_headers())
+            plot = table.plot(self.happy_indel_data, indel_headers)
         )
         
         self.add_section(
@@ -72,7 +72,7 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
-            plot = table.plot(self.happy_snp_data, snp_headers())
+            plot = table.plot(self.happy_snp_data, snp_headers)
         )
 
     def parse_log(self, f):

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -59,7 +59,7 @@ class MultiqcModule(BaseMultiqcModule):
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             ''',
             plot_indel = table.plot(self.happy_indel_data, self.gen_headers())
-            plot_snv = table.plot(self.happy_snv_data, self.gen_headers())
+#             plot_snv = table.plot(self.happy_snv_data, self.gen_headers())
         )
 
     def parse_log(self, f):


### PR DESCRIPTION
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated

This is an attempt to resolve issue #1233 
Data from the happy file is split into indel_data and snp_data and presented in separate tables in the report to allow for different thresholds to be set during conditional formatting set in the config file. Column headers now have an '_indel' or '_snp' suffix, so that they can be referred to in the config file.
Potential future improvement could include an option set in the config file whether or not to split the happy values.
