### PR TITLE
Add new module `tin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   - Added MultiQC module to add duplicate rate calculated by Sambamba Markdup.
 - [**Snippy**](https://github.com/tseemann/snippy)
   - Rapid haploid variant calling and core genome alignment.
+- [**TIN**](http://rseqc.sourceforge.net/#tin-py)
+  - RSeQC subtool that calculates the RNA integrity of samples at transcript level
 - [**VEP**](https://www.ensembl.org/info/docs/tools/vep/index.html)
   - Added MultiQC module to add summary statistics of Ensembl VEP annotations.
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,6 @@
   - Added MultiQC module to add duplicate rate calculated by Sambamba Markdup.
 - [**Snippy**](https://github.com/tseemann/snippy)
   - Rapid haploid variant calling and core genome alignment.
-- [**TIN**](http://rseqc.sourceforge.net/#tin-py)
-  - RSeQC subtool that calculates the RNA integrity of samples at transcript level
 - [**VEP**](https://www.ensembl.org/info/docs/tools/vep/index.html)
   - Added MultiQC module to add summary statistics of Ensembl VEP annotations.
   - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
@@ -66,6 +64,8 @@
   - Updated module to not fail on older field names.
 - **qualimap**
   - Added new percentage coverage plot in `QM_RNASeq`, and fixed wrong units in tool tip label ([#1258](https://github.com/ewels/MultiQC/issues/1258))
+- **RSeQC**
+  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/ewels/MultiQC/issues/737))
 - **QUAST**
   - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **Sentieon**

--- a/docs/modules/rseqc.md
+++ b/docs/modules/rseqc.md
@@ -22,6 +22,7 @@ Supported scripts:
 - `read_distribution`
 - `read_duplication`
 - `read_gc`
+- `tin`
 
 You can choose to hide sections of RSeQC output and customise their order.
 To do this, add and customise the following to your MultiQC config file:
@@ -29,6 +30,7 @@ To do this, add and customise the following to your MultiQC config file:
 ```yaml
 rseqc_sections:
   - read_distribution
+  - tin
   - gene_body_coverage
   - inner_distance
   - read_gc

--- a/multiqc/modules/rseqc/rseqc.py
+++ b/multiqc/modules/rseqc/rseqc.py
@@ -48,6 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "junction_saturation",
                 "infer_experiment",
                 "bam_stat",
+                "tin",
             ]
 
         # Add self.js to be included in template

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -26,8 +26,6 @@ def parse_reports(self):
         except csv.Error:
             continue
 
-        if "TIN(median)" not in contents:
-            continue
         s_name = contents["Bam_file"]
         contents.pop("Bam_file")
         self.tin_data[s_name] = contents

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -42,6 +42,14 @@ def parse_reports(self):
         self.write_data_file(self.tin_data, "multiqc_rseqc_tin")
 
         # Add to general stats table
+        self.general_stats_headers["TIN(stdev)"] = {
+            "title": "TIN stdev",
+            "description": "Standard Deviation for the Transcript Integriry Number (TIN)",
+            "max": 100,
+            "min": 0,
+            "scale": "Reds",
+            "hidden": True,
+        }
         self.general_stats_headers["TIN(median)"] = {
             "title": "TIN",
             "description": "Median Transcript Integriry Number (TIN), indicating the RNA integrity of a sample",
@@ -54,5 +62,6 @@ def parse_reports(self):
             if s_name not in self.general_stats_data:
                 self.general_stats_data[s_name] = dict()
             self.general_stats_data[s_name]["TIN(median)"] = self.tin_data[s_name]["TIN(median)"]
+            self.general_stats_data[s_name]["TIN(stdev)"] = self.tin_data[s_name]["TIN(stdev)"]
 
     return len(self.tin_data)

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -63,7 +63,12 @@ def parse_reports(self):
         self.add_section(
             name="TIN score",
             anchor="rseqc_tin",
-            description="[TIN](http://rseqc.sourceforge.net/#tin-py) measures the RNA degradation in a sample.",
+            description=(
+                "[TIN](http://rseqc.sourceforge.net/#tin-py) is designed to evaluate RNA integrity at transcript level. "
+                "TIN (transcript integrity number) is named in analogous to RIN (RNA integrity number). "
+                "RIN (RNA integrity number) is the most widely used metric to evaluate RNA integrity at sample (or transcriptome) level. "
+                "It is a very useful preventive measure to ensure good RNA quality and robust, reproducible RNA sequencing."
+            ),
             plot=bargraph.plot(self.tin_data, cats, pconfig),
         )
     return len(self.tin_data)

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -24,6 +24,7 @@ def parse_reports(self):
             reader = csv.DictReader(f["f"], delimiter="\t")
             contents = next(reader)
         except csv.Error:
+            log.error(f"Could not parse file '{f['fn']}'")
             continue
 
         s_name = contents["Bam_file"]
@@ -42,8 +43,8 @@ def parse_reports(self):
 
         # Add to general stats table
         self.general_stats_headers["TIN(median)"] = {
-            "title": "TIN median score",
-            "description": "the RNA integrity of a sample",
+            "title": "TIN",
+            "description": "Median Transcript Integriry Number (TIN), indicating the RNA integrity of a sample",
             "max": 100,
             "min": 0,
             "scale": "RdBu",
@@ -53,20 +54,5 @@ def parse_reports(self):
             if s_name not in self.general_stats_data:
                 self.general_stats_data[s_name] = dict()
             self.general_stats_data[s_name]["TIN(median)"] = self.tin_data[s_name]["TIN(median)"]
-        pconfig = {"id": "rseqc_tin_median_score_plot", "title": "RSeQC: TIN Score", "ylab": "TIN score"}
 
-        cats = OrderedDict()
-        cats["TIN(median)"] = {"name": "TIN median score"}
-
-        self.add_section(
-            name="TIN score",
-            anchor="rseqc_tin",
-            description=(
-                "[TIN](http://rseqc.sourceforge.net/#tin-py) is designed to evaluate RNA integrity at transcript level. "
-                "TIN (transcript integrity number) is named in analogous to RIN (RNA integrity number). "
-                "RIN (RNA integrity number) is the most widely used metric to evaluate RNA integrity at sample (or transcriptome) level. "
-                "It is a very useful preventive measure to ensure good RNA quality and robust, reproducible RNA sequencing."
-            ),
-            plot=bargraph.plot(self.tin_data, cats, pconfig),
-        )
     return len(self.tin_data)

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -52,7 +52,7 @@ def parse_reports(self):
         for s_name in self.tin_data:
             if s_name not in self.general_stats_data:
                 self.general_stats_data[s_name] = dict()
-                self.general_stats_data[s_name]["TIN(median)"] = self.tin_data[s_name]["TIN(median)"]
+            self.general_stats_data[s_name]["TIN(median)"] = self.tin_data[s_name]["TIN(median)"]
         pconfig = {"id": "rseqc_tin_median_score_plot", "title": "RSeQC: TIN Score", "ylab": "TIN score"}
 
         cats = OrderedDict()

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -610,6 +610,9 @@ rseqc/infer_experiment:
   - fn: "*infer_experiment.txt"
   - contents: "Fraction of reads explained by"
     max_filesize: 500000
+rseqc/tin:
+  contents: "Bam_file"
+  num_lines: 1
 salmon/meta:
   fn: "meta_info.json"
   contents: "salmon_version"

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -611,6 +611,7 @@ rseqc/infer_experiment:
   - contents: "Fraction of reads explained by"
     max_filesize: 500000
 rseqc/tin:
+  fn: "*.summary.txt"
   contents: "TIN(median)"
   num_lines: 1
 salmon/meta:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -611,7 +611,7 @@ rseqc/infer_experiment:
   - contents: "Fraction of reads explained by"
     max_filesize: 500000
 rseqc/tin:
-  contents: "Bam_file"
+  contents: "TIN(median)"
   num_lines: 1
 salmon/meta:
   fn: "meta_info.json"


### PR DESCRIPTION
Added new `tin` submodule to `rseqc` according to specification given in #737. The new modules adds the following functionality:
- New column for median TIN in general stats table
- New bar graph for median TIN score. 

---

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
- [x] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [x] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
