### PR TITLE
Fix failing qc3C tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
 - **VEP**
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
+- **qc3C**
+  - Updated module to not fail on older field names.
 
 ## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -965,20 +965,8 @@ class MultiqcModule(BaseMultiqcModule):
                 )
             parsed = parsed[-1]
             # Check if fields in json file are named as in the old version
-            if "unobs_fraction" not in parsed:
-                parsed["unobs_fraction"] = parsed["unobs_frac"]
-            if "vs_accepted" not in parsed["separation_bins"]:
-                parsed["separation_bins"]["vs_accepted"] = parsed["separation_bins"]["zvs_accepted"]
-
         except json.JSONDecodeError:
             log.warning("Could not parse qc3C JSON: '{}'".format(f["fn"]))
-            return
-        except KeyError as ex:
-            log.error(
-                "The entry {} was not found in the qc3C JSON file '{}'".format(
-                    str(ex), os.path.join(f["root"], f["fn"])
-                )
-            )
             return
 
         s_name = self.clean_s_name(os.path.basename(f["root"]), os.path.dirname(f["root"]))
@@ -987,8 +975,12 @@ class MultiqcModule(BaseMultiqcModule):
 
         try:
             analysis_mode = parsed["mode"]
+            if "unobs_fraction" not in parsed:
+                parsed["unobs_fraction"] = parsed["unobs_frac"]
 
             if analysis_mode == "bam":
+                if "vs_accepted" not in parsed["separation_bins"]:
+                    parsed["separation_bins"]["vs_accepted"] = parsed["separation_bins"]["zvs_accepted"]
 
                 # set some variables to shorten the lines below
                 inf = parsed["classification"]["informative"]

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -233,8 +233,8 @@ class MultiqcModule(BaseMultiqcModule):
                     [HiC-Pro](https://github.com/nservant/HiC-Pro).
                 """,
                 helptext="""
-                    As the field has moved from 6-cutter to 4-cutter enzymes, and subsequently dual-enzyme digests, the 
-                    higher density of sites has made this framework less useful, since it has become increasingly easy 
+                    As the field has moved from 6-cutter to 4-cutter enzymes, and subsequently dual-enzyme digests, the
+                    higher density of sites has made this framework less useful, since it has become increasingly easy
                     to satisfy the intervening site criteria.
                 """,
                 plot=self.bam_valid_plot(),
@@ -245,12 +245,12 @@ class MultiqcModule(BaseMultiqcModule):
                 anchor="qc3C-bam-longrange-plot",
                 description="This plot visualises the breakdown of read-pairs based on separation distance.",
                 helptext="""
-                    The breakdown of separation distance is only calculated for *cis*-mapping pairs. 
+                    The breakdown of separation distance is only calculated for *cis*-mapping pairs.
 
-                    Ideally, Hi-C proximity ligation should produce many pairs which are greater than 1000 bp apart. 
+                    Ideally, Hi-C proximity ligation should produce many pairs which are greater than 1000 bp apart.
                     However, these statistics are strongly influenced by the state of the reference. For draft assemblies
-                    the distance at which pairs can map is limited by the degree of fragmentation and length of contigs. 
-                    As a result, many more pairs will be categorised as *trans*-mapping and pairs which are truly 
+                    the distance at which pairs can map is limited by the degree of fragmentation and length of contigs.
+                    As a result, many more pairs will be categorised as *trans*-mapping and pairs which are truly
                     inter-molecular cannot be distinguished from those which are merely inter-contig.
                 """,
                 plot=self.bam_longrange_plot(),
@@ -260,23 +260,23 @@ class MultiqcModule(BaseMultiqcModule):
                 name="BAM mode distribution of fragment separation",
                 anchor="qc3C-bam-fragment-histogram",
                 description="""
-                    This figure displays the a normalised histogram of read-pair separation binned uniformly in 
-                    log-space. 
-                    
-                    Due to the binning strategy, the x-axis is log-scaled and visually accommodates pair separations up 
-                    to 1 million bp. The inferred insert size for each library is represented by a dashed, grey vertical 
-                    line. The y-axis is log-scaled by default, allowing the density attributed to long-range pairs to be 
+                    This figure displays the a normalised histogram of read-pair separation binned uniformly in
+                    log-space.
+
+                    Due to the binning strategy, the x-axis is log-scaled and visually accommodates pair separations up
+                    to 1 million bp. The inferred insert size for each library is represented by a dashed, grey vertical
+                    line. The y-axis is log-scaled by default, allowing the density attributed to long-range pairs to be
                     more easily seen.
                 """,
                 helptext="""
-                    A characteristic of Hi-C libraries, is the presence of a large peak below 1000 bp. qc3C attributes 
-                    this to regular (and undesirable) shotgun pairs creeping through the Hi-C protocol. The peak is used 
-                    by qc3C to infer the insert size, which is later employed to estimate unobservable extent of 
+                    A characteristic of Hi-C libraries, is the presence of a large peak below 1000 bp. qc3C attributes
+                    this to regular (and undesirable) shotgun pairs creeping through the Hi-C protocol. The peak is used
+                    by qc3C to infer the insert size, which is later employed to estimate unobservable extent of
                     inserts.
 
-                    **Note:** the inferred insert size can be significantly smaller than what a sequencing facility 
-                    might report the experimentally determined insert size to be. This discrepancy can be explained by 
-                    the failure to account for the additional adapter sequence when fragments are assessed during 
+                    **Note:** the inferred insert size can be significantly smaller than what a sequencing facility
+                    might report the experimentally determined insert size to be. This discrepancy can be explained by
+                    the failure to account for the additional adapter sequence when fragments are assessed during
                     library preparation.
                 """,
                 plot=self.bam_fragment_histogram(),
@@ -291,24 +291,24 @@ class MultiqcModule(BaseMultiqcModule):
                         are actually observed in the reads. (_Trivial single-digests are ignored_)
                     """,
                     helptext="""
-                        For trivial single-enzyme digests, there is only one possible junction sequence and so the 
-                        result for these experiments are not plotted. For dual-enzyme (such as Phase Genomics) there are 
-                        four potential junctions, while for dual-enzyme digests with one ambiguous site (such as Arima 
+                        For trivial single-enzyme digests, there is only one possible junction sequence and so the
+                        result for these experiments are not plotted. For dual-enzyme (such as Phase Genomics) there are
+                        four potential junctions, while for dual-enzyme digests with one ambiguous site (such as Arima
                         Genomics) there are 16 possible junction sequences.
-    
-                        How efficiently the more complicated library protocols are at producing hybrid junctions is 
+
+                        How efficiently the more complicated library protocols are at producing hybrid junctions is
                         possibly just a point of interest.
-                        
+
                         Junctions are named for which enzymes was responsible for creating the 5' and 3' ends.
-                        E.g. `Sau3AI/MluCI` would involve two different enzymes, while `Sau3AI/Sau3AI` only one, as 
-                        would be the case in a single-enzyme digest. Proceeding the name is the actual junction 
+                        E.g. `Sau3AI/MluCI` would involve two different enzymes, while `Sau3AI/Sau3AI` only one, as
+                        would be the case in a single-enzyme digest. Proceeding the name is the actual junction
                         sequence.
-                        
-                        The junctions are grouped by their 5' and then 3' enzyme, while the color spectrum used across 
+
+                        The junctions are grouped by their 5' and then 3' enzyme, while the color spectrum used across
                         each bar aims to emphasise these enzymatic sources.
-    
-                        **Note:** in BAM mode, the counts **are** controlled for false positives, in the sense that read 
-                        alignments must terminate at a cutsite, but the read sequence must continue and contain the 
+
+                        **Note:** in BAM mode, the counts **are** controlled for false positives, in the sense that read
+                        alignments must terminate at a cutsite, but the read sequence must continue and contain the
                         observed junction.
                     """,
                     plot=self.bam_junction_plot(),
@@ -333,11 +333,11 @@ class MultiqcModule(BaseMultiqcModule):
                 anchor="qc3C-kmer-hic-fraction",
                 description="This table lists the inferred proportion of Hi-C proximity ligation fragments.",
                 helptext="""
-                    Here, **Mean adjusted Hi-C fraction** represents the best estimate of the proportion of a library's 
-                    read-pairs which are a product of proximity ligation. This figure is arrived at by correcting the 
+                    Here, **Mean adjusted Hi-C fraction** represents the best estimate of the proportion of a library's
+                    read-pairs which are a product of proximity ligation. This figure is arrived at by correcting the
                     raw estimate for the fraction of insert extent which was not observable.
 
-                    The observable extent is limited by the length of reads relative to the supplied insert size, as 
+                    The observable extent is limited by the length of reads relative to the supplied insert size, as
                     well as a further constraint on flanking sequence around any suspected junction sequence.
                 """,
                 plot=self.kmer_signal_table(),
@@ -374,22 +374,22 @@ class MultiqcModule(BaseMultiqcModule):
                         are actually observed in the reads. (_Trivial single-digests are ignored_)
                     """,
                     helptext="""
-                        For trivial single-enzyme digests, there is only one possible junction sequence and so the 
-                        result for these experiments are not plotted. For dual-enzyme (such as Phase Genomics) there are 
-                        four potential junctions, while for dual-enzyme digests with one ambiguous site (such as Arima 
+                        For trivial single-enzyme digests, there is only one possible junction sequence and so the
+                        result for these experiments are not plotted. For dual-enzyme (such as Phase Genomics) there are
+                        four potential junctions, while for dual-enzyme digests with one ambiguous site (such as Arima
                         Genomics) there are 16 possible junction sequences.
-    
-                        How efficiently the more complicated library protocols are at producing hybrid junctions is 
+
+                        How efficiently the more complicated library protocols are at producing hybrid junctions is
                         possibly just a point of interest.
-    
+
                         Junctions are named for which enzymes was responsible for creating the 5' and 3' ends.
-                        E.g. `Sau3AI/MluCI` would involve two different enzymes, while `Sau3AI/Sau3AI` only one, as 
-                        would be the case in a single-enzyme digest. Proceeding the name is the actual junction 
+                        E.g. `Sau3AI/MluCI` would involve two different enzymes, while `Sau3AI/Sau3AI` only one, as
+                        would be the case in a single-enzyme digest. Proceeding the name is the actual junction
                         sequence.
-                        
-                        The junctions are grouped by their 5' and then 3' enzyme, while the color spectrum used across 
+
+                        The junctions are grouped by their 5' and then 3' enzyme, while the color spectrum used across
                         each bar aims to emphasise these enzymatic sources.
-                        
+
                     **Note:** in k-mer mode, the counts are not controlled for false positives.
                     """,
                     plot=self.kmer_junction_plot(),
@@ -964,8 +964,21 @@ class MultiqcModule(BaseMultiqcModule):
                     )
                 )
             parsed = parsed[-1]
+            # Check if fields in json file are named as in the old version
+            if "unobs_fraction" not in parsed:
+                parsed["unobs_fraction"] = parsed["unobs_frac"]
+            if "vs_accepted" not in parsed["separation_bins"]:
+                parsed["separation_bins"]["vs_accepted"] = parsed["separation_bins"]["zvs_accepted"]
+
         except json.JSONDecodeError:
             log.warning("Could not parse qc3C JSON: '{}'".format(f["fn"]))
+            return
+        except KeyError as ex:
+            log.error(
+                "The entry {} was not found in the qc3C JSON file '{}'".format(
+                    str(ex), os.path.join(f["root"], f["fn"])
+                )
+            )
             return
 
         s_name = self.clean_s_name(os.path.basename(f["root"]), os.path.dirname(f["root"]))

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -1106,7 +1106,7 @@ class MultiqcModule(BaseMultiqcModule):
             # to render the junction frequency plot
             if len(parsed["junction_frequency"]) > 1:
                 self.do_digest_plot = True
-                log.info("Enabled junction frequency plot for non-trivial digest: {}".format(f["root"]))
+                log.debug("Enabled junction frequency plot for non-trivial digest: {}".format(f["root"]))
                 # include the junction frequencies (1 or many depending on digest)
                 self.qc3c_data[analysis_mode][s_name].update(parsed["junction_frequency"])
 

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -964,7 +964,6 @@ class MultiqcModule(BaseMultiqcModule):
                     )
                 )
             parsed = parsed[-1]
-            # Check if fields in json file are named as in the old version
         except json.JSONDecodeError:
             log.warning("Could not parse qc3C JSON: '{}'".format(f["fn"]))
             return
@@ -975,11 +974,11 @@ class MultiqcModule(BaseMultiqcModule):
 
         try:
             analysis_mode = parsed["mode"]
-            if "unobs_fraction" not in parsed:
+            if "unobs_fraction" not in parsed and "unobs_frac" in parsed:
                 parsed["unobs_fraction"] = parsed["unobs_frac"]
 
             if analysis_mode == "bam":
-                if "vs_accepted" not in parsed["separation_bins"]:
+                if "vs_accepted" not in parsed["separation_bins"] and "zvs_accepted " in parsed["separation_bins"]:
                     parsed["separation_bins"]["vs_accepted"] = parsed["separation_bins"]["zvs_accepted"]
 
                 # set some variables to shorten the lines below


### PR DESCRIPTION
Fixed failing qc3C tests due to different field names in the older version of the files:
- `unobs_fraction` was `unobs_frac` in the older version
- `separation_bins:vs_accepted` was `separation_bins:zvs_accepted`
For reference:  [new](https://github.com/ewels/MultiQC_TestData/blob/master/data/modules/qc3C/bam_out/DRR177157/report.qc3C.json) and [old](https://github.com/ewels/MultiQC_TestData/blob/master/data/modules/qc3C/v0.4a2/bam_out/DRR177157/report.qc3C.json)

---

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated


