### PR TITLE
Ngsderive table refactor

### DIFF
--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -202,11 +202,9 @@ class MultiqcModule(BaseMultiqcModule):
         }
         self.general_stats_addcols(general_data, general_headers)
 
-        samples = []
         instruments = set()
 
-        for s, d in general_data.items():
-            samples.append(s)
+        for d in general_data.values():
             instruments.update(d.get("instrument").split(" / "))
 
         # move multiple instruments to the end if it exists

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -264,6 +264,9 @@ class MultiqcModule(BaseMultiqcModule):
         headers["majoritypctdetected"] = {
             "title": "Read Length: % Supporting",
             "description": "Percentage of reads which were measured at the predicted read length.",
+            "min": 0,
+            "max": 100,
+            "suffix": "%",
         }
         self.general_stats_addcols(data, headers)
 


### PR DESCRIPTION
continuation of #1360

@ewels One remaining question about this is that there's no straightforward way to show `basis` in the new table format (that I can think of). I think it conveys the important information well (once color coding is added), instrument(s) and confidence.

@claymcleod are we ok not displaying `basis` in this section? It can still be revealed as a default-hidden column in the general stats table. I think that's backwards from how other modules work.... In that more detailed information is present in the general stats and this dedicated `instrument` section is more of an "at-a-glance" look (because to make this categorical data "at-a-glance"-able it requires more visual space than is available in the general table).

I'll attach a screenshot momentarily.