### PR TITLE
Fixed typo causing wrong multipel of contigs from QUAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - **Picard**
   - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
   - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
+- **QUAST**
+  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 
 ## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -184,7 +184,7 @@ class MultiqcModule(BaseMultiqcModule):
             "min": 0,
             "suffix": self.total_number_contigs_suffix,
             "scale": "GnYlRd",
-            "mofidy": lambda x: x * self.total_number_contigs_multiplier,
+            "modify": lambda x: x * self.total_number_contigs_multiplier,
         }
         headers["Largest contig"] = {
             "title": "Largest contig ({})".format(self.contig_length_suffix),


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->
Should close #1442. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

