### PR TITLE
DRAGEN: support WES (coverage stats w/ target_bed prefix). Fixes #1290

### DIFF
--- a/multiqc/modules/dragen/coverage_hist.py
+++ b/multiqc/modules/dragen/coverage_hist.py
@@ -17,8 +17,8 @@ class DragenCoverageHist(BaseMultiqcModule):
     def add_coverage_hist(self):
         data_by_phenotype_by_sample = defaultdict(dict)
 
-        for f in self.find_log_files("dragen/wgs_fine_hist"):
-            data_by_phenotype = parse_wgs_fine_hist(f)
+        for f in self.find_log_files("dragen/fine_hist"):
+            data_by_phenotype = parse_fine_hist(f)
             if f["s_name"] in data_by_phenotype_by_sample:
                 log.debug("Duplicate sample name found! Overwriting: {}".format(f["s_name"]))
             self.add_data_source(f, section="stats")
@@ -87,10 +87,11 @@ class DragenCoverageHist(BaseMultiqcModule):
         return data_by_sample.keys()
 
 
-def parse_wgs_fine_hist(f):
+def parse_fine_hist(f):
     """
     T_SRR7890936_50pc.wgs_fine_hist_normal.csv
     T_SRR7890936_50pc.wgs_fine_hist_tumor.csv
+    T_SRR7890936_50pc.target_bed_fine_hist.csv
 
     Depth,Overall
     0,104231614
@@ -138,7 +139,7 @@ def parse_wgs_fine_hist(f):
         data[depth] = cnt
         cum_data[depth] = cum_pct
 
-    m = re.search(r"(.*).wgs_fine_hist_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*).(\S*)_fine_hist_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: (data, cum_data, depth_1pc)}

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -22,8 +22,8 @@ class DragenCoverageMetrics(BaseMultiqcModule):
     def add_coverage_metrics(self):
         data_by_phenotype_by_sample = defaultdict(dict)
 
-        for f in self.find_log_files("dragen/wgs_coverage_metrics"):
-            data_by_phenotype = parse_wgs_coverage_metrics(f)
+        for f in self.find_log_files("dragen/coverage_metrics"):
+            data_by_phenotype = parse_coverage_metrics(f)
             if f["s_name"] in data_by_phenotype_by_sample:
                 log.debug("Duplicate sample name found! Overwriting: {}".format(f["s_name"]))
             self.add_data_source(f, section="stats")
@@ -318,10 +318,11 @@ COV_METRICS = list(
 )
 
 
-def parse_wgs_coverage_metrics(f):
+def parse_coverage_metrics(f):
     """
     T_SRR7890936_50pc.wgs_coverage_metrics_normal.csv
     T_SRR7890936_50pc.wgs_coverage_metrics_tumor.csv
+    T_SRR7890936_50pc.target_bed_coverage_metrics.csv
 
     The coverage metrics report outputs a _coverage_metrics.csv file, which provides metrics over a region,
     where the region can be the genome, a target region, or a QC coverage region. The first column of the output
@@ -389,7 +390,7 @@ def parse_wgs_coverage_metrics(f):
         if percentage is not None:
             data[metric + " pct"] = percentage
 
-    m = re.search(r"(.*).wgs_coverage_metrics_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*).(\S*)_coverage_metrics_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: data}

--- a/multiqc/modules/dragen/coverage_per_contig.py
+++ b/multiqc/modules/dragen/coverage_per_contig.py
@@ -16,8 +16,8 @@ class DragenCoveragePerContig(BaseMultiqcModule):
     def add_coverage_per_contig(self):
         perchrom_data_by_phenotype_by_sample = defaultdict(dict)
 
-        for f in self.find_log_files("dragen/wgs_contig_mean_cov"):
-            perchrom_data_by_phenotype = parse_wgs_contig_mean_cov(f)
+        for f in self.find_log_files("dragen/contig_mean_cov"):
+            perchrom_data_by_phenotype = parse_contig_mean_cov(f)
             if f["s_name"] in perchrom_data_by_phenotype_by_sample:
                 log.debug("Duplicate sample name found! Overwriting: {}".format(f["s_name"]))
             self.add_data_source(f, section="stats")
@@ -89,7 +89,7 @@ class DragenCoveragePerContig(BaseMultiqcModule):
         return perchrom_data_by_sample.keys()
 
 
-def parse_wgs_contig_mean_cov(f):
+def parse_contig_mean_cov(f):
     """
     The Contig Mean Coverage report generates a _contig_mean_cov.csv file, which contains the estimated coverage for
     all contigs, and an autosomal estimated coverage. The file includes the following three columns
@@ -102,6 +102,7 @@ def parse_wgs_contig_mean_cov(f):
 
     T_SRR7890936_50pc.wgs_contig_mean_cov_normal.csv
     T_SRR7890936_50pc.wgs_contig_mean_cov_tumor.csv
+    T_SRR7890936_50pc.target_bed_contig_mean_cov.csv
 
     chr1,11292297134,48.9945
     chr10,6482885699,48.6473
@@ -156,7 +157,7 @@ def parse_wgs_contig_mean_cov(f):
         sorted(other_contig_perchrom_data.items(), key=lambda key_val: chrom_order(key_val[0]))
     )
 
-    m = re.search(r"(.*).wgs_contig_mean_cov_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*).(\S*)_contig_mean_cov_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: [main_contig_perchrom_data, other_contig_perchrom_data]}

--- a/multiqc/modules/dragen/dragen.py
+++ b/multiqc/modules/dragen/dragen.py
@@ -51,29 +51,35 @@ class MultiqcModule(
         )
 
         samples_found = set()
+
+        # <output prefix>.vc_metrics.csv
+        # a dedicated table and the total number of Variants into the general stats table
         samples_found |= self.add_vc_metrics()
-        # <output prefix>.vc_metrics.csv                   - a dedicated table and the total number of Variants into the general stats table
 
+        # <output prefix>.ploidy_estimation_metrics.csv
+        # a "Ploidy estimation" column in the general stats table
         samples_found |= self.add_ploidy_estimation_metrics()
-        # <output prefix>.ploidy_estimation_metrics.csv    - add just Ploidy estimation into gen stats
 
+        # <output prefix>.(wgs|target_bed)_fine_hist_(tumor|normal)?.csv
+        # coverage distribution and cumulative coverage plots
         samples_found |= self.add_coverage_hist()
-        # <output prefix>.wgs_fine_hist_normal.csv         - coverage distribution and cumulative coverage plots
-        # <output prefix>.wgs_fine_hist_tumor.csv          - same
 
+        # <output prefix>.(wgs|target_bed)_coverage_metrics_(tumor|normal)?.csv
+        # general stats table and a dedicated table
         samples_found |= self.add_coverage_metrics()
-        # <output prefix>.wgs_coverage_metrics_normal.csv  - general stats table and a dedicated table
-        # <output prefix>.wgs_coverage_metrics_tumor.csv   - same
 
+        # <output prefix>.(wgs|target_bed)_contig_mean_cov_(tumor|normal)?.csv
+        # a histogram like in mosdepth, with each chrom as a category on X axis, plus a category
+        # for autosomal chromosomes average
         samples_found |= self.add_coverage_per_contig()
-        # <output prefix>.wgs_contig_mean_cov_normal.csv   - a histogram like in mosdepth, with each chrom as a category on X axis, plus a category for autosomal chromosomes average
-        # <output prefix>.wgs_contig_mean_cov_tumor.csv    - same
 
+        # general stats table, a dedicated table, and a few barplots
+        # <output prefix>.mapping_metrics.csv
         samples_found |= self.add_mapping_metrics()
-        # <output prefix>.mapping_metrics.csv              - general stats table, a dedicated table, and a few barplots
 
+        # a histogram plot
+        # <output prefix>.fragment_length_hist.csv
         samples_found |= self.add_fragment_length_hist()
-        # <output prefix>.fragment_length_hist.csv         - a histogram plot
 
         if len(samples_found) == 0:
             raise UserWarning

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -234,12 +234,12 @@ dragen/vc_metrics:
   fn: "*.vc_metrics.csv"
 dragen/ploidy_estimation_metrics:
   fn: "*.ploidy_estimation_metrics.csv"
-dragen/wgs_contig_mean_cov:
-  fn_re: '.*\.wgs_contig_mean_cov_?(tumor|normal)?\.csv'
-dragen/wgs_coverage_metrics:
-  fn_re: '.*\.wgs_coverage_metrics_?(tumor|normal)?\.csv'
-dragen/wgs_fine_hist:
-  fn_re: '.*\.wgs_fine_hist_?(tumor|normal)?\.csv'
+dragen/contig_mean_cov:
+  fn_re: '.*\.(wgs|target_bed)_contig_mean_cov_?(tumor|normal)?\.csv'
+dragen/coverage_metrics:
+  fn_re: '.*\.(wgs|target_bed)_coverage_metrics_?(tumor|normal)?\.csv'
+dragen/fine_hist:
+  fn_re: '.*\.(wgs|target_bed)_fine_hist_?(tumor|normal)?\.csv'
 dragen/fragment_length_hist:
   fn: "*.fragment_length_hist.csv"
 dragen/mapping_metrics:


### PR DESCRIPTION
The files have the same structure and named with a `wgs_` or `target_bed_` prefix depending on the type of the run. So basically just adjusting the search patterns.