### PR TITLE
Add per-contig filters for mosdepth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/ewels/MultiQC/issues/1407))
 - **Mosdepth**
   - Show barplot instead of line graph for coverage-per-contig plot if there is only one contig.
+  - Include or exclude contigs based on patterns for coverage-per-contig plots
 - **Picard**
   - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
   - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))

--- a/docs/modules/mosdepth.md
+++ b/docs/modules/mosdepth.md
@@ -48,3 +48,21 @@ general_stats_coverage_hidden:
   - 20
   - 200
 ```
+
+For the per-contig coverage plot, you can include and exclude contigs based on name or pattern:
+
+```yaml
+mosdepth_config:
+  include_contigs:
+    - "chr*"
+  exclude_contigs:
+    - '*_alt'
+    - '*_decoy'
+    - '*_random'
+    - 'chrUn*'
+    - 'HLA*'
+    - 'chrM'
+    - 'chrEBV'
+```
+
+Note that exclusion superseeds inclusion for the contig filters.

--- a/docs/modules/mosdepth.md
+++ b/docs/modules/mosdepth.md
@@ -56,13 +56,13 @@ mosdepth_config:
   include_contigs:
     - "chr*"
   exclude_contigs:
-    - '*_alt'
-    - '*_decoy'
-    - '*_random'
-    - 'chrUn*'
-    - 'HLA*'
-    - 'chrM'
-    - 'chrEBV'
+    - "*_alt"
+    - "*_decoy"
+    - "*_random"
+    - "chrUn*"
+    - "HLA*"
+    - "chrM"
+    - "chrEBV"
 ```
 
 Note that exclusion superseeds inclusion for the contig filters.

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -202,20 +202,6 @@ class MultiqcModule(BaseMultiqcModule):
                         continue
                     contig, cutoff_reads, bases_fraction = line.split("\t")
 
-                    # filter out contigs based on exclusion patterns
-                    if any(fnmatch.fnmatch(contig, pattern) for pattern in exclude_contigs):
-                        # Commented out since this could be many thousands of contigs fo reach!
-                        # log.debug("Skipping excluded contig '{}'".format(contig))
-                        continue
-
-                    # filter out contigs based on inclusion patterns
-                    if 0 < len(include_contigs) and not any(
-                        fnmatch.fnmatch(contig, pattern) for pattern in include_contigs
-                    ):
-                        # Commented out since this could be many thousands of contigs fo reach!
-                        # log.debug("Skipping not included contig '{}'".format(contig))
-                        continue
-
                     if contig == "total":  # for global coverage distribution
                         cumcov = 100.0 * float(bases_fraction)
                         x = int(cutoff_reads)
@@ -235,6 +221,20 @@ class MultiqcModule(BaseMultiqcModule):
                         if cumcov > 1:  # require >1% to prevent long flat tail
                             xmax = max(xmax, x)
                     else:  # for per-contig plot
+                        # filter out contigs based on exclusion patterns
+                        if any(fnmatch.fnmatch(contig, pattern) for pattern in exclude_contigs):
+                            # Commented out since this could be many thousands of contigs fo reach!
+                            # log.debug("Skipping excluded contig '{}'".format(contig))
+                            continue
+
+                        # filter out contigs based on inclusion patterns
+                        if 0 < len(include_contigs) and not any(
+                            fnmatch.fnmatch(contig, pattern) for pattern in include_contigs
+                        ):
+                            # Commented out since this could be many thousands of contigs fo reach!
+                            # log.debug("Skipping not included contig '{}'".format(contig))
+                            continue
+
                         avg = perchrom_avg_data[s_name].get(contig, 0) + float(bases_fraction)
                         perchrom_avg_data[s_name][contig] = avg
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -177,7 +177,7 @@ class MultiqcModule(BaseMultiqcModule):
         cov_data = defaultdict(OrderedDict)  # absoulte (non-cumulative) coverage
         xmax = 0
         perchrom_avg_data = defaultdict(OrderedDict)  # per chromosome average coverage
-        
+
         try:
             include_contigs = config.mosdepth_config.get("include_contigs", [])
             assert type(include_contigs) == list, type(include_contigs)
@@ -205,13 +205,15 @@ class MultiqcModule(BaseMultiqcModule):
                     # filter out contigs based on exclusion patterns
                     if any(fnmatch.fnmatch(contig, pattern) for pattern in exclude_contigs):
                         # Commented out since this could be many thousands of contigs fo reach!
-                        #log.debug("Skipping excluded contig '{}'".format(contig))
+                        # log.debug("Skipping excluded contig '{}'".format(contig))
                         continue
-                    
+
                     # filter out contigs based on inclusion patterns
-                    if 0 < len(include_contigs) and not any(fnmatch.fnmatch(contig, pattern) for pattern in include_contigs):
+                    if 0 < len(include_contigs) and not any(
+                        fnmatch.fnmatch(contig, pattern) for pattern in include_contigs
+                    ):
                         # Commented out since this could be many thousands of contigs fo reach!
-                        #log.debug("Skipping not included contig '{}'".format(contig))
+                        # log.debug("Skipping not included contig '{}'".format(contig))
                         continue
 
                     if contig == "total":  # for global coverage distribution

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -178,10 +178,16 @@ class MultiqcModule(BaseMultiqcModule):
         xmax = 0
         perchrom_avg_data = defaultdict(OrderedDict)  # per chromosome average coverage
         
-        include_contigs = config.mosdepth_config.get("include_contigs", [])
-        assert type(include_contigs) == list, type(include_contigs)
-        exclude_contigs = config.mosdepth_config.get("exclude_contigs", [])
-        assert type(exclude_contigs) == list, type(exclude_contigs)
+        try:
+            include_contigs = config.mosdepth_config.get("include_contigs", [])
+            assert type(include_contigs) == list, type(include_contigs)
+        except (AttributeError, TypeError, AssertionError):
+            include_contigs = []
+        try:
+            exclude_contigs = config.mosdepth_config.get("exclude_contigs", [])
+            assert type(exclude_contigs) == list, type(exclude_contigs)
+        except (AttributeError, TypeError, AssertionError):
+            exclude_contigs = []
         log.debug("include_congtigs: {}".format(include_contigs))
         log.debug("exclude_congtigs: {}".format(exclude_contigs))
 


### PR DESCRIPTION
For genomes with many decoy, alts, random, and additional sequences, we may want to selectively remove contigs from the `mosdepth` per-contig plots.  I've added support for pattern matching, the same as the file inclusion/exclusion patterns.  The `mosdepth` docs have been updated.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated