### PR TITLE
mosdepth fixes for issues #1566, #1568, and a bug on calculating per-contig avg coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 - **RSeQC**
   - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
   - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/ewels/MultiQC/issues/1582))
+- **Mosdepth**
+  - Added mean coverage, as requested by [#1566](https://github.com/ewels/MultiQC/issues/1566), and fixed a bug when reporting per contig coverage
 
 ## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@
   - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
   - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/ewels/MultiQC/issues/1582))
 - **Mosdepth**
-  - Added mean coverage, as requested by [#1566](https://github.com/ewels/MultiQC/issues/1566), and fixed a bug when reporting per contig coverage
+  - Added mean coverage, as requested by [#1566](https://github.com/ewels/MultiQC/issues/1566)
+  - Fixed issue [#1568](https://github.com/ewels/MultiQC/issues/1568)
+  - Fixed a bug when reporting per contig coverage
 
 ## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
 

--- a/docs/modules/mosdepth.md
+++ b/docs/modules/mosdepth.md
@@ -23,8 +23,8 @@ The MultiQC module plots coverage distributions from 2 kinds of outputs:
 
 Using "region" if exists, otherwise "global". Plotting 3 figures:
 
-- Distribution of the number of locations in the genome with a given depth of coverage.
-- Absoulute number of locations in the genome with a given depth of coverage.
+- Proportion of bases in the reference genome with, at least, a given depth of coverage (cumulative coverage distribution).
+- Proportion of bases in the reference genome with a given depth of coverage (absolute coverage distribution).
 - Average coverage per contig/chromosome.
 
 Also plotting the percentage of the genome covered at a threshold in the General Stats section.

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -275,7 +275,7 @@ class MultiqcModule(BaseMultiqcModule):
                             # log.debug("Skipping not included contig '{}'".format(contig))
                             continue
 
-                        if cutoff_reads > 0:
+                        if cutoff_reads != "0":
                             avg = perchrom_avg_data[s_name].get(contig, 0) + float(bases_fraction)
                             perchrom_avg_data[s_name][contig] = avg
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -282,14 +282,14 @@ class MultiqcModule(BaseMultiqcModule):
                         avg = perchrom_avg_data[s_name].get(contig, 0) + float(bases_fraction)
                         perchrom_avg_data[s_name][contig] = avg
 
-                # Correct per-contig average
-                for i in perchrom_avg_data:
-                    for j in perchrom_avg_data[i]:
-                        perchrom_avg_data[i][j] -= 1
-
                 if s_name in cumcov_dist_data:
                     self.add_data_source(f, s_name=s_name, section="genome_results")
 
+            # Correct per-contig average
+            for i in perchrom_avg_data:
+                for j in perchrom_avg_data[i]:
+                    perchrom_avg_data[i][j] -= 1
+            log.debug(perchrom_avg_data)
         return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -282,11 +282,12 @@ class MultiqcModule(BaseMultiqcModule):
                 if s_name in cumcov_dist_data:
                     self.add_data_source(f, s_name=s_name, section="genome_results")
 
-            # Correct per-contig average
+            # Correct per-contig average, since mosdepth reports cumulative coverage for at least
+            # a certain value (see https://github.com/brentp/mosdepth#distribution-output).
+            # For that reason, the 0 category (which is always 1) should not be included.
             for i in perchrom_avg_data:
                 for j in perchrom_avg_data[i]:
                     perchrom_avg_data[i][j] -= 1
-            log.debug(perchrom_avg_data)
         return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -217,7 +217,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Parse mean coverage
         for f in self.find_log_files("mosdepth/summary"):
-            s_name = self.clean_s_name(f["fn"], f).replace(".mosdepth", "")
+            s_name = self.clean_s_name(f["fn"], f)
             for line in f["f"].splitlines():
                 chrom, length, bases, mean, min_cov, max_cov = line.split("\t")
                 if chrom.startswith("total"):
@@ -226,7 +226,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Parse coverage distributions
         for scope in ("region", "global"):
             for f in self.find_log_files("mosdepth/" + scope + "_dist"):
-                s_name = self.clean_s_name(f["fn"], f).replace(".mosdepth." + scope + ".dist", "")
+                s_name = self.clean_s_name(f["fn"], f)
                 if s_name in cumcov_dist_data:  # both region and global might exist, prioritizing region
                     continue
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -283,7 +283,7 @@ class MultiqcModule(BaseMultiqcModule):
                 if s_name in cumcov_dist_data:
                     self.add_data_source(f, s_name=s_name, section="genome_results")
 
-        return mean_cov, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
+        return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
 
     def genstats_cov_thresholds(self, cumcov_dist_data, threshs, hidden_threshs):

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -285,9 +285,10 @@ class MultiqcModule(BaseMultiqcModule):
             # Correct per-contig average, since mosdepth reports cumulative coverage for at least
             # a certain value (see https://github.com/brentp/mosdepth#distribution-output).
             # For that reason, the 0 category (which is always 1) should not be included.
-            for i in perchrom_avg_data:
-                for j in perchrom_avg_data[i]:
-                    perchrom_avg_data[i][j] -= 1
+            if scope == "region":
+                for i in perchrom_avg_data:
+                    for j in perchrom_avg_data[i]:
+                        perchrom_avg_data[i][j] -= 1
         return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -85,10 +85,10 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Filter out any samples from --ignore-samples
         if genstats:
-            genstats = self.ignore_samples(genstats)
-        cumcov_dist_data = self.ignore_samples(cumcov_dist_data)
-        cov_dist_data = self.ignore_samples(cov_dist_data)
-        perchrom_avg_data = self.ignore_samples(perchrom_avg_data)
+            genstats = defaultdict(OrderedDict, self.ignore_samples(genstats))
+        cumcov_dist_data = defaultdict(OrderedDict, self.ignore_samples(cumcov_dist_data))
+        cov_dist_data = defaultdict(OrderedDict, self.ignore_samples(cov_dist_data))
+        perchrom_avg_data = defaultdict(OrderedDict, self.ignore_samples(perchrom_avg_data))
 
         # No samples found
         num_samples = max(len(genstats), len(cumcov_dist_data), len(cov_dist_data), len(perchrom_avg_data))

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -96,7 +96,6 @@ class MultiqcModule(BaseMultiqcModule):
             raise UserWarning
         log.info(f"Found {num_samples} reports")
 
-
         if cumcov_dist_data:
             # Write data to file
             self.write_data_file(cumcov_dist_data, "mosdepth_cumcov_dist")
@@ -186,7 +185,6 @@ class MultiqcModule(BaseMultiqcModule):
             self.genstats_cov_thresholds(genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs)
             self.genstats_mediancov(genstats, genstats_headers, cumcov_dist_data)
 
-
         # Add mean coverage to General Stats
         genstats_headers["mean_coverage"] = {
             "title": "Mean Cov.",
@@ -196,7 +194,6 @@ class MultiqcModule(BaseMultiqcModule):
             "scale": "BuPu",
         }
         self.general_stats_addcols(genstats, genstats_headers)
-
 
     def parse_cov_dist(self):
         genstats = defaultdict(OrderedDict)  # mean coverage
@@ -292,7 +289,6 @@ class MultiqcModule(BaseMultiqcModule):
             log.debug(perchrom_avg_data)
         return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
-
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):
         for s_name, d in cumcov_dist_data.items():
             dist_subset = {t: data for t, data in d.items() if t in threshs}
@@ -312,7 +308,6 @@ class MultiqcModule(BaseMultiqcModule):
                 "scale": "RdYlGn",
                 "hidden": t in hidden_threshs,
             }
-
 
     def genstats_mediancov(self, genstats, genstats_headers, cumcov_dist_data):
         for s_name, d in cumcov_dist_data.items():

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -248,6 +248,7 @@ fn_clean_exts:
   - "ccs"
   - "_NanoStats"
   - ".cutadapt"
+  - ".mosdepth"
 
 # These are removed after the above, only if sample names
 # start or end with this string. Again, removed in order.

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -414,6 +414,8 @@ mirtrace/mirnacomplexity:
   fn: "mirtrace-stats-mirna-complexity.tsv"
 mtnucratio:
   fn: "*mtnuc.json"
+mosdepth/summary:
+  fn: "*.mosdepth.summary.txt"
 mosdepth/global_dist:
   fn: "*.mosdepth.global.dist.txt"
 mosdepth/region_dist:


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

Changes:
- Added mean coverage ([#1566](https://github.com/ewels/MultiQC/issues/1566))
- Fixed issue [#1568](https://github.com/ewels/MultiQC/issues/1568)                                                                                                                                               
- Fixed a bug when reporting per contig coverage
- General code tweaks (e.g. unification of gen stats table, text clarifications)

@brentp this module calculates per-contig average coverage by summing over the cumulative distribution of `.mosdepth.region.dist.txt` (or global). However, this value does not always match the one in `.mosdepth.summary.txt`. Is this expected?
