### PR TITLE
Handle zero read samples in `RSEM`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **Sentieon**
   - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
+- **RSEM**
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/ewels/MultiQC/issues/1040))
+andled `Zerod
 - **RSeQC**
   - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/ewels/MultiQC/issues/1457))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@
   - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
 - **RSEM**
   - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/ewels/MultiQC/issues/1040))
-andled `Zerod
 - **RSeQC**
   - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/ewels/MultiQC/issues/1457))
 

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -79,11 +79,7 @@ class MultiqcModule(BaseMultiqcModule):
                 try:
                     data["alignable_percent"] = (float(s[1]) / float(s[3])) * 100.0
                 except ZeroDivisionError:
-                    if float(s[1]) == 0.0:
-                        log.warning(f"Skipping zero reads sample '{f['fn']}'")
-                    else:
-                        log.error("Erroneous sample: Alignable reads can't be be non-zero if total reads are zero")
-                    return None
+                    data["alignable_percent"] = 0
             elif len(s) == 3:
                 # Line: nUnique nMulti nUncertain
                 # nUnique, number of reads aligned uniquely to a gene

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -49,6 +49,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.rsem_mapped_data, "multiqc_rsem")
 
         # Basic Stats Table
+
         self.rsem_stats_table()
 
         # Assignment bar plot
@@ -76,7 +77,14 @@ class MultiqcModule(BaseMultiqcModule):
                 data["Alignable"] = int(s[1])
                 data["Filtered"] = int(s[2])
                 data["Total"] = int(s[3])
-                data["alignable_percent"] = (float(s[1]) / float(s[3])) * 100.0
+                try:
+                    data["alignable_percent"] = (float(s[1]) / float(s[3])) * 100.0
+                except ZeroDivisionError:
+                    if float(s[1]) == 0.0:
+                        log.warning(f"Skipping zero reads sample '{f['fn']}'")
+                    else:
+                        log.error("Erroneous sample: Alignable reads can't be be non-zero if total reads are zero")
+                    return None
             elif len(s) == 3:
                 # Line: nUnique nMulti nUncertain
                 # nUnique, number of reads aligned uniquely to a gene

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -49,7 +49,6 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.rsem_mapped_data, "multiqc_rsem")
 
         # Basic Stats Table
-
         self.rsem_stats_table()
 
         # Assignment bar plot


### PR DESCRIPTION
Handled `ZeroDivisionError` in `RSEM` module when input sample have zero reads by skipping sample. Should close #1040. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
