### PR TITLE
update samtools stats documentation

### DIFF
--- a/docs/modules/samtools.md
+++ b/docs/modules/samtools.md
@@ -18,6 +18,21 @@ Supported commands:
 - `idxstats`
 - `rmdup`
 
+### stats
+
+The `samtools stats` tool collects many statistics from SAM/BAM files. MultiQC can pick these files up by including `stats` in the filename, i.e. `sample_ID.stats.txt`. It is likely most useful when you want to easily create a bargraph of mapped vs unmapped against a reference file from a preferred aligner. Some useful settings to customize the plot might look like:
+
+```yaml
+custom_plot_config:
+    samtools_alignment_plot:
+        cpswitch_c_active: False
+        reads_mapped:
+                color: "#ff7654"
+        reads_unmapped:
+                color: "#47ff94"
+```
+This allows you to customize whether or not percent mapped is the default visualization of the barplot, and the colors of the mapped/unmapped stacked portions of the plot. This type of plot generation is substantially easier than trying to parse results from `samtools flagstat` if you're only interested in percent mapping against a reference.
+
 ### idxstats
 
 The `samtools idxstats` prints its results to standard

--- a/docs/modules/samtools.md
+++ b/docs/modules/samtools.md
@@ -31,6 +31,7 @@ custom_plot_config:
         reads_unmapped:
                 color: "#47ff94"
 ```
+
 This allows you to customize whether or not percent mapped is the default visualization of the barplot, and the colors of the mapped/unmapped stacked portions of the plot. This type of plot generation is substantially easier than trying to parse results from `samtools flagstat` if you're only interested in percent mapping against a reference.
 
 ### idxstats


### PR DESCRIPTION
for usecase of wanting mapped/unmapped barplot vs reference

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
