### PR TITLE
Support `--collapse` on ErrorRateByReadPosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,8 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 * **FastQ Screen**
     * When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
     * Fixed MultiQC linting errors
+* **fgbio**
+    * Support the new output format of `ErrorRateByReadPosition`, as well as the old output format.
 * **GATK**
     * Refactored BaseRecalibrator code to be more consistent with MultiQC Python style
     * Handle zero count errors in BaseRecalibrator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
     * When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
     * Fixed MultiQC linting errors
 * **fgbio**
-    * Support the new output format of `ErrorRateByReadPosition`, as well as the old output format.
+    * Support the new output format of `ErrorRateByReadPosition` first introduced in version `1.3.0`, as well as the old output format.
 * **GATK**
     * Refactored BaseRecalibrator code to be more consistent with MultiQC Python style
     * Handle zero count errors in BaseRecalibrator

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -118,8 +118,8 @@ def parse_reports(self):
     for s_name, s_data in all_data.items():
         for read_number, read_data in s_data.items():
             s_name_with_read = "%s_R%d" % (s_name, int(read_number))
-            for lg, index in zip(linegraph_data, range(7)):
-                lg[s_name_with_read] = dict((d['position'], d[linegraph_keys[index]]) for d in read_data.values())
+            for index, lg in enumerate(linegraph_data):
+                lg[s_name_with_read] = dict((d["position"], d[keys[index]]) for d in read_data.values())
 
     # add a section for the plot
     self.add_section(

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -13,42 +13,27 @@ def parse_reports(self):
     Stores the per-read-per-position metrics into a data file and adds a section
     with a per-sample plot.
     """
-    linegraph_keys = [
-        "error_rate",
-        "a_to_c_error_rate",
-        "a_to_g_error_rate",
-        "a_to_t_error_rate",
-        "c_to_a_error_rate",
-        "c_to_g_error_rate",
-        "c_to_t_error_rate",
-    ]
-    non_collapsed_keys = [
-        "g_to_a_error_rate",
-        "g_to_c_error_rate",
-        "g_to_t_error_rate",
-        "t_to_a_error_rate",
-        "t_to_c_error_rate",
-        "t_to_g_error_rate",
-    ]
+    linegraph_keys = ['error_rate', 'a_to_c_error_rate', 'a_to_g_error_rate', 'a_to_t_error_rate', 'c_to_a_error_rate', 'c_to_g_error_rate', 'c_to_t_error_rate']
+    non_collapsed_keys = ['g_to_a_error_rate', 'g_to_c_error_rate', 'g_to_t_error_rate', 't_to_a_error_rate', 't_to_c_error_rate', 't_to_g_error_rate']
 
     # slurp in all the data
     all_data = dict()
     error_rates = dict()
     y_max = 0.01  # default to 1%
     collapse = True  # same as the `--collapse` option on `ErrorRateByReadPosition`
-    for f in self.find_log_files("fgbio/errorratebyreadposition", filehandles=True):
-        fh = f["f"]
+    for f in self.find_log_files('fgbio/errorratebyreadposition', filehandles=True):
+        fh = f['f']
         header = fh.readline().rstrip("\r\n").split("\t")
-        if not header or header[0] != "read_number":
+        if not header or header[0] != 'read_number':
             continue
 
         # slurp in the data for this sample
-        s_name = f["s_name"]
+        s_name = f['s_name']
         s_data = dict()
         bases_total = 0
         errors = 0
         for line in fh:
-            fields = line.rstrip("\r\n").split("\t")
+            fields = line.rstrip('\r\n').split('\t')
             fields[1:4] = [int(field) for field in fields[1:4]]
             fields[4:11] = [float(field) for field in fields[4:11]]
             # Check if this is the new style
@@ -61,21 +46,21 @@ def parse_reports(self):
                     fields[11:-1] = [float(field) for field in fields[4:11]]
 
             row_data = dict(zip(header, fields))
-            read_number = row_data["read_number"]
-            position = row_data["position"]
+            read_number = row_data['read_number']
+            position = row_data['position']
             if read_number not in s_data:
                 s_data[read_number] = dict()
             s_data[read_number][position] = row_data
 
             for key in linegraph_keys + (non_collapsed_keys if not collapse else []):
                 y_max = max(y_max, row_data[key])
-            bases_total += row_data["bases_total"]
-            errors += row_data["errors"]
+            bases_total += row_data['bases_total']
+            errors += row_data['errors']
 
         if s_data:
             all_data[s_name] = s_data
             error_rate = 0.0 if bases_total == 0 else errors / float(bases_total)
-            error_rates[s_name] = {"error_rate": error_rate}
+            error_rates[s_name] = {'error_rate': error_rate}
 
     # ignore samples
     all_data = self.ignore_samples(all_data)
@@ -85,41 +70,41 @@ def parse_reports(self):
         return 0
 
     # Write parsed data to a file
-    self.write_data_file(all_data, "multiqc_fgbio_ErrorRateByReadPosition_per_position")
-    self.write_data_file(error_rates, "multiqc_fgbio_ErrorRateByReadPosition_total")
+    self.write_data_file(all_data, 'multiqc_fgbio_ErrorRateByReadPosition_per_position')
+    self.write_data_file(error_rates, 'multiqc_fgbio_ErrorRateByReadPosition_total')
 
     # Plot the data and add section
     pconfig = {
-        "id": "fgbio_ErrorRateByReadPosition",
-        "title": "Fgbio: Error Rate by Read Position",
-        "ylab": "Error rate",
-        "xlab": "Read Position",
-        "xDecimals": False,
-        "tt_label": "<b>read position {point.x}</b>: {point.y:.2f} %",
-        "ymax": y_max,
-        "ymin": 0,
-        "data_labels": [
-            {"name": "Error Rate", "ylab": "Error Rate"},
-            {"name": "A > C", "ylab": "A to C error rate (and T to G when collapsed)"},
-            {"name": "A > G", "ylab": "A to G error rate (and T to C when collapsed)"},
-            {"name": "A > T", "ylab": "A to T error rate (and T to A when collapsed)"},
-            {"name": "C > A", "ylab": "C to A error rate (and G to T when collapsed)"},
-            {"name": "C > G", "ylab": "C to G error rate (and G to C when collapsed)"},
-            {"name": "C > T", "ylab": "C to T error rate (and G to A when collapsed)"},
+        'id': 'fgbio_ErrorRateByReadPosition',
+        'title': 'Fgbio: Error Rate by Read Position',
+        'ylab': 'Error rate',
+        'xlab': 'Read Position',
+        'xDecimals': False,
+        'tt_label': '<b>read position {point.x}</b>: {point.y:.2f} %',
+        'ymax': y_max,
+        'ymin': 0,
+        'data_labels': [
+            {'name': 'Error Rate', 'ylab': 'Error Rate'},
+            {'name': 'A > C', 'ylab': 'A to C error rate (and T to G when collapsed)'},
+            {'name': 'A > G', 'ylab': 'A to G error rate (and T to C when collapsed)'},
+            {'name': 'A > T', 'ylab': 'A to T error rate (and T to A when collapsed)'},
+            {'name': 'C > A', 'ylab': 'C to A error rate (and G to T when collapsed)'},
+            {'name': 'C > G', 'ylab': 'C to G error rate (and G to C when collapsed)'},
+            {'name': 'C > T', 'ylab': 'C to T error rate (and G to A when collapsed)'},
         ],
     }
 
     uncollapsed_labels = [
-        {"name": "G > A", "ylab": "G to A error rate"},
-        {"name": "G > C", "ylab": "G to C error rate"},
-        {"name": "G > T", "ylab": "G to T error rate"},
-        {"name": "T > A", "ylab": "T to A error rate"},
-        {"name": "T > C", "ylab": "T to C error rate"},
-        {"name": "T > G", "ylab": "T to G error rate"},
+        {'name': 'G > A', 'ylab': 'G to A error rate'},
+        {'name': 'G > C', 'ylab': 'G to C error rate'},
+        {'name': 'G > T', 'ylab': 'G to T error rate'},
+        {'name': 'T > A', 'ylab': 'T to A error rate'},
+        {'name': 'T > C', 'ylab': 'T to C error rate'},
+        {'name': 'T > G', 'ylab': 'T to G error rate'},
     ]
 
     if not collapse:
-        pconfig["data_labels"] += uncollapsed_labels
+        pconfig['data_labels'] += uncollapsed_labels
 
     keys = linegraph_keys + (non_collapsed_keys if not collapse else [])
 
@@ -133,10 +118,10 @@ def parse_reports(self):
 
     # add a section for the plot
     self.add_section(
-        name="Error Rate by Read Position",
-        anchor="fgbio-error-rate-by-read-position",
-        description="Error rate by read position. Plot tabs show the error rates for specific substitution types.",
-        helptext="""
+        name='Error Rate by Read Position',
+        anchor='fgbio-error-rate-by-read-position',
+        description='Error rate by read position. Plot tabs show the error rates for specific substitution types.',
+        helptext='''
         The error rate by read position. If `collapsed` was `true`, then complementary
         substitutions were grouped together into the first 6 error rates.
         e.g. `T>G` substitutions are reported as `A>C`. Otherwise, all 12 substitution
@@ -153,21 +138,21 @@ def parse_reports(self):
         * Reads with MAPQ < `--min-mapping-quality` (default: `20`)
         * Bases with base quality < `--min-base-quality` (default: `0`)
         * Bases where either the read base or the reference base is non-ACGT
-        """,
+        ''',
         plot=linegraph.plot(linegraph_data, pconfig),
     )
 
     # Add to general stats table
     headers = {
-        "error_rate": {
-            "title": "% Error",
-            "description": "Percent error across all read positions",
-            "min": 0,
-            "max": 100.0,
-            "scale": "GnYlRd",
-            "suffix": "%",
-            "format": "{:,.2f}",
-            "modify": lambda x: 100.0 * x,
+        'error_rate': {
+            'title': '% Error',
+            'description': 'Percent error across all read positions',
+            'min': 0,
+            'max': 100.0,
+            'scale': 'GnYlRd',
+            'suffix': '%',
+            'format': '{:,.2f}',
+            'modify': lambda x: 100.0 * x,
         }
     }
     self.general_stats_addcols(error_rates, headers)

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -3,6 +3,7 @@
 """ MultiQC submodule to parse output from fgbio ErrorRateByReadPosition """
 
 
+from distutils.util import strtobool
 from multiqc.plots import linegraph
 
 
@@ -12,43 +13,69 @@ def parse_reports(self):
     Stores the per-read-per-position metrics into a data file and adds a section
     with a per-sample plot.
     """
-    linegraph_keys = ['error_rate', 'a_to_c_error_rate', 'a_to_g_error_rate', 'a_to_t_error_rate', 'c_to_a_error_rate', 'c_to_g_error_rate', 'c_to_t_error_rate']
+    linegraph_keys = [
+        "error_rate",
+        "a_to_c_error_rate",
+        "a_to_g_error_rate",
+        "a_to_t_error_rate",
+        "c_to_a_error_rate",
+        "c_to_g_error_rate",
+        "c_to_t_error_rate",
+    ]
+    non_collapsed_keys = [
+        "g_to_a_error_rate",
+        "g_to_c_error_rate",
+        "g_to_t_error_rate",
+        "t_to_a_error_rate",
+        "t_to_c_error_rate",
+        "t_to_g_error_rate",
+    ]
 
     # slurp in all the data
     all_data = dict()
     error_rates = dict()
     y_max = 0.01  # default to 1%
-    for f in self.find_log_files('fgbio/errorratebyreadposition', filehandles=True):
-        fh = f['f']
-        header = fh.readline().rstrip('\r\n').split('\t')
-        if not header or header[0] != 'read_number':
+    collapse = True  # same as the `--collapse` option on `ErrorRateByReadPosition`
+    for f in self.find_log_files("fgbio/errorratebyreadposition", filehandles=True):
+        fh = f["f"]
+        header = fh.readline().rstrip("\r\n").split("\t")
+        if not header or header[0] != "read_number":
             continue
 
         # slurp in the data for this sample
-        s_name = f['s_name']
+        s_name = f["s_name"]
         s_data = dict()
         bases_total = 0
         errors = 0
         for line in fh:
-            fields = line.rstrip('\r\n').split('\t')
+            fields = line.rstrip("\r\n").split("\t")
             fields[1:4] = [int(field) for field in fields[1:4]]
-            fields[4:] = [float(field) for field in fields[4:]]
+            fields[4:11] = [float(field) for field in fields[4:11]]
+            # Check if this is the new style
+            if len(fields) > 11:
+                # Check if collapse was true or false
+                fields[-1] = bool(strtobool(fields[-1]))
+                collapse = fields[-1]
+                if not collapse:
+                    # Substitutions types were not collapsed, parse them
+                    fields[11:-1] = [float(field) for field in fields[4:11]]
+
             row_data = dict(zip(header, fields))
-            read_number = row_data['read_number']
-            position = row_data['position']
+            read_number = row_data["read_number"]
+            position = row_data["position"]
             if read_number not in s_data:
                 s_data[read_number] = dict()
             s_data[read_number][position] = row_data
-            for key in linegraph_keys:
+
+            for key in linegraph_keys + (non_collapsed_keys if not collapse else []):
                 y_max = max(y_max, row_data[key])
-            bases_total += row_data['bases_total']
-            errors += row_data['errors']
+            bases_total += row_data["bases_total"]
+            errors += row_data["errors"]
 
         if s_data:
             all_data[s_name] = s_data
             error_rate = 0.0 if bases_total == 0 else errors / float(bases_total)
-            error_rates[s_name] = {'error_rate': error_rate}
-
+            error_rates[s_name] = {"error_rate": error_rate}
 
     # ignore samples
     all_data = self.ignore_samples(all_data)
@@ -58,48 +85,63 @@ def parse_reports(self):
         return 0
 
     # Write parsed data to a file
-    self.write_data_file(all_data, 'multiqc_fgbio_ErrorRateByReadPosition_per_position')
-    self.write_data_file(error_rates, 'multiqc_fgbio_ErrorRateByReadPosition_total')
+    self.write_data_file(all_data, "multiqc_fgbio_ErrorRateByReadPosition_per_position")
+    self.write_data_file(error_rates, "multiqc_fgbio_ErrorRateByReadPosition_total")
 
     # Plot the data and add section
     pconfig = {
-        'id': 'fgbio_ErrorRateByReadPosition',
-        'title': 'Fgbio: Error Rate by Read Position',
-        'ylab': 'Error rate',
-        'xlab': 'Read Position',
-        'xDecimals': False,
-        'tt_label': '<b>read position {point.x}</b>: {point.y:.2f} %',
-        'ymax': y_max,
-        'ymin': 0,
-        'data_labels': [
-            {'name': 'Error Rate', 'ylab': 'Error Rate'},
-            {'name': 'A > C', 'ylab': 'A to C error rate'},
-            {'name': 'A > G', 'ylab': 'A to G error rate'},
-            {'name': 'A > T', 'ylab': 'A to T error rate'},
-            {'name': 'C > A', 'ylab': 'C to A error rate'},
-            {'name': 'C > G', 'ylab': 'C to G error rate'},
-            {'name': 'C > T', 'ylab': 'C to T error rate'},
-        ]
+        "id": "fgbio_ErrorRateByReadPosition",
+        "title": "Fgbio: Error Rate by Read Position",
+        "ylab": "Error rate",
+        "xlab": "Read Position",
+        "xDecimals": False,
+        "tt_label": "<b>read position {point.x}</b>: {point.y:.2f} %",
+        "ymax": y_max,
+        "ymin": 0,
+        "data_labels": [
+            {"name": "Error Rate", "ylab": "Error Rate"},
+            {"name": "A > C", "ylab": "A to C error rate (and T to G when collapsed)"},
+            {"name": "A > G", "ylab": "A to G error rate (and T to C when collapsed)"},
+            {"name": "A > T", "ylab": "A to T error rate (and T to A when collapsed)"},
+            {"name": "C > A", "ylab": "C to A error rate (and G to T when collapsed)"},
+            {"name": "C > G", "ylab": "C to G error rate (and G to C when collapsed)"},
+            {"name": "C > T", "ylab": "C to T error rate (and G to A when collapsed)"},
+        ],
     }
 
+    uncollapsed_labels = [
+        {"name": "G > A", "ylab": "G to A error rate"},
+        {"name": "G > C", "ylab": "G to C error rate"},
+        {"name": "G > T", "ylab": "G to T error rate"},
+        {"name": "T > A", "ylab": "T to A error rate"},
+        {"name": "T > C", "ylab": "T to C error rate"},
+        {"name": "T > G", "ylab": "T to G error rate"},
+    ]
+
+    if not collapse:
+        pconfig["data_labels"] += uncollapsed_labels
+
+    keys = linegraph_keys + (non_collapsed_keys if not collapse else [])
+
     # Build a list of linegraphs
-    linegraph_data = [{} for _ in linegraph_keys]
+    linegraph_data = [{} for _ in keys]
     for s_name, s_data in all_data.items():
         for read_number, read_data in s_data.items():
             s_name = "%s_R%d" % (s_name, int(read_number) + 1)
-            for lg, index in zip(linegraph_data, range(7)):
-                lg[s_name] = dict((d['position'], d[linegraph_keys[index]]) for d in read_data.values())
+            for index, lg in enumerate(linegraph_data):
+                lg[s_name] = dict((d["position"], d[keys[index]]) for d in read_data.values())
 
     # add a section for the plot
-    self.add_section (
-        name = 'Error Rate by Read Position',
-        anchor = 'fgbio-error-rate-by-read-position',
-        description = 'Error rate by read position. Plot tabs show the error rates for specific substitution types.',
-        helptext = '''
-        The error rate by read position. Substitution types are collapsed based on the
-        reference or expected base, with only six substitution types being reported:
-        `A>C`, `A>G`, `A>T`, `C>A`, `C>G` and `C>T`.
-        For example, `T>G` is grouped in with `A>C`.
+    self.add_section(
+        name="Error Rate by Read Position",
+        anchor="fgbio-error-rate-by-read-position",
+        description="Error rate by read position. Plot tabs show the error rates for specific substitution types.",
+        helptext="""
+        The error rate by read position. If `collapsed` was `true`, then complementary
+        substitutions were grouped together into the first 6 error rates.
+        e.g. `T>G` substitutions are reported as `A>C`. Otherwise, all 12 substitution
+        rates are reported.
+
 
         The following are reads / bases are excluded from the analysis:
 
@@ -111,21 +153,21 @@ def parse_reports(self):
         * Reads with MAPQ < `--min-mapping-quality` (default: `20`)
         * Bases with base quality < `--min-base-quality` (default: `0`)
         * Bases where either the read base or the reference base is non-ACGT
-        ''',
-        plot = linegraph.plot(linegraph_data, pconfig)
+        """,
+        plot=linegraph.plot(linegraph_data, pconfig),
     )
 
     # Add to general stats table
     headers = {
-        'error_rate': {
-            'title': '% Error',
-            'description': 'Percent error across all read positions',
-            'min': 0,
-            'max': 100.0,
-            'scale': 'GnYlRd',
-            'suffix': '%',
-            'format': '{:,.2f}',
-            'modify': lambda x: 100.0 * x
+        "error_rate": {
+            "title": "% Error",
+            "description": "Percent error across all read positions",
+            "min": 0,
+            "max": 100.0,
+            "scale": "GnYlRd",
+            "suffix": "%",
+            "format": "{:,.2f}",
+            "modify": lambda x: 100.0 * x,
         }
     }
     self.general_stats_addcols(error_rates, headers)

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -23,7 +23,7 @@ def parse_reports(self):
     collapse = True  # same as the `--collapse` option on `ErrorRateByReadPosition`
     for f in self.find_log_files('fgbio/errorratebyreadposition', filehandles=True):
         fh = f['f']
-        header = fh.readline().rstrip("\r\n").split("\t")
+        header = fh.readline().rstrip('\r\n').split('\t')
         if not header or header[0] != 'read_number':
             continue
 


### PR DESCRIPTION
This now supports the old format output that only has columns 0:11, and
the new format which includes another 7 columns that may or may not have
values.

This change supports the PR found here: https://github.com/fulcrumgenomics/fgbio/pull/608 that adds the option to not collapse positions.

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated

The original test data for this works still. 