### PR TITLE
catch zerodivisionerror

### DIFF
--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -230,7 +230,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.fastp_data[s_name]["adapter_cutting_adapter_trimmed_reads"]
                 / self.fastp_data[s_name]["before_filtering_total_reads"]
             ) * 100.0
-        except (KeyError):
+        except (KeyError): #, ZeroDivisionError):
             log.debug("Could not calculate 'pct_adapter': {}".format(f["fn"]))
 
         # Duplication rate plot data

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -230,7 +230,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.fastp_data[s_name]["adapter_cutting_adapter_trimmed_reads"]
                 / self.fastp_data[s_name]["before_filtering_total_reads"]
             ) * 100.0
-        except (KeyError): #, ZeroDivisionError):
+        except (KeyError, ZeroDivisionError):
             log.debug("Could not calculate 'pct_adapter': {}".format(f["fn"]))
 
         # Duplication rate plot data

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -230,7 +230,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.fastp_data[s_name]["adapter_cutting_adapter_trimmed_reads"]
                 / self.fastp_data[s_name]["before_filtering_total_reads"]
             ) * 100.0
-        except (KeyError): #, ZeroDivisionError):
+        except (KeyError):
             log.debug("Could not calculate 'pct_adapter': {}".format(f["fn"]))
 
         # Duplication rate plot data

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -230,7 +230,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.fastp_data[s_name]["adapter_cutting_adapter_trimmed_reads"]
                 / self.fastp_data[s_name]["before_filtering_total_reads"]
             ) * 100.0
-        except KeyError:
+        except (KeyError, ZeroDivisionError):
             log.debug("Could not calculate 'pct_adapter': {}".format(f["fn"]))
 
         # Duplication rate plot data

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -230,7 +230,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.fastp_data[s_name]["adapter_cutting_adapter_trimmed_reads"]
                 / self.fastp_data[s_name]["before_filtering_total_reads"]
             ) * 100.0
-        except (KeyError, ZeroDivisionError):
+        except (KeyError): #, ZeroDivisionError):
             log.debug("Could not calculate 'pct_adapter': {}".format(f["fn"]))
 
         # Duplication rate plot data


### PR DESCRIPTION
I had the experience of encountering a ZeroDivisionError in the fastp module when a number of reads was zero. There was already a try: except around the block, so I just updated it to catch the ZeroDivisionError as well. I'd be grateful if you would consider this change!

Thank you for making this tool available. 

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [X] This comment contains a description of changes (with reason)
