### PR TITLE
[bugfix] Fix sample and phenotype extraction for DRAGEN

### DIFF
--- a/multiqc/modules/dragen/coverage_hist.py
+++ b/multiqc/modules/dragen/coverage_hist.py
@@ -139,7 +139,7 @@ def parse_fine_hist(f):
         data[depth] = cnt
         cum_data[depth] = cum_pct
 
-    m = re.search(r"(.*).(\S*)_fine_hist_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*)\.(\S*)_fine_hist_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: (data, cum_data, depth_1pc)}

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -390,7 +390,7 @@ def parse_coverage_metrics(f):
         if percentage is not None:
             data[metric + " pct"] = percentage
 
-    m = re.search(r"(.*).(\S*)_coverage_metrics_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*)\.(\S*)_coverage_metrics_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: data}

--- a/multiqc/modules/dragen/coverage_per_contig.py
+++ b/multiqc/modules/dragen/coverage_per_contig.py
@@ -157,7 +157,7 @@ def parse_contig_mean_cov(f):
         sorted(other_contig_perchrom_data.items(), key=lambda key_val: chrom_order(key_val[0]))
     )
 
-    m = re.search(r"(.*).(\S*)_contig_mean_cov_?(\S*)?.csv", f["fn"])
+    m = re.search(r"(.*)\.(\S*)_contig_mean_cov_?(\S*)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     f["s_name"] = sample
     return {phenotype: [main_contig_perchrom_data, other_contig_perchrom_data]}

--- a/multiqc/modules/dragen/fragment_length.py
+++ b/multiqc/modules/dragen/fragment_length.py
@@ -96,7 +96,7 @@ def parse_fragment_length_hist_file(f):
     39317,1
     """
 
-    f["s_name"] = re.search(r"(.*).fragment_length_hist.csv", f["fn"]).group(1)
+    f["s_name"] = re.search(r"(.*)\.fragment_length_hist.csv", f["fn"]).group(1)
 
     data_by_rg = defaultdict(dict)
 

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -292,7 +292,7 @@ def parse_mapping_metrics_file(f):
     We are reporting summary metrics in the general stats table, and per-read-group in a separate table.
     """
 
-    f["s_name"] = re.search(r"(.*).mapping_metrics.csv", f["fn"]).group(1)
+    f["s_name"] = re.search(r"(.*)\.mapping_metrics.csv", f["fn"]).group(1)
 
     data_by_readgroup = defaultdict(dict)
     data_by_phenotype = defaultdict(dict)

--- a/multiqc/modules/dragen/ploidy_estimation_metrics.py
+++ b/multiqc/modules/dragen/ploidy_estimation_metrics.py
@@ -52,7 +52,7 @@ def parse_ploidy_estimation_metrics_file(f):
     PLOIDY ESTIMATION,,Ploidy estimation,X0
     """
 
-    f["s_name"] = re.search(r"(.*).ploidy_estimation_metrics.csv", f["fn"]).group(1)
+    f["s_name"] = re.search(r"(.*)\.ploidy_estimation_metrics.csv", f["fn"]).group(1)
 
     data = defaultdict(dict)
 

--- a/multiqc/modules/dragen/vc_metrics.py
+++ b/multiqc/modules/dragen/vc_metrics.py
@@ -330,7 +330,7 @@ def parse_vc_metrics_file(f):
     VARIANT CALLER POSTFILTER,T_SRR7890936_50pc,Percent Autosome Callability,NA
     """
 
-    f["s_name"] = re.search(r"(.*).vc_metrics.csv", f["fn"]).group(1)
+    f["s_name"] = re.search(r"(.*)\.vc_metrics.csv", f["fn"]).group(1)
 
     summary_data = dict()
     prefilter_data = dict()


### PR DESCRIPTION
DRAGEN metric files named `sample.wgs_coverage_metrics.csv` would have sample `"sample.wgs"` and phenotype `""` due to incorrect anchoring of a period.

```python
>>> re.search(r"(.*).(\S*)_coverage_metrics_?(\S*)?.csv", "Exp91-Rep1.wgs_coverage_metrics.csv").groups()
('Exp91-Rep1.wg', '', '')
>>> re.search(r"(.*)\.(\S*)_coverage_metrics_?(\S*)?.csv", "Exp91-Rep1.wgs_coverage_metrics.csv").groups()
('Exp91-Rep1', 'wgs', '')
```