### PR TITLE
feat: add `encoding` and `junction-annotation` ngsderive modules

### DIFF
--- a/docs/plots.md
+++ b/docs/plots.md
@@ -135,13 +135,14 @@ config = {
 ### Switching datasets
 
 It's possible to have single plot with buttons to switch between different
-datasets. To do this, give a list of data objects (same formats as described
-above). Also add the following config options to supply names to the buttons:
+datasets. To do this, give a list of data objects to the `plot` function
+and specify the `data_labels` config option with the text to be used for the buttons:
 
 ```python
 config = {
     'data_labels': ['Reads', 'Bases']
 }
+html_content = bargraph.plot([data1, data2], pconfig=config)
 ```
 
 You can also customise the y-axis label and min/max values for each dataset:
@@ -180,7 +181,10 @@ cats[0]['aligned_reads'] =        {'name': 'Aligned Reads',        'color': '#8b
 cats[0]['unaligned_reads'] =      {'name': 'Unaligned Reads',      'color': '#f7a35c'}
 cats[1]['aligned_base_pairs'] =   {'name': 'Aligned Base Pairs',   'color': '#8bbc21'}
 cats[1]['unaligned_base_pairs'] = {'name': 'Unaligned Base Pairs', 'color': '#f7a35c'}
+html_content = bargraph.plot([data, data], cats, config)
 ```
+
+Note that, as in this example, the plot data can be the same dictionary supplied twice.
 
 ### Interactive / Flat image plots
 

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -426,6 +426,7 @@ class MultiqcModule(BaseMultiqcModule):
             "title": "ngsderive: Junction Annotation",
             "cpswitch_counts_label": "Number",
             "yDecimals": False,
+            "ylab": "Number of junctions",
             "data_labels": [
                 {"name": "Junctions", "ylab": "Number of junctions"},
                 {"name": "Spliced Reads", "ylab": "Number of spliced reads"},

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -445,5 +445,5 @@ class MultiqcModule(BaseMultiqcModule):
             anchor="ngsderive-junctions",
             description="""Junction annotations provided by ngsderive. For more information, please see
             [the documentation](https://stjudecloud.github.io/ngsderive/subcommands/junction_annotation/).""",
-            plot=bargraph.plot(bardata, cats, pconfig),
+            plot=bargraph.plot([bardata, bardata], cats, pconfig),
         )

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -444,6 +444,6 @@ class MultiqcModule(BaseMultiqcModule):
             name="Junction Annotations",
             anchor="ngsderive-junctions",
             description="""Junction annotations provided by ngsderive. For more information, please see
-            [the documentation](https://stjudecloud.github.io/ngsderive/subcommands/junction-annotation/).""",
+            [the documentation](https://stjudecloud.github.io/ngsderive/subcommands/junction_annotation/).""",
             plot=bargraph.plot(bardata, cats, pconfig),
         )

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -396,6 +396,12 @@ ngsderive/instrument:
 ngsderive/readlen:
   contents_re: "(.*)File(.*)Evidence(.*)MajorityPctDetected(.*)ConsensusReadLength"
   num_lines: 1
+ngsderive/encoding:
+  contents_re: "(.*)File(.*)Evidence(.*)ProbableEncoding"
+  num_lines: 1
+ngsderive/junction_annotation:
+  contents_re: "(.*)File(.*)total_junctions(.*)total_splice_events(.*)known_junctions(.*)partial_novel_junctions(.*)complete_novel_junctions(.*)known_spliced_reads(.*)partial_novel_spliced_reads(.*)complete_novel_spliced_reads"
+  num_lines: 1
 peddy/summary_table:
   fn: "*.peddy.ped"
 peddy/het_check:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -390,19 +390,19 @@ disambiguate:
   contents: "unique species A pairs"
   num_lines: 2
 ngsderive/strandedness:
-  contents_re: "File	TotalReads	ForwardPct	ReversePct	Predicted"
+  contents: "File	TotalReads	ForwardPct	ReversePct	Predicted"
   num_lines: 1
 ngsderive/instrument:
-  contents_re: "File	Instrument	Confidence	Basis"
+  contents: "File	Instrument	Confidence	Basis"
   num_lines: 1
 ngsderive/readlen:
-  contents_re: "File	Evidence	MajorityPctDetected	ConsensusReadLength"
+  contents: "File	Evidence	MajorityPctDetected	ConsensusReadLength"
   num_lines: 1
 ngsderive/encoding:
-  contents_re: "(.*)File(.*)Evidence(.*)ProbableEncoding"
+  contents: "File	Evidence	ProbableEncoding"
   num_lines: 1
 ngsderive/junction_annotation:
-  contents_re: "(.*)File(.*)total_junctions(.*)total_splice_events(.*)known_junctions(.*)partial_novel_junctions(.*)complete_novel_junctions(.*)known_spliced_reads(.*)partial_novel_spliced_reads(.*)complete_novel_spliced_reads"
+  contents: "File	total_junctions	total_splice_events	known_junctions	partial_novel_junctions	complete_novel_junctions	known_spliced_reads	partial_novel_spliced_reads	complete_novel_spliced_reads"
   num_lines: 1
 peddy/summary_table:
   fn: "*.peddy.ped"


### PR DESCRIPTION
This is essentially a continuation of the previous `ngsderive` PR. We've added two modules since that PR, don't think anything new needs to go into the CHANGELOG/docs since this is still the same release.

One thing I can't figure out is how to switch datasets for a barplot. I followed the instructions in the docs by adding a `data_labels` entry to the config and supplying a `categories` list, but I don't see the button to flip the `junction-annotation` graph from "junctions" to "spliced reads". Can you point me towards what I'm missing?