### PR TITLE
Document the name of the custom_content module

### DIFF
--- a/docs/custom_content.md
+++ b/docs/custom_content.md
@@ -13,6 +13,10 @@ All plot types can be generated using custom content - see the
 [test files](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content)
 for examples of how data should be structured.
 
+> **Note**: Use the name `custom_content` to refer to this module within configuration
+> settings that require a module name, such as [`module_order`](#order-of-modules) or
+> [`run_modules`](#removing-modules-or-sections).
+
 ## Data from a released tool
 If your data comes from a released bioinformatics tool, you shouldn't be using this
 feature of MultiQC! Sure, you can probably get it to work, but it's better if a


### PR DESCRIPTION
I spent some time using `custom_data` as module name within `run_modules` (because that’s the name of the key one needs to write) until I found how to do it in the examples.