### PR TITLE
Fix logger to enable multiple calls to `multiqc.run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+Fixed logger bugs when calling `multiqc.run` by removing logging file handlers between calls ([#1141](https://github.com/ewels/MultiQC/issues/1141)
+
 ### New Modules
 
 ### Module updates

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -281,7 +281,7 @@ def run_cli(
     sys.exit(multiqc_run["sys_exit_code"])
 
 
-# Main function that runs MultQC. Available to use within an interactive Python environment
+# Main function that runs MultiQC. Available to use within an interactive Python environment
 def run(
     analysis_dir,
     dirs=False,

--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -37,6 +37,10 @@ def init_log(logger, loglevel=0, no_ansi=False):
     debug_template = "[%(asctime)s] %(name)-50s [%(levelname)-7s]  %(message)s"
     info_template = "|%(module)18s | %(message)s"
 
+    # Remove log handlers left from previous calls to multiqc.run
+    while logger.hasHandlers():
+        logger.removeHandler(logger.handlers[0])
+
     # Base level setup
     logger.setLevel(getattr(logging, "DEBUG"))
 


### PR DESCRIPTION
Fixed MultiQC crashing when calling `multiq.run` multiple times by removing logger file handlers between calls. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
