### PR TITLE
[bugfix] fgbio error rate by read position per-base plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
     * Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/ewels/MultiQC/issues/1212))
 * **PycoQC**
     * Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
+* **fgbio**
+    * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific
+	  base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  See ([#1215](https://github.com/ewels/MultiQC/pull/1251))
 
 #### New Custom Content features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@
 * **PycoQC**
     * Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
 * **fgbio**
-    * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific
-	  base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  See ([#1215](https://github.com/ewels/MultiQC/pull/1251))
+    * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  ([#1215](https://github.com/ewels/MultiQC/pull/1251))
 
 #### New Custom Content features
 

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -12,6 +12,7 @@ def parse_reports(self):
     Stores the per-read-per-position metrics into a data file and adds a section
     with a per-sample plot.
     """
+    linegraph_keys = ['error_rate', 'a_to_c_error_rate', 'a_to_g_error_rate', 'a_to_t_error_rate', 'c_to_a_error_rate', 'c_to_g_error_rate', 'c_to_t_error_rate']
 
     # slurp in all the data
     all_data = dict()
@@ -38,8 +39,8 @@ def parse_reports(self):
             if read_number not in s_data:
                 s_data[read_number] = dict()
             s_data[read_number][position] = row_data
-            if row_data['error_rate'] > y_max:
-                y_max = row_data['error_rate']
+            for key in linegraph_keys:
+                y_max = max(y_max, row_data[key])
             bases_total += row_data['bases_total']
             errors += row_data['errors']
 
@@ -82,8 +83,7 @@ def parse_reports(self):
     }
 
     # Build a list of linegraphs
-    linegraph_data = [{}, {}, {}, {}, {}, {}, {}]
-    linegraph_keys = ['error_rate', 'a_to_c_error_rate', 'a_to_g_error_rate', 'a_to_t_error_rate', 'c_to_a_error_rate', 'c_to_g_error_rate', 'c_to_t_error_rate']
+    linegraph_data = [{} for _ in linegraph_keys]
     for s_name, s_data in all_data.items():
         for read_number, read_data in s_data.items():
             s_name = "%s_R%d" % (s_name, int(read_number) + 1)


### PR DESCRIPTION
If the error rate for any base-to-base (ex. A>C/a_to_c_error_rate column ) error
was higher than the overall error rate (error_rate column), then it
would be filtered out by y_max.

This fix calculates y_max across not only the overall error rate (across
positions), but also the base-to-base error rate columns.

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
