### PR TITLE
Add empirical vs reported graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
     * Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
 * **fgbio**
     * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  ([#1215](https://github.com/ewels/MultiQC/pull/1251))
+* **GATK**
+  * Add support for creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
 
 #### New Custom Content features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * **fgbio**
     * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  ([#1215](https://github.com/ewels/MultiQC/pull/1251))
 * **GATK**
-  * Add support for creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
+  * Add support for the creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
 
 #### New Custom Content features
 

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -35,6 +35,11 @@ class BaseRecalibratorMixin():
         }
 
         for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
+
+            # Check that we're not ignoring this sample name
+            if self.is_ignore_sample(f['s_name']):
+                continue
+
             parsed_data = self.parse_report(f['f'].readlines(), report_table_headers)
             rt_type = determine_recal_table_type(parsed_data)
             if len(parsed_data) > 0:

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 from itertools import groupby
 from multiqc.plots import linegraph
 from multiqc.plots import scatter
-h
 
 # Initialise the logger
 log = logging.getLogger(__name__)

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -159,16 +159,12 @@ class BaseRecalibratorMixin():
                 table_rows.sort(key=lambda r: r['QualityScore'])
                 for reported, group in groupby(table_rows, lambda r: r['QualityScore']):
                     g = list(group)
-                    try:
-                        reported_empirical[sample].append(
-                            {
-                                'x': int(reported),
-                                'y': sum(float(r['EmpiricalQuality']) for r in g) / len(g),
-                            }
-                        )
-                    except ZeroDivisionError:
-                        reported_empirical[sample][int(reported)] = 0
-                        reported_empirical[sample].append({'x': int(reported), 'y': 0})
+                    reported_empirical[sample].append(
+                        {
+                            'x': int(reported),
+                            'y': sum(float(r['EmpiricalQuality']) for r in g) / len(g) if len(g) > 0 else 0,
+                        }
+                    )
 
             sample_data.append(reported_empirical)
 

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -5,7 +5,10 @@
 
 import logging
 from collections import namedtuple
+from itertools import groupby
 from multiqc.plots import linegraph
+from multiqc.plots import scatter
+h
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -32,11 +35,6 @@ class BaseRecalibratorMixin():
         }
 
         for f in self.find_log_files('gatk/base_recalibrator', filehandles=True):
-
-            # Check that we're not ignoring this sample name
-            if self.is_ignore_sample(f['s_name']):
-                continue
-
             parsed_data = self.parse_report(f['f'].readlines(), report_table_headers)
             rt_type = determine_recal_table_type(parsed_data)
             if len(parsed_data) > 0:
@@ -60,6 +58,7 @@ class BaseRecalibratorMixin():
             log.info("Found {} BaseRecalibrator reports".format(n_reports_found))
 
             self.add_quality_score_vs_no_of_observations_section()
+            self.add_reported_vs_empirical_section()
 
         return n_reports_found
 
@@ -135,6 +134,61 @@ class BaseRecalibratorMixin():
                 '.'
             ),
             plot = plot,
+        )
+
+    def add_reported_vs_empirical_section(self):
+        sample_data = []
+        data_labels = []
+
+        # Loop through the different data types
+        for rt_type_name, rt_type, in recal_table_type._asdict().items():
+            # This table appears to be the correct one to use for reported vs empirical
+            # https://github.com/broadinstitute/gatk/blob/853b53ec2a3ac2d90d7d82a6c8451e29a34692d2/src/main/resources/org/broadinstitute/hellbender/utils/recalibration/BQSR.R#L148
+            sample_tables = self.gatk_base_recalibrator[rt_type]['recal_table_1']
+            if len(sample_tables) == 0:
+                continue
+
+            reported_empirical = {}
+            for sample, table in sample_tables.items():
+                reported_empirical[sample] = []
+                table_rows = [dict(zip(table, r)) for r in zip(*table.values())]
+                table_rows.sort(key=lambda r: r['QualityScore'])
+                for reported, group in groupby(table_rows, lambda r: r['QualityScore']):
+                    g = list(group)
+                    try:
+                        reported_empirical[sample].append(
+                            {
+                                'x': int(reported),
+                                'y': sum(float(r['EmpiricalQuality']) for r in g) / len(g),
+                            }
+                        )
+                    except ZeroDivisionError:
+                        reported_empirical[sample][int(reported)] = 0
+                        reported_empirical[sample].append({'x': int(reported), 'y': 0})
+
+            sample_data.append(reported_empirical)
+
+            # Build data label configs for this data type
+            data_labels.append(
+                {'name': '{} Reported vs. Empirical Quality', 'ylab': 'Empirical quality score'}
+            )
+        plot = scatter.plot(
+            sample_data,
+            pconfig={
+                'title': 'Reported vs. Empirical Quality',
+                'id': 'gatk-base-recalibrator-reported-empirical-plot',
+                'xlab': 'Reported quality score',
+                'ylab': 'Empirical quality score',
+                'xDecimals': False,
+                'data_labels': data_labels,
+            },
+        )
+
+        self.add_section(
+            name='Reported Quality vs. Empirical Quality',
+            anchor='gatk-base-recalibrator-reported-empirical',
+            description='Plot shows the reported quality score vs the empirical quality score.',
+            plot=plot,
         )
 
 


### PR DESCRIPTION
This PR adds adds support for generating an empirical vs reported quality graph to the GATK Base Recalibrator module. 

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated


