### PR TITLE
Handled `ZeroDivisionError` in Sentieon module on zero read input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   - Updated module to not fail on older field names.
 - **QUAST**
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
+- **Sentieon**
+ - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
 - **VEP**
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - **QUAST**
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **Sentieon**
- - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
 - **VEP**
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
 

--- a/multiqc/modules/sentieon/InsertSizeMetrics.py
+++ b/multiqc/modules/sentieon/InsertSizeMetrics.py
@@ -107,7 +107,11 @@ def parse_reports(self):
 
     # Calculate summed mean values for all read orientations
     for s_name, v in self.sentieon_insertSize_samplestats.items():
-        self.sentieon_insertSize_samplestats[s_name]["summed_mean"] = v["meansum"] / v["total_pairs"]
+        try:
+            self.sentieon_insertSize_samplestats[s_name]["summed_mean"] = v["meansum"] / v["total_pairs"]
+        except ZeroDivisionError:
+            # The mean of zero elements is zero
+            self.sentieon_insertSize_samplestats[s_name]["summed_mean"] = 0
 
     # Calculate summed median values for all read orientations
     for s_name in self.sentieon_insertSize_histogram:


### PR DESCRIPTION
Handled `ZeroDivisionError` in Sentieon module on zero read input. Should close #1420. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

