### PR TITLE
AdapterRemoval: fixed bug when showing number of read types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - **Picard**
   - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
   - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
+- **AdapterRemoval**
+  - Fixed bug where reported retained read pairs was misleading (@fgvieira)
 
 ## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -177,8 +177,8 @@ class MultiqcModule(BaseMultiqcModule):
         self.result_data["reads_total"] = reads_total
         self.result_data["discarded_total"] = reads_total - self.result_data["retained"]
 
-        self.result_data["retained_reads"] = (
-            self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+        self.result_data["paired_reads"] = (
+            self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"] - self.result_data["full-length_cp"] - self.result_data["truncated_cp"]
         )
         try:
             self.result_data["percent_aligned"] = (
@@ -268,7 +268,7 @@ class MultiqcModule(BaseMultiqcModule):
         cats_pec = OrderedDict()
 
         if self.__any_paired:
-            cats_pec["retained_reads"] = {"name": "Retained Read Pairs"}
+            cats_pec["paired_reads"] = {"name": "Paired Reads"}
 
         cats_pec["singleton_m1"] = {"name": "Singleton R1"}
 

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -178,7 +178,11 @@ class MultiqcModule(BaseMultiqcModule):
         self.result_data["discarded_total"] = reads_total - self.result_data["retained"]
 
         self.result_data["paired_reads"] = (
-            self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"] - self.result_data["full-length_cp"] - self.result_data["truncated_cp"]
+            self.result_data["retained"]
+            - self.result_data["singleton_m1"]
+            - self.result_data["singleton_m2"]
+            - self.result_data["full-length_cp"]
+            - self.result_data["truncated_cp"]
         )
         try:
             self.result_data["percent_aligned"] = (


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated


I believe the number of reads displayed is misleading.
As an example, after adapter removal trimming, a sample ends up with these reads on the output files:
```
reads.pair1.truncated.gz: 72,571,435
reads.pair2.truncated.gz: 72,571,435
reads.singleton.truncated.gz: 56,678 (55,102 + 1,576)
reads.collapsed.gz: 8,093,391
reads.collapsed.truncated.gz: 1,457,443
reads.discarded.gz: 3,486,928 (1,716,701 + 1,770,227)
```

However, the module currently shows:

![adapt_removal](https://user-images.githubusercontent.com/1151762/117128278-7c312b80-ad9d-11eb-9d57-26036a91c2ea.png)

I believe that the first number should be `R1 + R2` (145,142,870).
The issue is that Adapter removal counts retained reads as the sum of `R1 + R2 + Singleton R1 + Singleton R2 + Full length Collapsed + Truncated Collapsed`, but the module is currently only doing `retained_reads = retained - Singleton R1 - Singleton R2`.
I think it would make more sense to also remove the number of collapsed reads from `retained_reads` and call it `Paired reads`.