### PR TITLE
Bugfix: fix repeating error values in fgbio ErrorRateByReadPosition 

### DIFF
--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -48,7 +48,7 @@ def parse_reports(self):
                 collapse = fields[-1]
                 if not collapse:
                     # Substitutions types were not collapsed, parse them
-                    fields[11:-1] = [float(field) for field in fields[4:11]]
+                    fields[11:-1] = [float(field) for field in fields[11:-1]]
 
             row_data = dict(zip(header, fields))
             read_number = row_data['read_number']


### PR DESCRIPTION
Instead of pulling the values for the non-collapsed values, it was re-pulling the values for the collapsed values. Since slice assignment replaces the lefthand side slice with what is on the right, and what was on the right was all float values covering the desired indices, there was no runtime error.

 - [X] This comment contains a description of changes (with reason)
 - [X] `CHANGELOG.md` has been updated

Changelog is still up to date. 
