### PR TITLE
Added clearer warning messages when no bargraph can be created in `Cutadapt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
 - **Cutadapt**
-  - Added support for linked adapters [[#1329](https://github.com/ewels/MultiQC/issues/1329)]
+  - Added support for linked adapters [[#1329](https://github.com/ewels/multiqc/issues/1329)]
   - Parse whether trimming was 5' or 3' for _Lengths of Trimmed Sequences_ plot where possible
+  - Warn user when all filtered reads categories are zero and filtered reads bar graph can't be created ([#1328](https://github.com/ewels/multiqc/issues/1328))
 - **Dragen**
   - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 - **fastp**

--- a/multiqc/modules/cutadapt/cutadapt.py
+++ b/multiqc/modules/cutadapt/cutadapt.py
@@ -237,10 +237,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         pconfig = {"id": "cutadapt_filtered_reads_plot", "title": "Cutadapt: Filtered Reads", "ylab": "Counts"}
 
-        # We just use all categories. If a report is generated with a mixture
-        # of SE and PE data then this means quite a lot of categories.
-        # Usually, only a single data type is used though - in that case
-        # any categories with 0 across all samples will be ignored.
+        # Check if there are any non zero samples in data
         cats_with_zero = []
         plottable = False
         for sample in self.cutadapt_data.values():
@@ -267,6 +264,11 @@ class MultiqcModule(BaseMultiqcModule):
         if not plottable:
             log.warning("Found no non-zero read or pairs categories in report. Skipping bar graph...")
             return None
+
+        # We just use all categories. If a report is generated with a mixture
+        # of SE and PE data then this means quite a lot of categories.
+        # Usually, only a single data type is used though - in that case
+        # any categories with 0 across all samples will be ignored.
 
         cats = OrderedDict()
         cats["pairs_written"] = {"name": "Pairs passing filters"}


### PR DESCRIPTION
Added checks for read/pair categories which are included in `Cutadapt` report but are set to zero. If such categories are found, a warning message is displayed. Additionally, if _only_ such categories are found, the filtered reads bar graph is not created and `multiqc` displays a warning message. Should close #1328.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
