### PR TITLE
Minor Fix MALT axis labels

### DIFF
--- a/multiqc/modules/malt/malt.py
+++ b/multiqc/modules/malt/malt.py
@@ -85,7 +85,7 @@ class MultiqcModule(BaseMultiqcModule):
         config = {
             'id': 'malt-mappability-plot',
             'title': 'MALT: Metagenomic Mappability',
-            'ylab': 'Samples',
+            'ylab': 'Reads',
         }
         self.add_section(
             name='Metagenomic Mappability',
@@ -103,7 +103,7 @@ class MultiqcModule(BaseMultiqcModule):
         config = {
             'id': 'malt-taxonomic-success-plot',
             'title': 'MALT: Taxonomic assignment success',
-            'ylab': 'Samples',
+            'ylab': 'Reads',
         }
         self.add_section(
             name='Taxonomic assignment success',


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated

This fixes the X axis labels for the MALT module from samples to reads. The 'samples' are presumably left over from a template.

Too small to an update to warrant changelog ;)