### PR TITLE
Adding module for ARTIC (sars-cov-2 consensus genome pipeline)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
   * Reference-free QC of Hi-C sequencing data
 * [**Sentieon**](https://www.sentieon.com/products/)
   * Submodules added to catch Picard-based QC metrics files
-
+* [**ARTIC**](https://github.com/artic-network/fieldbioinformatics)
+  * Viral consensus genome pipeline for nanopore amplicon sequencing data
 
 #### Module updates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ MultiQC Modules:
     DRAGEN: modules/dragen.md
     MALT: modules/malt.md
   Post-alignment:
+    ARTIC: modules/artic.md
     Bamtools: modules/bamtools.md
     Bcftools: modules/bcftools.md
     biobambam2: modules/biobambam2.md

--- a/docs/modules/artic.md
+++ b/docs/modules/artic.md
@@ -1,0 +1,9 @@
+---
+Name: ARTIC
+URL: https://github.com/artic-network/fieldbioinformatics
+Description: A bioinformatics pipeline for working with virus sequencing data sequenced with nanopore.
+---
+
+ARTIC is a bioinformatics pipeline for working with virus sequencing data sequenced with nanopore.
+
+This module parses the output from the `minion pipeline` command. It produces amplicon coverage plot and some general statistics.

--- a/multiqc/modules/artic/__init__.py
+++ b/multiqc/modules/artic/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import
+from .artic import MultiqcModule

--- a/multiqc/modules/artic/artic.py
+++ b/multiqc/modules/artic/artic.py
@@ -56,9 +56,6 @@ class MultiqcModule(BaseMultiqcModule):
         log.info("Found {} align_trim reports".format(len(self.aligntrim_data)))
         log.info("Found {} vcf_check reports".format(len(self.vcfcheck_data)))
 
-        # Check the same primer scheme was used across reports
-        self.check_used_schemes()
-
         # Write parsed data to a file
         self.write_data_file(self.aligntrim_data,
                              'multiqc_artic_aligntrim_summary')
@@ -134,19 +131,6 @@ class MultiqcModule(BaseMultiqcModule):
             if match:
                 passed_vars = int(match.group(1))
         self.vcfcheck_data[sample]['overlap_fails'] = total_vars - passed_vars
-
-    # Check the same primer scheme was used across reports
-    def check_used_schemes(self):
-        """ Check collected reports used the same primer schemes, otherwise amplicon plot might be weird
-        """
-        i = 1
-        while (i < len(self.aligntrim_data)):
-
-            # check there are no differences between the amplicon names for each sample
-            if (len((list(self.aligntrim_data.keys())[i-1] ^ list(self.aligntrim_data.keys())[i])) != 0):
-                log.debug("Different primer schemes used between align_trim reports! Report plot may look odd.")
-            i += 1
-
 
     # Process collected data for all samples
     def process_artic_data(self):

--- a/multiqc/modules/artic/artic.py
+++ b/multiqc/modules/artic/artic.py
@@ -78,7 +78,7 @@ class MultiqcModule(BaseMultiqcModule):
     def parse_aligntrim_report(self, f):
         """ Parse ARTIC aligntrim report file
         """
-        sample = f['s_name']
+        sample = f['s_name'].replace('.alignreport', '')
 
         # Check if overwriting
         if sample in self.aligntrim_data:

--- a/multiqc/modules/artic/artic.py
+++ b/multiqc/modules/artic/artic.py
@@ -38,6 +38,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.aligntrim_data = dict()
         self.vcfcheck_data = dict()
         self.artic_stats = dict()
+        self.primer_scheme = ""
         for f in self.find_log_files('artic/aligntrim_reports', filehandles=True):
             self.parse_aligntrim_report(f)
         for f in self.find_log_files('artic/vcf_reports', filehandles=True):
@@ -106,6 +107,18 @@ class MultiqcModule(BaseMultiqcModule):
             if fields[3] not in self.aligntrim_data[sample]:
                 self.aligntrim_data[sample][fields[3]] = 0
             self.aligntrim_data[sample][fields[3]] += 1
+
+        # Empty file check
+        if (len(self.aligntrim_data[sample]) == 0):
+            del self.aligntrim_data[sample]
+            return
+
+        # Update the primer scheme name tracker
+        scheme = list(self.aligntrim_data[sample])[0].split("_")[0]
+        if (self.primer_scheme != "") and (self.primer_scheme != scheme):
+            log.debug("Found reports from different primer schemes: {} and {}".format(self.primer_scheme, scheme))
+            raise UserWarning
+        self.primer_scheme = scheme
 
     # Parse a vcf_check report
     def parse_vcf_report(self, f):

--- a/multiqc/modules/artic/artic.py
+++ b/multiqc/modules/artic/artic.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" MultiQC module to parse output files from ARTIC """
+
+from __future__ import print_function
+from collections import OrderedDict
+import logging
+import re
+
+from multiqc import config
+from multiqc.plots import linegraph
+from multiqc.modules.base_module import BaseMultiqcModule
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+# Alignment_Length_Threshold drops binned reads that are <X% of amplicon length)
+Alignment_Length_Threshold = 0.95
+
+# Amplicon_Dropout_Val will report amplicon dropout in any amplicon which has fewer than X reads
+Amplicon_Dropout_Val = 50
+
+
+class MultiqcModule(BaseMultiqcModule):
+
+    def __init__(self):
+
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(
+            name='ARTIC',
+            anchor='ARTIC',
+            href='https://github.com/artic-network/fieldbioinformatics',
+            info="is a bioinformatics pipeline for working with virus sequencing data sequenced with nanopore."
+        )
+
+        # Find and load ARTIC align_trim results
+        self.aligntrim_data = dict()
+        self.vcfcheck_data = dict()
+        self.artic_stats = dict()
+        for f in self.find_log_files('artic/aligntrim_reports', filehandles=True):
+            self.parse_aligntrim_report(f)
+        for f in self.find_log_files('artic/vcf_reports', filehandles=True):
+            self.parse_vcf_report(f)
+
+        # Filter to strip out ignored sample names
+        self.aligntrim_data = self.ignore_samples(self.aligntrim_data)
+        self.vcfcheck_data = self.ignore_samples(self.vcfcheck_data)
+
+        # Stop if no files are found
+        num_samples = max(len(self.aligntrim_data), len(self.vcfcheck_data))
+        if num_samples == 0:
+            raise UserWarning
+
+        # Log number of reports
+        log.info("Found {} align_trim reports".format(len(self.aligntrim_data)))
+        log.info("Found {} vcf_check reports".format(len(self.vcfcheck_data)))
+
+        # Check the same primer scheme was used across reports
+        self.check_used_schemes()
+
+        # Write parsed data to a file
+        self.write_data_file(self.aligntrim_data,
+                             'multiqc_artic_aligntrim_summary')
+        self.write_data_file(self.vcfcheck_data,
+                             'multiqc_artic_vcfcheck_summary')
+
+        # Process collected files
+        self.process_artic_data()
+
+        # Update General Stats Table
+        self.artic_general_stats_table()
+
+        # Add amplicon coverage lot
+        self.plot_amplicons()
+
+    # Parse an aligntrim report
+    def parse_aligntrim_report(self, f):
+        """ Parse ARTIC aligntrim report file
+        """
+        sample = f['s_name']
+
+        # Check if overwriting
+        if sample in self.aligntrim_data:
+            log.debug(
+                "Duplicate sample name found! Overwriting: {}".format(sample))
+
+        # Set up data holder for sample
+        self.aligntrim_data[sample] = dict()
+
+        # Skip first line of report (header)
+        _ = f['f'].readline()
+
+        # Read aligntrim report and bin reads by amplicon
+        for l in f['f']:
+            fields = l.rstrip().split('\t')
+
+            # Check read is from a properly paired amplicon
+            if int(fields[12]) != 1:
+                continue
+
+            # Check the read alignment length covers enough of the amplicon
+            aLen = int(fields[11]) - int(fields[10])
+            rLen = int(fields[2]) - int(fields[1])
+            if aLen < (Alignment_Length_Threshold * rLen):
+                continue
+
+            # Update the read count for this amplicon
+            if fields[3] not in self.aligntrim_data[sample]:
+                self.aligntrim_data[sample][fields[3]] = 0
+            self.aligntrim_data[sample][fields[3]] += 1
+
+    # Parse a vcf_check report
+    def parse_vcf_report(self, f):
+        """ Parse ARTIC vcf_check report file
+        """
+        sample = f['s_name']
+
+        # Check if overwriting
+        if sample in self.vcfcheck_data:
+            log.debug("Duplicate sample name found! Overwriting: {}".format(sample))
+
+    # Check the same primer scheme was used across reports
+    def check_used_schemes(self):
+        """ Check collected reports used the same primer schemes
+        """
+        i = 1
+        while (i < len(self.aligntrim_data)):
+
+            # check there are no differences between the amplicon names for each sample
+            if (len((list(self.aligntrim_data.keys())[i-1] ^ list(self.aligntrim_data.keys())[i])) != 0):
+                log.debug("Different primer schemes used between align_trim reports! Report plot may look odd.")
+            i += 1
+
+
+    # Process collected data for all samples
+    def process_artic_data(self):
+        """ Process the data from the parsed artic files
+        """
+
+        # Get the amplicon counts
+        for sample in self.aligntrim_data:
+            self.artic_stats[sample] = dict()
+            self.artic_stats[sample]['amplicon_dropouts'] = 0
+            for count in self.aligntrim_data[sample].values():
+                if count < Amplicon_Dropout_Val:
+                    self.artic_stats[sample]['amplicon_dropouts'] += 1
+
+        # Get the vcf counts
+        for sample in self.vcfcheck_data:
+
+            # check for that sample already has an aligntrim report
+            if sample not in self.artic_stats:
+                log.debug(
+                    "Sample has vcf report but no aligntrim report! {}".format(sample))
+            self.artic_stats[sample]['overlap_fails'] = 0
+
+    # Add to general stats table
+    def artic_general_stats_table(self):
+        """ Take the parsed stats from the artic reports and add to the
+        general stats table"""
+
+        headers = OrderedDict()
+        headers['amplicon_dropouts'] = {
+            'title': '# low cov. amplicons',
+            'description': 'The number of amplicons for this sample with read coverage <{}' .format(Amplicon_Dropout_Val),
+            'min': 0,
+            'scale': 'RdYlGn-rev',
+            'format': '{:,.0f}'
+        }
+        headers['overlap_fails'] = {
+            'title': '# overlap fails',
+            'description': 'The number of variants detected only once in scheme overlap regions',
+            'min': 0,
+            'scale': 'RdYlGn-rev',
+            'format': '{:,.0f}'
+        }
+        self.general_stats_addcols(self.artic_stats, headers)
+
+    # Create amplicon coverage plot
+    def plot_amplicons(self):
+        """ Plot the amplicon coverage"""
+
+        pconfig = {
+            'id': 'amplicon_plot',
+            'title': 'Module: Amplicon Coverage',
+            'ylab': '# reads',
+            'xlab': 'amplicon',
+            'yPlotLines': [{
+                'color': '#FF0000',
+                'width': 2,
+                'dashStyle': 'LongDash',
+                'label': 'Amplicon dropout',
+                'value': Amplicon_Dropout_Val
+            }],
+            'categories': True
+        }
+
+        if self.aligntrim_data is not None:
+            amplicon_plot_html = linegraph.plot(
+                self.aligntrim_data, pconfig)
+            self.add_section(
+                name='Amplicon coverage',
+                anchor='artic_amplicon_plot',
+                # description='Mean depth of coverage per amplicon.',
+                helptext='''
+                This plot summarises the number of reads that were assigned to each amplicon in the primer scheme.
+
+                We use the `align_trim` report file from the ARTIC pipeline and group each read by its assigned amplicon.
+
+                If the length of alignment between read and reference is <{}% of the amplicon length, the read discarded from the coverage plot.
+
+                If the total number of reads assigned to an amplicon is below {} (red dashed line), the amplicon is marked as dropped out.
+                ''' .format(Alignment_Length_Threshold*100, Amplicon_Dropout_Val),
+                plot=amplicon_plot_html
+            )

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -357,6 +357,11 @@ module_order:
             - miRNA
 
     # Post-alignment processing
+    - artic:
+        module_tag:
+            - RNA
+            - epidemiology
+            - virus
     - homer:
         module_tag:
             - RNA

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -9,6 +9,12 @@ adapterRemoval:
 afterqc:
     fn: '*.json'
     contents: 'allow_mismatch_in_poly'
+artic/aligntrim_reports:
+    fn: '*.alignreport.txt'
+    contents_re: 'QueryName\tReferenceStart\tReferenceEnd\tPrimerPair\tPrimer1\tPrimer1Start\tPrimer2\tPrimer2Start\tIsSecondary\tIsSupplementary\tStart\tEnd\tCorrectlyPaired'
+    num_lines: 1
+artic/vcf_reports:
+    fn: '*.vcfreport.txt'
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -15,6 +15,8 @@ artic/aligntrim_reports:
     num_lines: 1
 artic/vcf_reports:
     fn: '*.vcfreport.txt'
+    contents_re: '.*artic-tools.*'
+    num_lines: 1
 bamtools/stats:
     contents: 'Stats for BAM file(s):'
     shared: true

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         'multiqc.modules.v1': [
             'adapterRemoval = multiqc.modules.adapterRemoval:MultiqcModule',
             'afterqc = multiqc.modules.afterqc:MultiqcModule',
+            'artic = multiqc.modules.artic:MultiqcModule',
             'bamtools = multiqc.modules.bamtools:MultiqcModule',
             'bbmap = multiqc.modules.bbmap:MultiqcModule',
             'bcftools = multiqc.modules.bcftools:MultiqcModule',


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

This PR adds a module for [ARTIC](https://github.com/artic-network/fieldbioinformatics) - a viral consensus genome pipeline widely used for SARS-CoV-2 work. It plots amplicon coverage and reports amplicons with dropout, as well as flagging variants with low support in overlap regions. 

 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->
 - [x] There is example tool output [here](https://github.com/ewels/MultiQC_TestData/pull/181)
 - [x] Code is tested and works locally (including with `--lint` flag)
 - [x] `docs/README.md` is updated with link to below
 - [x] `docs/modulename.md` is created
 - [x] Everything that can be represented with a plot instead of a table is a plot
 - [x] Report sections have a description and help text (with `self.add_section`)
 - [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
 - [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
 - [x] Module does not do any significant computational work
