### PR TITLE
New Module: GffCompare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * [**HOPS**](https://www.github.com/rhubler/HOPS)
   * Post-alignment ancient DNA analysis tool for MALT
 
+* [**GffCompare**]](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml) 
+    * GffCompare can annotate and estimate accuracy of one or more GFF files compared with a reference annotation. 
+
 #### Module updates
 
 * **DRAGEN**

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ MultiQC Modules:
     featureCounts: modules/featureCounts.md
     fgbio: modules/fgbio.md
     GATK: modules/gatk.md
+    GffCompare: modules/gffcompare.md
     goleft_indexcov: modules/goleft_indexcov.md
     Hap.py: modules/happy.md
     HiCExplorer: modules/hicexplorer.md

--- a/docs/modules/gffcompare.md
+++ b/docs/modules/gffcompare.md
@@ -5,11 +5,8 @@ Description: >
     is a tool to compare, merge and annotate one or more GFF files with a reference annotation in GFF format.
 ---
 
-TODO
+Currently, nothing is added to the general statistics table. Thisis ebcause there is not a single most important key value. Additionally this allows multiple GffCompare results for the same sample (different references?) having a different name without bloating the general stats table.
 
-- Single Query
+The Sensitivity/Precision values are displayed in a single plot, different loci levels can be switched by choosing a different dataset.
 
-- Multiple Query
-
-- Isoform annotation
-
+Please use gffcompare only with single samples. Multi-Sample comparisons are not correctly rendered by this module.

--- a/docs/modules/gffcompare.md
+++ b/docs/modules/gffcompare.md
@@ -1,0 +1,15 @@
+---
+Name: GffCompare
+URL: https://ccb.jhu.edu/software/stringtie/gffcompare.shtml
+Description: >
+    is a tool to compare, merge and annotate one or more GFF files with a reference annotation in GFF format.
+---
+
+TODO
+
+- Single Query
+
+- Multiple Query
+
+- Isoform annotation
+

--- a/multiqc/modules/gffcompare/__init__.py
+++ b/multiqc/modules/gffcompare/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import
+from .gffcompare import MultiqcModule

--- a/multiqc/modules/gffcompare/gffcompare.py
+++ b/multiqc/modules/gffcompare/gffcompare.py
@@ -23,52 +23,76 @@ class MultiqcModule(BaseMultiqcModule):
         info="is a tool to compare, merge and annotate one or more GFF files with a reference annotation in GFF format.")
 
         # Parse stats file
+        # Everything is hardcoded, needs to be adjusted if output should change. 
+        # I hope there are no other versions of gffcompare that produce different output formats
         self.gffcompare_data = {}
         for f in self.find_log_files('gffcompare'):
+            #print(f)
             sample = f['s_name']
             self.gffcompare_data[sample]= {}
             lines = f['f'].splitlines()
-            for line in lines[1:]:
-                print(line)
+
+            ## Transcript and loci numbers:
+            # Query
+            c = [int(s) for s in lines[5].replace("(", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts'] = {}
+            self.gffcompare_data[sample]['counts']['query'] = {}
+            self.gffcompare_data[sample]['counts']['query']['mRNA'] =c[0]
+            self.gffcompare_data[sample]['counts']['query']['loci'] = c[1]
+            self.gffcompare_data[sample]['counts']['query']['multi_exon_transcripts'] = c[2]
+            c = [int(s) for s in lines[6].replace("(", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['query']['multi_transcript_loci'] = c[0]
+            
+            # Reference
+            c = [int(s) for s in lines[7].replace("(", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['reference'] = {}
+            self.gffcompare_data[sample]['counts']['reference']['mRNA'] = c[0]
+            self.gffcompare_data[sample]['counts']['reference']['loci'] = c[1]
+            self.gffcompare_data[sample]['counts']['reference']['multi_exon_transcripts'] = c[2]
+            
+            c = [int(s) for s in lines[8].replace("(", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['super_loci'] = c[0]
+
+            ## Accuracy metrics (Sensitivity/Precision)
+            self.gffcompare_data[sample]['accuracy'] = {}
+            for line in lines[10:16]:
+                split = line.replace("|", "").replace("Intron chain", "Intron_chain").split()
+                self.gffcompare_data[sample]['accuracy'][split[0]] = {}
+                self.gffcompare_data[sample]['accuracy'][split[0]]['sensitivity'] = float(split[2])
+                self.gffcompare_data[sample]['accuracy'][split[0]]['precision'] = float(split[3])
+
+            ## Additional count data
+            self.gffcompare_data[sample]['counts']['matching_intron_chains'] = [int(s) for s in lines[17].replace("(", " ").split() if s.isdigit()][0]
+            self.gffcompare_data[sample]['counts']['matching_transcripts'] = [int(s) for s in lines[18].replace("(", " ").split() if s.isdigit()][0]
+            self.gffcompare_data[sample]['counts']['matching_loci'] = [int(s) for s in lines[19].replace("(", " ").split() if s.isdigit()][0]
+
+            ## Additional count data
+            self.gffcompare_data[sample]['counts']['missed_exons'] = [int(s) for s in lines[21].replace("/", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['novel_exons'] = [int(s) for s in lines[22].replace("/", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['missed_introns'] = [int(s) for s in lines[23].replace("/", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['novel_introns'] = [int(s) for s in lines[24].replace("/", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['missed_loci'] = [int(s) for s in lines[25].replace("/", " ").split() if s.isdigit()]
+            self.gffcompare_data[sample]['counts']['novel_loci'] = [int(s) for s in lines[26].replace("/", " ").split() if s.isdigit()]
+
+        print(self.gffcompare_data)
 
         # Filter to strip out ignored sample names
         self.gffcompare_data = self.ignore_samples(self.gffcompare_data)
 
         # Raise user warning if no data found
-        if len(self.pychopper_data) == 0:
+        if len(self.gffcompare_data) == 0:
             raise UserWarning
 
         log.info("Found {} reports".format(len(self.gffcompare_data)))
 
-        # Add to general statistics table:
-        # Percentage of full length transcripts
-        """
-        data_general_stats={}
-        for sample in self.gffcompare_data.keys():
-            data_general_stats[sample] = {}
-            c=self.pychopper_data[sample]['Classification']
-            ftp=c['Primers_found'] * 100 / (c['Primers_found'] + c['Rescue'] + c['Unusable'])
-            data_general_stats[sample]['ftp']=ftp
-
-        headers = OrderedDict()
-        headers['ftp'] = {
-            'title' : 'Full-Length cDNA',
-            'description' : 'Percentage of full length cDNA reads with correct primers at both ends',
-            'suffix' : '%',
-            'max': 100,
-            'min': 0,
-        }
-        
-
-        self.general_stats_addcols(data_general_stats, headers)
-        """
-
+        # Add nothing to general statistics table  general statistics table
+       
         # Write data file
-        self.write_data_file(self.pychopper_data, 'multiqc_pychopper')
+        self.write_data_file(self.gffcompare_data, 'multiqc_gffcompare')
 
         # Report sections
         self.add_section (
-            name = "cDNA Read Classification",
+            name = "Gffcompare comparison accuracy",
             description = (
                 """
                 This plot shows the cDNA read categories identified by Pychopper </br>
@@ -82,11 +106,11 @@ class MultiqcModule(BaseMultiqcModule):
                 * **Unusable**: Reads without correct primer combinations.
                 """
             ),
-            anchor = 'pychopper_classification',
-            plot = self.plot_classification()
+            anchor = 'gffcompare_accuracy',
+            plot = self.plot_accuracy()
         )
         self.add_section (
-            name = "cDNA Strand Orientation",
+            name = "GffCompare  Strand Orientation",
             description = (
                 """
                 This plot shows the strand orientation of full length cDNA reads

--- a/multiqc/modules/gffcompare/gffcompare.py
+++ b/multiqc/modules/gffcompare/gffcompare.py
@@ -25,9 +25,9 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse stats file
         # Everything is hardcoded with linenumbers, needs to be adjusted if output should change. 
         # Other versions of GffCompare with different ouptut formats might not work.
+        
         self.gffcompare_data = {}
         for f in self.find_log_files('gffcompare'):
-            #print(f)
             sample = f['s_name']
             self.gffcompare_data[sample]= {}
             lines = f['f'].splitlines()
@@ -48,8 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.gffcompare_data[sample]['counts']['reference'] = {}
             self.gffcompare_data[sample]['counts']['reference']['mRNA'] = c[0]
             self.gffcompare_data[sample]['counts']['reference']['loci'] = c[1]
-            self.gffcompare_data[sample]['counts']['reference']['multi_exon_transcripts'] = c[2]
-            
+            self.gffcompare_data[sample]['counts']['reference']['multi_exon_transcripts'] = c[2]    
             c = [int(s) for s in lines[8].replace("(", " ").split() if s.isdigit()]
             self.gffcompare_data[sample]['counts']['super_loci'] = c[0]
 
@@ -68,7 +67,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.gffcompare_data[sample]['counts']['matching_transcripts'] = [int(s) for s in lines[18].replace("(", " ").split() if s.isdigit()][0]
             self.gffcompare_data[sample]['counts']['matching_loci'] = [int(s) for s in lines[19].replace("(", " ").split() if s.isdigit()][0]
 
-            ## Additional count data
+            ## Missed/Novel genomic elements
             self.gffcompare_data[sample]['missed']['Exons'] = [int(s) for s in lines[21].replace("/", " ").split() if s.isdigit()]
             self.gffcompare_data[sample]['novel']['Exons'] = [int(s) for s in lines[22].replace("/", " ").split() if s.isdigit()]
             self.gffcompare_data[sample]['missed']['Introns'] = [int(s) for s in lines[23].replace("/", " ").split() if s.isdigit()]
@@ -76,7 +75,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.gffcompare_data[sample]['missed']['Loci'] = [int(s) for s in lines[25].replace("/", " ").split() if s.isdigit()]
             self.gffcompare_data[sample]['novel']['Loci'] = [int(s) for s in lines[26].replace("/", " ").split() if s.isdigit()]
 
-        print(self.gffcompare_data)
+        #print(self.gffcompare_data)
 
         # Filter to strip out ignored sample names
         self.gffcompare_data = self.ignore_samples(self.gffcompare_data)
@@ -87,25 +86,29 @@ class MultiqcModule(BaseMultiqcModule):
 
         log.info("Found {} reports".format(len(self.gffcompare_data)))
 
-        # Add nothing to general statistics table  general statistics table
+        # Add nothing to general statistics table
        
         # Write data file
         self.write_data_file(self.gffcompare_data, 'multiqc_gffcompare')
 
         # Report sectionsq
         self.add_section (
-            name = "Gffcompare comparison accuracy",
+            name = "GffCompare: Accuracy values",
             description = (
                 """
-                Accuracy values for comparison of 
+                Displayed are the accuracy values precisiond and sensitivity for different levels of genomic features. 
+                The metrics are calculated for the comparison of a query and reference GTF file.
                 """
             ),
             helptext = (
                 """
-                There are three possible cases:
-                * **Primers found**: Full length cDNA reads with correct primers at both ends.
-                * **Rescued reads**: Split fusion reads.
-                * **Unusable**: Reads without correct primer combinations.
+                Sensitivity (also known as recall) is the True Positive Rate where True Positives are query features which agree with corresponding reference annotation features.
+
+                Precision (also known specificity) is the positive predictive value 
+
+                The accuracy metrics are calculated. Please not3
+
+                Full description of how the levels are compared can be found [here](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml#levels)
                 """
             ),
             anchor = 'gffcompare_accuracy',
@@ -113,7 +116,7 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
         self.add_section (
-            name = "Gffcompare novel loci",
+            name = "Gffcompare: Novel features",
             description = (
                 """
                 Comparison of samples with new loci
@@ -132,7 +135,7 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
         self.add_section (
-            name = "Gffcompare missed loci",
+            name = "Gffcompare: Missed features",
             description = (
                 """
                 Accuracy values for comparison of 
@@ -166,7 +169,11 @@ class MultiqcModule(BaseMultiqcModule):
             'ymax': 1,
             'xmin': 0,
             'xmax': 1,
-            'data_labels' : [{'name' : x} for x in datasets]
+            'data_labels' : [{
+                'name' : x,
+                'ylab': 'Precision',
+                'xlab': 'Sensitivity'
+                } for x in datasets]
         }
 
         data_classification = [{
@@ -180,16 +187,28 @@ class MultiqcModule(BaseMultiqcModule):
         for dataset in datasets
         ]
                         
-        print(data_classification)
         return scatter.plot(data_classification, pconfig)
 
     # Plot number of novel and missing transcripts
     def plot_novel(self):
         """ Generate GffCompare novel elements plot"""
 
-        cats = ['novel', 'found']
+        cats = [{
+            'novel':{
+                'name': 'Novel features',
+                'color': '#f7a35c'
+            }, 
+            'matching': {
+                'name': 'Matching features',
+                'color': '#8bbc21'
+            }
+        }] *3
+
         datasets = ['Exons', 'Introns', 'Loci']
         pconfig = {
+            'id': 'gffcompare_novel_plot',
+            'title': 'Gffcompare: Novel features',
+            'ylab': 'Reads',
             'ymin': 0,    
             'data_labels': datasets
         }
@@ -197,7 +216,7 @@ class MultiqcModule(BaseMultiqcModule):
         data_novel = [{
                 sample:{
                     'novel' : self.gffcompare_data[sample]['novel'][dataset][0],
-                    'found' : (self.gffcompare_data[sample]['novel'][dataset][1] -
+                    'matching' : (self.gffcompare_data[sample]['novel'][dataset][1] -
                         self.gffcompare_data[sample]['novel'][dataset][0])
                 }
             for sample in self.gffcompare_data.keys()
@@ -205,16 +224,28 @@ class MultiqcModule(BaseMultiqcModule):
         for dataset in datasets
         ]
         
-        print(data_novel)
         return bargraph.plot(data_novel, cats, pconfig)
         
     
     def plot_missed(self):
         """ Generate GffCompare missed elements plot"""
 
-        cats = ['missed', 'found']
+        cats = [{
+            'missed':{
+                'name': 'Missed features',
+                'color': '#f7a35c'
+            }, 
+            'matching': {
+                'name': 'Matching features',
+                'color': '#8bbc21'
+            }
+        }] *3
+
         datasets = ['Exons', 'Introns', 'Loci']
         pconfig = {
+            'id': 'gffcompare_missing_plot',
+            'title': 'Gffcompare: Missing features',
+            'ylab': 'Reads',
             'ymin': 0,    
             'data_labels': datasets
         }
@@ -222,7 +253,7 @@ class MultiqcModule(BaseMultiqcModule):
         data_missed = [{
                 sample:{
                     'missed' : self.gffcompare_data[sample]['missed'][dataset][0],
-                    'found' : (self.gffcompare_data[sample]['missed'][dataset][1] -
+                    'matching' : (self.gffcompare_data[sample]['missed'][dataset][1] -
                         self.gffcompare_data[sample]['missed'][dataset][0])
                 }
             for sample in self.gffcompare_data.keys()
@@ -230,5 +261,4 @@ class MultiqcModule(BaseMultiqcModule):
         for dataset in datasets
         ]
         
-        print(data_missed)
         return bargraph.plot(data_missed, cats, pconfig)

--- a/multiqc/modules/gffcompare/gffcompare.py
+++ b/multiqc/modules/gffcompare/gffcompare.py
@@ -102,13 +102,16 @@ class MultiqcModule(BaseMultiqcModule):
             ),
             helptext = (
                 """
-                Sensitivity (also known as recall) is the True Positive Rate where True Positives are query features which agree with corresponding reference annotation features.
+                Accuracy metrics are calculated as described in [Burset et al. (1996)](http://dx.doi.org/10.1006/geno.1996.0298). Sensitivity is the true positive rate, Precision 
+                True Positives are query features that agree with features in the reference. The exact definition depends on the feature level:
 
-                Precision (also known specificity) is the positive predictive value 
-
-                The accuracy metrics are calculated. Please not3
-
-                Full description of how the levels are compared can be found [here](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml#levels)
+                - *Base*: True positives are bases reported at the same coordinates. 
+                - *Exon*: Comparison units are exons that overlap in query and reference with same coordinates.
+                - *Intron chain*: True positives are query transcripts for which all introns coordinates match those in the reference.
+                - *Transcript*: More stringent then intron chain, all Exon coordinates need to match. Outer exon coordinates (start + end) can vary by 100 bases in default settings
+                - *Locus*: Cluster of exons need to match.
+                
+                More in depth description [here](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml#levels)        
                 """
             ),
             anchor = 'gffcompare_accuracy',
@@ -119,15 +122,13 @@ class MultiqcModule(BaseMultiqcModule):
             name = "Gffcompare: Novel features",
             description = (
                 """
-                Comparison of samples with new loci
+                Number of novel features in the query
                 """
             ),
             helptext = (
                 """
-                There are three possible cases:
-                * **Primers found**: Full length cDNA reads with correct primers at both ends.
-                * **Rescued reads**: Split fusion reads.
-                * **Unusable**: Reads without correct primer combinations.
+                GffCompare does not give a value for matching features. It is calculated by the difference of total features and novel features.
+                More documentation [here](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml)
                 """
             ),
             anchor = 'gffcompare_novel',
@@ -135,18 +136,16 @@ class MultiqcModule(BaseMultiqcModule):
         )
 
         self.add_section (
-            name = "Gffcompare: Missed features",
+            name = "Gffcompare: Missing features",
             description = (
                 """
-                Accuracy values for comparison of 
+                Number of missing features in the query
                 """
             ),
             helptext = (
                 """
-                There are three possible cases:
-                * **Primers found**: Full length cDNA reads with correct primers at both ends.
-                * **Rescued reads**: Split fusion reads.
-                * **Unusable**: Reads without correct primer combinations.
+                GffCompare does not give a value for matching features. It is calculated by the difference of total features and missing features.
+                More documentation [here](https://ccb.jhu.edu/software/stringtie/gffcompare.shtml)
                 """
             ),
             anchor = 'gffcompare_missed',
@@ -232,7 +231,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         cats = [{
             'missed':{
-                'name': 'Missed features',
+                'name': 'Missing features',
                 'color': '#f7a35c'
             }, 
             'matching': {

--- a/multiqc/modules/gffcompare/gffcompare.py
+++ b/multiqc/modules/gffcompare/gffcompare.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+""" MultiQC module to parse output from gffcompare """
+
+from __future__ import print_function
+import logging
+import os
+from collections import OrderedDict
+
+from multiqc.plots import linegraph, bargraph
+from multiqc.modules.base_module import BaseMultiqcModule
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+class MultiqcModule(BaseMultiqcModule):
+
+    def __init__(self):
+
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(name='GffCompare', anchor='gffcompare',
+                href='https://ccb.jhu.edu/software/stringtie/gffcompare.shtml',
+        info="is a tool to compare, merge and annotate one or more GFF files with a reference annotation in GFF format.")
+
+        # Parse stats file
+        self.gffcompare_data = {}
+        for f in self.find_log_files('gffcompare'):
+            sample = f['s_name']
+            self.gffcompare_data[sample]= {}
+            lines = f['f'].splitlines()
+            for line in lines[1:]:
+                print(line)
+
+        # Filter to strip out ignored sample names
+        self.gffcompare_data = self.ignore_samples(self.gffcompare_data)
+
+        # Raise user warning if no data found
+        if len(self.pychopper_data) == 0:
+            raise UserWarning
+
+        log.info("Found {} reports".format(len(self.gffcompare_data)))
+
+        # Add to general statistics table:
+        # Percentage of full length transcripts
+        """
+        data_general_stats={}
+        for sample in self.gffcompare_data.keys():
+            data_general_stats[sample] = {}
+            c=self.pychopper_data[sample]['Classification']
+            ftp=c['Primers_found'] * 100 / (c['Primers_found'] + c['Rescue'] + c['Unusable'])
+            data_general_stats[sample]['ftp']=ftp
+
+        headers = OrderedDict()
+        headers['ftp'] = {
+            'title' : 'Full-Length cDNA',
+            'description' : 'Percentage of full length cDNA reads with correct primers at both ends',
+            'suffix' : '%',
+            'max': 100,
+            'min': 0,
+        }
+        
+
+        self.general_stats_addcols(data_general_stats, headers)
+        """
+
+        # Write data file
+        self.write_data_file(self.pychopper_data, 'multiqc_pychopper')
+
+        # Report sections
+        self.add_section (
+            name = "cDNA Read Classification",
+            description = (
+                """
+                This plot shows the cDNA read categories identified by Pychopper </br>
+                """
+            ),
+            helptext = (
+                """
+                There are three possible cases:
+                * **Primers found**: Full length cDNA reads with correct primers at both ends.
+                * **Rescued reads**: Split fusion reads.
+                * **Unusable**: Reads without correct primer combinations.
+                """
+            ),
+            anchor = 'pychopper_classification',
+            plot = self.plot_classification()
+        )
+        self.add_section (
+            name = "cDNA Strand Orientation",
+            description = (
+                """
+                This plot shows the strand orientation of full length cDNA reads
+                """
+            ),
+            helptext = (
+                """
+                Nanopore cDNA reads are always read forward. To estimate their original strand, 
+                Pychopper searches for the location of the start and end primers and assigns the reads accordingly.
+                """
+            ),
+            anchor = 'pychopper_orientation',
+            plot = self.plot_orientation()
+        )
+
+    # Plotting functions
+    def plot_classification(self):
+        """ Generate the cDNA read classification plot """
+
+        pconfig = {
+            'id': 'pychopper_classification_plot',
+            'title': 'Pychopper: Read classification',
+            'ylab': '',
+            'xDecimals': False,
+            'ymin': 0
+        }
+
+        data_classification = {}
+        for sample in self.pychopper_data.keys():
+            data_classification[sample] = {}
+            data_classification[sample]=self.pychopper_data[sample]['Classification']
+
+        cats = ['Primers_found', 'Rescue', 'Unusable']
+        return bargraph.plot(data_classification, cats, pconfig)
+
+    def plot_orientation(self):
+        """ Generate the read strand orientation plot """
+
+        pconfig = {
+            'id': 'pychopper_orientation_plot',
+            'title': 'Pychopper: Strand Orientation',
+            'ylab': '',
+            'cpswitch_c_active': False,  
+            'xDecimals': False,
+            'ymin': 0
+        }
+
+        data_orientation = {}
+        for sample in self.pychopper_data.keys():
+            data_orientation[sample] = {}
+            data_orientation[sample]=self.pychopper_data[sample]['Strand']
+
+        cats = ['+', '-']
+        return bargraph.plot(data_orientation, cats, pconfig)

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -315,6 +315,9 @@ module_order:
     - goleft_indexcov:
         module_tag:
             - DNA
+    - gffcompare:
+        module_tag:
+            - RNA
     - disambiguate:
         module_tag:
             - RNA

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -281,7 +281,7 @@ gatk/base_recalibrator:
     num_lines: 3
 gffcompare:
     fn: '*.stats'
-    contents: '#gffcompare*'
+    contents: '# gffcompare'
     num_lines: 2
 goleft_indexcov/roc:
     fn: '*-indexcov.roc'

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -279,6 +279,10 @@ gatk/varianteval:
 gatk/base_recalibrator:
     contents: '#:GATKTable:Arguments:Recalibration'
     num_lines: 3
+gffcompare:
+    fn: '*.stats'
+    contents: '#gffcompare*'
+    num_lines: 2
 goleft_indexcov/roc:
     fn: '*-indexcov.roc'
 goleft_indexcov/ped:

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
             'fgbio = multiqc.modules.fgbio:MultiqcModule',
             'flash = multiqc.modules.flash:MultiqcModule',
             'flexbar = multiqc.modules.flexbar:MultiqcModule',
+            'gffcompare = multiqc.modules.gffcompare:MultiqcModule',
             'gatk = multiqc.modules.gatk:MultiqcModule',
             'goleft_indexcov = multiqc.modules.goleft_indexcov:MultiqcModule',
             'happy = multiqc.modules.happy:MultiqcModule',


### PR DESCRIPTION
 - [x] There is example tool output for tools in the https://github.com/ewels/MultiQC_TestData repository or attached to this PR
 - [x] Code is tested and works locally (including with `--lint` flag)
 - [x] `docs/README.md` is updated with link to below
 - [x] `docs/modulename.md` is created
 - [x] Everything that can be represented with a plot instead of a table is a plot
 - [x] Report sections have a description and help text (with `self.add_section`)
 - [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [x] Module does not do any significant computational work

This module only parses the summary stats file and displays the (imo) most important values. GffCompare additionally creates an annotated GTF file with classified transcripts.
This is also important data, but would mean that multiQC has to fully parse and aggregate a potentially large file (>10Mb). Therefore it is not included in this PR.

The accuracy values calculated by GffCompare are precision and sensitivity. The plot needs therefore a slighlt different interpretation from the precision/recall plots often used in model evaluation. Hopefully this is not too confusing.
