### PR TITLE
Update figures, bug fix, and improve efficiency in biscuit module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 #### Module updates
 
+- **biscuit**
+  - Duplicate Rate and Cytosine Retention tables are now bargraphs.
+  - Refactor code to only calculate alignment statistics once.
+  - Fixed bug where cytosine retentions values would not be properly read if in scientific notation.
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
 - **Flexbar**

--- a/multiqc/modules/biscuit/biscuit.py
+++ b/multiqc/modules/biscuit/biscuit.py
@@ -171,20 +171,14 @@ class MultiqcModule(BaseMultiqcModule):
             "scale": "YlOrBr",
             "hidden": True,
         }
-        pheader["dup_all"] = {
-            "title": "Dup. % for All Reads",
-            "min": 0,
-            "max": 100,
-            "suffix": "%",
-            "scale": "Reds"
-        }
+        pheader["dup_all"] = {"title": "Dup. % for All Reads", "min": 0, "max": 100, "suffix": "%", "scale": "Reds"}
         pheader["aligned"] = {
             "title": "% Aligned",
             "min": 0,
             "max": 100,
             "suffix": "%",
             "scale": "RdYlGn",
-            "format": "{:,.2f}"
+            "format": "{:,.2f}",
         }
 
         self.general_stats_addcols(pd, pheader)
@@ -218,7 +212,7 @@ class MultiqcModule(BaseMultiqcModule):
             "opt_align": 0,
             "sub_align": 0,
             "not_align": 0,
-            "mapqs": dict(zip(range(61), [0 for _ in range(61)]))
+            "mapqs": dict(zip(range(61), [0 for _ in range(61)])),
         }
         if len(mapq) > 0:
             total = sum([int(cnt) for _, cnt in mapq.items() if _ != "unmapped"])
@@ -233,8 +227,11 @@ class MultiqcModule(BaseMultiqcModule):
                     else:
                         data["sub_align"] += int(cnt)
 
-            data["frc_align"] = 100 * (data["opt_align"] + data["sub_align"]) / \
-                    (data["opt_align"] + data["sub_align"] + data["not_align"])
+            data["frc_align"] = (
+                100
+                * (data["opt_align"] + data["sub_align"])
+                / (data["opt_align"] + data["sub_align"] + data["not_align"])
+            )
 
         return data
 
@@ -259,11 +256,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Calculate alignment counts
         for s_name, dd in self.mdata["align_mapq"].items():
             if len(dd) > 0:
-                pd[s_name] = {
-                    "opt_align": dd["opt_align"],
-                    "sub_align": dd["sub_align"],
-                    "not_align": dd["not_align"]
-                }
+                pd[s_name] = {"opt_align": dd["opt_align"], "sub_align": dd["sub_align"], "not_align": dd["not_align"]}
 
         pheader = OrderedDict()
         pheader["opt_align"] = {"color": "#1f78b4", "name": "Optimally Aligned Reads"}
@@ -535,29 +528,22 @@ class MultiqcModule(BaseMultiqcModule):
             No returns, generates Duplicate Rates chart
         """
 
-        pd1 = {} # Overall duplicate rate
-        pd2 = {} # MAPQ>=40 duplicate rate
+        pd1 = {}  # Overall duplicate rate
+        pd2 = {}  # MAPQ>=40 duplicate rate
         for s_name, dd in self.mdata["dup_report"].items():
             if "all" in dd and dd["all"] != -1:
                 pd1[s_name] = {"dup_rate": dd["all"]}
             if "q40" in dd and dd["q40"] != -1:
                 pd2[s_name] = {"dup_rate": dd["q40"]}
 
-        pheader = OrderedDict(
-            [
-                ("dup_rate", {"color": "#a50f15", "name": "Duplicate Rate"})
-            ]
-        )
+        pheader = OrderedDict([("dup_rate", {"color": "#a50f15", "name": "Duplicate Rate"})])
 
         pconfig = {
             "id": "biscuit_dup_report",
             "cpswitch": False,
             "cpswitch_c_active": False,
             "title": "BISCUIT: Percentage of Duplicate Reads",
-            "data_labels": [
-                {"name": "Overall Duplicate Rate"},
-                {"name": "MAPQ>=40 Duplicate Rate"}
-            ],
+            "data_labels": [{"name": "Overall Duplicate Rate"}, {"name": "MAPQ>=40 Duplicate Rate"}],
             "ylab": "Duplicate Rate [%]",
             "ymin": 0,
             "ymax": 100,
@@ -565,7 +551,7 @@ class MultiqcModule(BaseMultiqcModule):
             "use_legend": False,
             "tt_decimals": 1,
             "tt_suffix": "%",
-            "tt_percentages": False
+            "tt_percentages": False,
         }
 
         if len(pd1) > 0:
@@ -1221,10 +1207,7 @@ class MultiqcModule(BaseMultiqcModule):
             "cpswitch": False,
             "cpswitch_c_active": False,
             "title": "BISCUIT: Cytosine Retention",
-            "data_labels": [
-                {"name": "Read-averaged Retention"},
-                {"name": "Base-averaged Retention"}
-            ],
+            "data_labels": [{"name": "Read-averaged Retention"}, {"name": "Base-averaged Retention"}],
             "ylab": "Percent Retained",
             "ymin": 0,
             "ymax": 100,
@@ -1233,7 +1216,7 @@ class MultiqcModule(BaseMultiqcModule):
             "use_legend": True,
             "tt_decimals": 1,
             "tt_suffix": "%",
-            "tt_percentages": False
+            "tt_percentages": False,
         }
 
         self.add_section(


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

This pull request is to address comments made in PR #1167.
- *% Duplicate reads seems to be calculated twice*: I looked through the duplicate rate code and I couldn't seem to find where this was calculated twice. However, the percent aligned was calculated twice. I've updated the code to only calculate the various percentages needed once (occurs during log file parsing). Let me know if there was a particular part you had in mind for the duplicate rate being calculated twice.
- *I think that the Duplicate Rates and Cytosine Retention tables would be better presented as bar plots*: These two charts have been updated to be bar graphs, rather than tables.

I also updated how the cytosine retention log files were parsed to avoid a bug where values in scientific notation wouldn't be properly read from the file and turned into percentages.