### PR TITLE
extend PATH variable including directory containing multiqc binary. A…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /usr/src/multiqc
 # Install MultiQC
 RUN python -m pip install .
 
+ENV PATH "$PATH:/usr/src/multiqc"
+
 # Set up entrypoint and cmd for easy docker usage
 ENTRYPOINT [ "multiqc" ]
 CMD [ "." ]


### PR DESCRIPTION
extended PATH env variable including the directory that contains multiqc binary.

The docker container will work correctly even if entrypoint will be overwrite to default value.

```sh
docker run -it --rm --entrypoint="" -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc . --title "My amazing report" -b "This was made with docker"
```


<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

 - [x] This comment contains a description of changes (with reason)
 - [ ] `CHANGELOG.md` has been updated
