### PR TITLE
Fix bug in line names for fgbio error-rate-by-read-position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
     * Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
 * **fgbio**
     * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  ([#1215](https://github.com/ewels/MultiQC/pull/1251))
-    * Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and to fix the off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
+    * Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
 
 #### New Custom Content features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
     * Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
 * **fgbio**
     * Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...).  ([#1215](https://github.com/ewels/MultiQC/pull/1251))
+    * Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and to fix the off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
 
 #### New Custom Content features
 

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -86,9 +86,9 @@ def parse_reports(self):
     linegraph_data = [{} for _ in linegraph_keys]
     for s_name, s_data in all_data.items():
         for read_number, read_data in s_data.items():
-            s_name = "%s_R%d" % (s_name, int(read_number) + 1)
+            s_name_with_read = "%s_R%d" % (s_name, int(read_number))
             for lg, index in zip(linegraph_data, range(7)):
-                lg[s_name] = dict((d['position'], d[linegraph_keys[index]]) for d in read_data.values())
+                lg[s_name_with_read] = dict((d['position'], d[linegraph_keys[index]]) for d in read_data.values())
 
     # add a section for the plot
     self.add_section (


### PR DESCRIPTION
The (samplename + read) name in the Error Rate By Read Position code was both off by 1 and appending to itself so you would see `sample1_R2_R3` when hovering over the plot. This PR fixes it so that the `R#` is not appended to the self, and it is no longer off by one. 

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated
