### PR TITLE
Add PCT_SELECTED_BASES to HsMetrics output

### DIFF
--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -226,6 +226,7 @@ def _get_table_headers(data):
             "PCT_USABLE_BASES_ON_TARGET",
             "PF_BASES_ALIGNED",
             "PF_READS",
+            "PCT_SELECTED_BASES",
             "PF_UNIQUE_READS",
             "PF_UQ_BASES_ALIGNED",
             "PF_UQ_READS_ALIGNED",


### PR DESCRIPTION
The `PCT_SELECTED_BASES` is probably the most useful output of this metric (as per the original author @tfenne), so not making it hidden by default.


