### PR TITLE
Added handling of missing section in FastQC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 - **fastp**
   - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
+- **FastQC**
+  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/ewels/MultiQC/issues/1444))
 - **Flexbar**
   - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/ewels/MultiQC/issues/1407))
 - **Kraken**

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -862,6 +862,7 @@ class MultiqcModule(BaseMultiqcModule):
                     data[s_name]["top_overrepresented"] = 0
                     data[s_name]["remaining_overrepresented"] = 0
                 else:
+                    del data[s_name]
                     log.debug("Couldn't find data for {}, invalid Key".format(s_name))
 
         if all(len(data[s_name]) == 0 for s_name in self.fastqc_data):

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -857,12 +857,19 @@ class MultiqcModule(BaseMultiqcModule):
                 data[s_name]["top_overrepresented"] = max_pcnt
                 data[s_name]["remaining_overrepresented"] = total_pcnt - max_pcnt
             except KeyError:
-                if self.fastqc_data[s_name]["statuses"]["overrepresented_sequences"] == "pass":
-                    data[s_name]["total_overrepresented"] = 0
-                    data[s_name]["top_overrepresented"] = 0
-                    data[s_name]["remaining_overrepresented"] = 0
-                else:
-                    log.debug("Couldn't find data for {}, invalid Key".format(s_name))
+                try:
+                    if self.fastqc_data[s_name]["statuses"]["overrepresented_sequences"] == "pass":
+                        data[s_name]["total_overrepresented"] = 0
+                        data[s_name]["top_overrepresented"] = 0
+                        data[s_name]["remaining_overrepresented"] = 0
+                    else:
+                        log.debug("Couldn't find data for {}, invalid Key".format(s_name))
+                except KeyError:
+                    pass
+
+        if all(len(data[s_name]) == 0 for s_name in self.fastqc_data):
+            log.warning("overrepresented_sequences not found in FastQC reports")
+            return None
 
         cats = OrderedDict()
         cats["top_overrepresented"] = {"name": "Top over-represented sequence"}

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -875,7 +875,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Config for the plot
         pconfig = {
-            "id": "fastqc_overrepresented_sequencesi_plot",
+            "id": "fastqc_overrepresented_sequences_plot",
             "title": "FastQC: Overrepresented sequences",
             "ymin": 0,
             "yCeiling": 100,

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -857,18 +857,15 @@ class MultiqcModule(BaseMultiqcModule):
                 data[s_name]["top_overrepresented"] = max_pcnt
                 data[s_name]["remaining_overrepresented"] = total_pcnt - max_pcnt
             except KeyError:
-                try:
-                    if self.fastqc_data[s_name]["statuses"]["overrepresented_sequences"] == "pass":
-                        data[s_name]["total_overrepresented"] = 0
-                        data[s_name]["top_overrepresented"] = 0
-                        data[s_name]["remaining_overrepresented"] = 0
-                    else:
-                        log.debug("Couldn't find data for {}, invalid Key".format(s_name))
-                except KeyError:
-                    pass
+                if self.fastqc_data[s_name]["statuses"].get("overrepresented_sequences") == "pass":
+                    data[s_name]["total_overrepresented"] = 0
+                    data[s_name]["top_overrepresented"] = 0
+                    data[s_name]["remaining_overrepresented"] = 0
+                else:
+                    log.debug("Couldn't find data for {}, invalid Key".format(s_name))
 
         if all(len(data[s_name]) == 0 for s_name in self.fastqc_data):
-            log.warning("overrepresented_sequences not found in FastQC reports")
+            log.debug("overrepresented_sequences not found in FastQC reports")
             return None
 
         cats = OrderedDict()


### PR DESCRIPTION
Added check in `fastqc` to skip  `overrepresented_sequences`  section if it is missing from reports, to catch bug reported in #1281.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated