### PR TITLE
Enable prepending of directory to sample names for mosdepth module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     * Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/ewels/MultiQC/issues/1217))
 * **MALT**
     * Fix y-axis labelling in bargraphs
+* **mosdepth**
+    * Enable prepending of directory to sample names
 * **Picard**
     * Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/ewels/MultiQC/issues/1212))
 * **PycoQC**

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -152,7 +152,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         for scope in ('region', 'global'):
             for f in self.find_log_files('mosdepth/' + scope + '_dist'):
-                s_name = self.clean_s_name(f['fn'], root=None).replace('.mosdepth.' + scope + '.dist', '')
+                s_name = self.clean_s_name(f['fn'], f['root']).replace('.mosdepth.' + scope + '.dist', '')
                 if s_name in dist_data:  # both region and global might exist, prioritizing region
                     continue
 


### PR DESCRIPTION
Running multiqc with the `-d/--dir` option currently does not prepend the directory to the samples names for the mosdepth module. `None` was passed to `self.clean_s_name` instead of `f['root']` which contains the directory path.


<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated
