### PR TITLE
Clarify length field in general statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Fixed logger bugs when calling `multiqc.run` multiple times by removing logging 
   - Fixed bug in sample name regular expression ([#1537](https://github.com/ewels/MultiQC/pull/1537))
 - **RSeQC**
   - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
+- **FastQC**
+  - Clarify general statistics table header for length
+- **QUAST**
+  - Clarify general statistics table header for length
 
 ## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
 

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -272,8 +272,8 @@ class MultiqcModule(BaseMultiqcModule):
             "format": "{:,.0f}",
         }
         headers["avg_sequence_length"] = {
-            "title": "Length",
-            "description": "Average Sequence Length (bp)",
+            "title": "Read Length",
+            "description": "Average Read Length (bp)",
             "min": 0,
             "suffix": " bp",
             "scale": "RdYlGn",

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -138,8 +138,8 @@ class MultiqcModule(BaseMultiqcModule):
             "modify": lambda x: x * self.contig_length_multiplier,
         }
         headers["Total length"] = {
-            "title": "Length ({})".format(self.total_length_suffix),
-            "description": "The total number of bases in the assembly (mega base pairs).",
+            "title": "Assembly Length ({})".format(self.total_length_suffix),
+            "description": "The total number of bases in the assembly ({}).".format(self.total_length_suffix),
             "min": 0,
             "suffix": self.total_length_suffix,
             "scale": "YlGn",


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

When both FastQC and QUAST reports are included in MultiQC, both tools include a field with the header `Length` in the general statistics table. On first glance, this is very confusing for users. Here we just clarify which length they're presenting. Also fixed a bug where QUAST size suffixes can change.