### PR TITLE
Make commadecimal checker more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
   - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
   - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
   - Add metrics from `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/ewels/MultiQC/pull/1336))
+  - Made checker for comma as decimal separator in `HsMetrics` more robust.([#1296](https://github.com/ewels/MultiQC/issues/1296))
 - **qc3C**
   - Updated module to not fail on older field names.
 - **QUAST**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
   - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
   - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
   - Add metrics from `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/ewels/MultiQC/pull/1336))
-  - Made checker for comma as decimal separator in `HsMetrics` more robust.([#1296](https://github.com/ewels/MultiQC/issues/1296))
+  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/ewels/MultiQC/issues/1296))
 - **qc3C**
   - Updated module to not fail on older field names.
 - **QUAST**

--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -93,12 +93,12 @@ def parse_reports(self):
                         parsed_data[s_name][j] = dict()
                         # Check that we're not using commas for decimal places
                         if commadecimal is None:
+                            commadecimal = False
                             for i, k in enumerate(keys):
-                                if k.startswith("PCT_"):
+                                if "PCT" in k or "BAIT" in k or "MEAN" in k:
                                     if "," in vals[i]:
                                         commadecimal = True
-                                    else:
-                                        commadecimal = False
+                                        break
                         for i, k in enumerate(keys):
                             try:
                                 if commadecimal:


### PR DESCRIPTION
`picard/HsMetrics` was failing on input data with a lot of null values, as reported in #1296. The errors were caused by the comma checker in the MultiQC module not reporting comma as decimal separator when null values were set to `0` instead of `0,0`. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
