### PR TITLE
MultiQC fails to parse plotProfile when TSS values is missing

### DIFF
--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -142,7 +142,7 @@ class plotProfileMixin:
                     step = self._int(abs(start / bin_labels.index("TSS")))
                     end = step * (len(bin_labels) - bin_labels.index("TSS"))
                     converted_bin_labels = range((self._int(start) + step), (self._int(end) + step), step)
-                except UnboundLocalError, IndexError:
+                except (UnboundLocalError, ValueError):
                     converted_bin_labels = bins
 
                 for i in bins:

--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -142,7 +142,7 @@ class plotProfileMixin:
                     step = self._int(abs(start / bin_labels.index("TSS")))
                     end = step * (len(bin_labels) - bin_labels.index("TSS"))
                     converted_bin_labels = range((self._int(start) + step), (self._int(end) + step), step)
-                except UnboundLocalError:
+                except UnboundLocalError, IndexError:
                     converted_bin_labels = bins
 
                 for i in bins:


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

MultiQC fails to parse `plotProfile` text output if the TSS bin is not found (eg. unannotated peaks). I fixed the issue by catching the error. 