### PR TITLE
Flat image log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added docs describing tools for downstream analysis of MultiQC outputs.
 - Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/ewels/MultiQC/issues/1413))
 - Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/ewels/MultiQC/issues/1416))
+- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/ewels/MultiQC/issues/1254))
 
 #### New Modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1003,7 +1003,7 @@ def run(
 
     if report.num_mpl_plots > 0:
         logger.info("Generated {} static plot{} in the report".format(report.num_mpl_plots, "s" if report.num_mpl_plots > 1 else ""))
-        logger.info(" - Your sample size has exceeded the 'plots_flat_numseries' config threshold")
+        logger.info(" - Your sample size likely exceeds the 'plots_flat_numseries' config threshold ({})".format(config.plots_flat_numseries))
         logger.info(" - To avoid this behavior, use the '--interactive' command line option")
         logger.info(" - For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)")
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1002,10 +1002,20 @@ def run(
         logger.info("For more information, see the 'Run Time' section in {}".format(os.path.relpath(config.output_fn)))
 
     if report.num_mpl_plots > 0:
-        logger.info("Generated {} static plot{} in the report".format(report.num_mpl_plots, "s" if report.num_mpl_plots > 1 else ""))
-        logger.info(" - Your sample size likely exceeds the 'plots_flat_numseries' config threshold ({})".format(config.plots_flat_numseries))
+        logger.info(
+            "Generated {} static plot{} in the report".format(
+                report.num_mpl_plots, "s" if report.num_mpl_plots > 1 else ""
+            )
+        )
+        logger.info(
+            " - Your sample size likely exceeds the 'plots_flat_numseries' config threshold ({})".format(
+                config.plots_flat_numseries
+            )
+        )
         logger.info(" - To avoid this behavior, use the '--interactive' command line option")
-        logger.info(" - For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)")
+        logger.info(
+            " - For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)"
+        )
 
     if lint and len(report.lint_errors) > 0:
         logger.error("Found {} linting errors!\n{}".format(len(report.lint_errors), "\n".join(report.lint_errors)))

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1001,20 +1001,12 @@ def run(
         logger.info(" - {:.2f}s: Compressing report data".format(report.runtimes["total_compression"]))
         logger.info("For more information, see the 'Run Time' section in {}".format(os.path.relpath(config.output_fn)))
 
-    if report.num_mpl_plots > 0:
-        logger.info(
-            "Generated {} static plot{} in the report".format(
-                report.num_mpl_plots, "s" if report.num_mpl_plots > 1 else ""
-            )
-        )
-        logger.info(
-            " - Your sample size likely exceeds the 'plots_flat_numseries' config threshold ({})".format(
-                config.plots_flat_numseries
-            )
-        )
-        logger.info(" - To avoid this behavior, use the '--interactive' command line option")
-        logger.info(
-            " - For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)"
+    if report.num_mpl_plots > 0 and not config.plots_force_flat:
+        logger.warning("Flat-image plots used in the report due to large sample numbers")
+        console.print(
+            "[blue]|           multiqc[/] | "
+            "To force interactive plots, use the [yellow]'--interactive'[/] flag. "
+            "See the [link=https://multiqc.info/docs/#flat--interactive-plots]documentation[/link]."
         )
 
     if lint and len(report.lint_errors) > 0:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1001,6 +1001,11 @@ def run(
         logger.info(" - {:.2f}s: Compressing report data".format(report.runtimes["total_compression"]))
         logger.info("For more information, see the 'Run Time' section in {}".format(os.path.relpath(config.output_fn)))
 
+    if report.num_mpl_plots > 0:
+        logger.info("Generated {} static plots in the report!".format(report.num_mpl_plots))
+        logger.info("To always use interactive plots, use the '--interactive' command line options")
+        logger.info("For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)")
+
     if lint and len(report.lint_errors) > 0:
         logger.error("Found {} linting errors!\n{}".format(len(report.lint_errors), "\n".join(report.lint_errors)))
         sys_exit_code = 1

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1002,9 +1002,10 @@ def run(
         logger.info("For more information, see the 'Run Time' section in {}".format(os.path.relpath(config.output_fn)))
 
     if report.num_mpl_plots > 0:
-        logger.info("Generated {} static plots in the report!".format(report.num_mpl_plots))
-        logger.info("To always use interactive plots, use the '--interactive' command line options")
-        logger.info("For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)")
+        logger.info("Generated {} static plot{} in the report".format(report.num_mpl_plots, "s" if report.num_mpl_plots > 1 else ""))
+        logger.info(" - Your sample size has exceeded the 'plots_flat_numseries' config threshold")
+        logger.info(" - To avoid this behavior, use the '--interactive' command line option")
+        logger.info(" - For more information, see 'Flat / interactive plots' section in the docs (https://multiqc.info/docs/#flat--interactive-plots)")
 
     if lint and len(report.lint_errors) > 0:
         logger.error("Found {} linting errors!\n{}".format(len(report.lint_errors), "\n".join(report.lint_errors)))

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -190,7 +190,7 @@ def plot(data, cats=None, pconfig=None):
         ):
             try:
                 plot = matplotlib_bargraph(plotdata, plotsamples, pconfig)
-                report.num_mpl_plots += 1 # count MatpPlotLib figure
+                report.num_mpl_plots += 1
                 return plot
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")
@@ -556,7 +556,5 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
 
     # Close wrapping div
     html += "</div>"
-
-
 
     return html

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -189,7 +189,9 @@ def plot(data, cats=None, pconfig=None):
             not config.plots_force_interactive and len(plotsamples[0]) > config.plots_flat_numseries
         ):
             try:
-                return matplotlib_bargraph(plotdata, plotsamples, pconfig)
+                plot = matplotlib_bargraph(plotdata, plotsamples, pconfig)
+                report.num_mpl_plots += 1 # count MatpPlotLib figure
+                return plot
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")
                 logger.debug(e, exc_info=True)
@@ -555,6 +557,6 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
     # Close wrapping div
     html += "</div>"
 
-    report.num_mpl_plots += 1
+
 
     return html

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -189,9 +189,8 @@ def plot(data, cats=None, pconfig=None):
             not config.plots_force_interactive and len(plotsamples[0]) > config.plots_flat_numseries
         ):
             try:
-                plot = matplotlib_bargraph(plotdata, plotsamples, pconfig)
                 report.num_mpl_plots += 1
-                return plot
+                return matplotlib_bargraph(plotdata, plotsamples, pconfig)
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")
                 logger.debug(e, exc_info=True)

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -216,9 +216,8 @@ def plot(data, pconfig=None):
             not config.plots_force_interactive and plotdata and len(plotdata[0]) > config.plots_flat_numseries
         ):
             try:
-                plot = matplotlib_linegraph(plotdata, pconfig)
                 report.num_mpl_plots += 1
-                return plot
+                return matplotlib_linegraph(plotdata, pconfig)
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")
                 logger.debug(e, exc_info=True)

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -216,7 +216,9 @@ def plot(data, pconfig=None):
             not config.plots_force_interactive and plotdata and len(plotdata[0]) > config.plots_flat_numseries
         ):
             try:
-                return matplotlib_linegraph(plotdata, pconfig)
+                plot = matplotlib_linegraph(plotdata, pconfig)
+                report.num_mpl_plots += 1 # count MatpPlotLib figure
+                return plot
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")
                 logger.debug(e, exc_info=True)
@@ -586,8 +588,6 @@ def matplotlib_linegraph(plotdata, pconfig=None):
 
     # Close wrapping div
     html += "</div>"
-
-    report.num_mpl_plots += 1
 
     return html
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -217,7 +217,7 @@ def plot(data, pconfig=None):
         ):
             try:
                 plot = matplotlib_linegraph(plotdata, pconfig)
-                report.num_mpl_plots += 1 # count MatpPlotLib figure
+                report.num_mpl_plots += 1
                 return plot
             except Exception as e:
                 logger.error("############### Error making MatPlotLib figure! Falling back to HighCharts.")


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

This pull request addresses the issue  #1254.
`report.num_mpl_plots` counter is moved to where the program decides to include a flat image in the report.
If the counter is >0, a message is displayed in the log informing the user that static plots were used and suggesting to use the "--interactive" command option. 