### PR TITLE
Fixed dragen generating errors when run on single-end output 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
+- **Dragen**
+  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 - **fastp**
   - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
 - **Flexbar**
@@ -45,8 +47,6 @@
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **VEP**
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
-- **Dragen**
-  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 
 ## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **VEP**
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
+- **Dragen**
+  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 
 ## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -100,7 +100,7 @@ class DragenMappingMetics(BaseMultiqcModule):
                 + data["Unmapped reads"]
                 != data["Total reads in RG"]
             ):
-                log.warning(
+                log.debug(
                     "sum of unpaired/discordant/proppaired/unmapped reads not matching total, "
                     "skipping mapping/paired percentages plot for: {}".format(sample_id)
                 )
@@ -335,21 +335,19 @@ def parse_mapping_metrics_file(f):
 
     # adding some missing values that we wanna report for consistency
     for data in itertools.chain(data_by_readgroup.values(), data_by_phenotype.values()):
-        # fixing when deduplication wasn't performed
-        if data.get("Number of duplicate marked reads", "NA") == "NA":
-            data["Number of duplicate marked reads"] = 0
-        if data.get("Number of duplicate marked and mate reads removed", "NA") == "NA":
-            data["Number of duplicate marked and mate reads removed"] = 0
-        if data.get("Number of unique reads (excl. duplicate marked reads)", "NA") == "NA":
-            data["Number of unique reads (excl. duplicate marked reads)"] = data["Mapped reads"]
-
-        # fixing when dragen was run on single-end data
-        if data.get("Mismatched bases R2 (excl. indels)", "NA") == "NA":
-            data["Mismatched bases R2 (excl. indels)"] = 0
-        if data.get("Mismatched bases R2", "NA") == "NA":
-            data["Mismatched bases R2"] = 0
-        if data.get("Soft-clipped bases R2", "NA") == "NA":
-            data["Soft-clipped bases R2"] = 0
+        # fixing when deduplication wasn't performed, or running with single-end data
+        for field in [
+            "Number of duplicate marked reads",
+            "Number of duplicate marked and mate reads removed",
+            "Number of unique reads (excl. duplicate marked reads)",
+            "Mismatched bases R2 (excl. indels)",
+            "Mismatched bases R2",
+            "Soft-clipped bases R2",
+        ]:
+            try:
+                data.pop(field)
+            except KeyError:
+                pass
 
         # adding alignment percentages
         if exist_and_number(data, "Total alignments", "Secondary alignments") and data["Total alignments"] > 0:

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -107,11 +107,11 @@ class DragenMappingMetics(BaseMultiqcModule):
                 continue
             if (
                 data["Number of unique & mapped reads (excl. duplicate marked reads)"]
-                + data["Number of duplicate marked reads"]
+                + data.get("Number of duplicate marked reads", 0)
                 + data["Unmapped reads"]
                 != data["Total reads in RG"]
             ):
-                log.warning(
+                log.debug(
                     "sum of unique/duplicate/unmapped reads not matching total, "
                     "skipping mapping/duplicates percentages plot for: {}".format(sample_id)
                 )

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -117,48 +117,52 @@ class DragenMappingMetics(BaseMultiqcModule):
                 )
                 continue
             chart_data[sample_id] = data
-        self.add_section(
-            name="Mapped / paired / duplicated",
-            anchor="dragen-mapped-paired-duplicated",
-            description="Distribution of reads based on pairing, duplication and mapping.",
-            plot=bargraph.plot(
-                [chart_data, chart_data],
-                [
-                    {
-                        "Number of unique & mapped reads (excl. duplicate marked reads)": {
-                            "color": "#437bb1",
-                            "name": "Unique",
-                        },
-                        "Number of duplicate marked reads": {"color": "#f5a742", "name": "Duplicated"},
-                        "Unmapped reads": {"color": "#b1084c", "name": "Unmapped"},
-                    },
-                    {
-                        "Properly paired reads": {"color": "#099109", "name": "Paired, properly"},
-                        "Not properly paired reads (discordant)": {"color": "#c27a0e", "name": "Paired, discordant"},
-                        "Singleton reads (itself mapped; mate unmapped)": {"color": "#912476", "name": "Singleton"},
-                        "Unmapped reads": {"color": "#b1084c", "name": "Unmapped"},
-                    },
-                ],
-                {
-                    "id": "mapping_dup_percentage_plot",
-                    "title": "Dragen: Mapped/paired/duplicated reads per read group",
-                    "ylab": "Reads",
-                    "cpswitch_counts_label": "Reads",
-                    "data_labels": [
+        if len(chart_data) > 0:
+            self.add_section(
+                name="Mapped / paired / duplicated",
+                anchor="dragen-mapped-paired-duplicated",
+                description="Distribution of reads based on pairing, duplication and mapping.",
+                plot=bargraph.plot(
+                    [chart_data, chart_data],
+                    [
                         {
-                            "name": "Unique vs duplicated vs unmapped",
-                            "ylab": "Reads",
-                            "cpswitch_counts_label": "Reads",
+                            "Number of unique & mapped reads (excl. duplicate marked reads)": {
+                                "color": "#437bb1",
+                                "name": "Unique",
+                            },
+                            "Number of duplicate marked reads": {"color": "#f5a742", "name": "Duplicated"},
+                            "Unmapped reads": {"color": "#b1084c", "name": "Unmapped"},
                         },
                         {
-                            "name": "Paired vs. discordant vs. singleton",
-                            "ylab": "Reads",
-                            "cpswitch_counts_label": "Reads",
+                            "Properly paired reads": {"color": "#099109", "name": "Paired, properly"},
+                            "Not properly paired reads (discordant)": {
+                                "color": "#c27a0e",
+                                "name": "Paired, discordant",
+                            },
+                            "Singleton reads (itself mapped; mate unmapped)": {"color": "#912476", "name": "Singleton"},
+                            "Unmapped reads": {"color": "#b1084c", "name": "Unmapped"},
                         },
                     ],
-                },
-            ),
-        )
+                    {
+                        "id": "mapping_dup_percentage_plot",
+                        "title": "Dragen: Mapped/paired/duplicated reads per read group",
+                        "ylab": "Reads",
+                        "cpswitch_counts_label": "Reads",
+                        "data_labels": [
+                            {
+                                "name": "Unique vs duplicated vs unmapped",
+                                "ylab": "Reads",
+                                "cpswitch_counts_label": "Reads",
+                            },
+                            {
+                                "name": "Paired vs. discordant vs. singleton",
+                                "ylab": "Reads",
+                                "cpswitch_counts_label": "Reads",
+                            },
+                        ],
+                    },
+                ),
+            )
 
 
 def parse_mapping_metrics_file(f):
@@ -338,6 +342,14 @@ def parse_mapping_metrics_file(f):
             data["Number of duplicate marked and mate reads removed"] = 0
         if data.get("Number of unique reads (excl. duplicate marked reads)", "NA") == "NA":
             data["Number of unique reads (excl. duplicate marked reads)"] = data["Mapped reads"]
+
+        # fixing when dragen was run on single-end data
+        if data.get("Mismatched bases R2 (excl. indels)", "NA") == "NA":
+            data["Mismatched bases R2 (excl. indels)"] = 0
+        if data.get("Mismatched bases R2", "NA") == "NA":
+            data["Mismatched bases R2"] = 0
+        if data.get("Soft-clipped bases R2", "NA") == "NA":
+            data["Soft-clipped bases R2"] = 0
 
         # adding alignment percentages
         if exist_and_number(data, "Total alignments", "Secondary alignments") and data["Total alignments"] > 0:


### PR DESCRIPTION
Handled the `dragen` module generating errors when run on single-end output due to numbers being replaced by `NA`, as suggested in #1374. Also added check that data is present before generation of bar graph in `mapping_metrics.py`.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

