### PR TITLE
Allow for custom css sheet overrides for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Fixed logger bugs when calling `multiqc.run` multiple times by removing logging 
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
   - See the documenation for details: [Using log filenames as sample names](https://multiqc.info/docs/#using-log-filenames-as-sample-names) and [Custom sample names](https://multiqc.info/docs/#custom-sample-names).
-- Added support for `--custom-css-files` / config `custom_css_files` option to include custom CSS in the final report
+  - Added support for `--custom-css-files` / config `custom_css_files` option to include custom CSS in the final report
 
 ### MultiQC updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Fixed logger bugs when calling `multiqc.run` multiple times by removing logging 
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
   - See the documenation for details: [Using log filenames as sample names](https://multiqc.info/docs/#using-log-filenames-as-sample-names) and [Custom sample names](https://multiqc.info/docs/#custom-sample-names).
-  - Added support for `--custom-css-files` / config `custom_css_files` option to include custom CSS in the final report
+  - Added support for `--custom-css-files` / `config.custom_css_files` option to include custom CSS in the final report
 
 ### MultiQC updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Fixed logger bugs when calling `multiqc.run` multiple times by removing logging 
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
   - See the documenation for details: [Using log filenames as sample names](https://multiqc.info/docs/#using-log-filenames-as-sample-names) and [Custom sample names](https://multiqc.info/docs/#custom-sample-names).
+- Added support for `--custom-css-files` / config `custom_css_files` option to include custom CSS in the final report
 
 ### MultiQC updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Fixed logger bugs when calling `multiqc.run` multiple times by removing logging 
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
   - See the documenation for details: [Using log filenames as sample names](https://multiqc.info/docs/#using-log-filenames-as-sample-names) and [Custom sample names](https://multiqc.info/docs/#custom-sample-names).
-  - Added support for `--custom-css-files` / `config.custom_css_files` option to include custom CSS in the final report
+  - Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report
 
 ### MultiQC updates
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -520,5 +520,5 @@ custom_css_files:
   - myfile.css
 ```
 
-Or pass `--custom-css-files` (can be specified multiple times) and MultiQC will include
+Or pass `--custom-css-file` (can be specified multiple times) and MultiQC will include
 them in the final report HTML.

--- a/docs/config.md
+++ b/docs/config.md
@@ -521,4 +521,4 @@ custom_css_files:
 ```
 
 Or pass `--custom-css-files` (can be specified multiple times) and MultiQC will include
-them in the final report html.
+them in the final report HTML.

--- a/docs/config.md
+++ b/docs/config.md
@@ -514,6 +514,7 @@ speed things up though.
 
 MultiQC generates an html report. You can include custom CSS in your final report.
 Simply add css files to the `custom_css_files` config option:
+
 ```yaml
 custom_css_files:
   - myfile.css

--- a/docs/config.md
+++ b/docs/config.md
@@ -514,7 +514,7 @@ speed things up though.
 
 MultiQC generates an html report. You can include custom CSS in your final report.
 Simply add css files to the `custom_css_files` config option:
-```
+```yaml
 custom_css_files:
   - myfile.css
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -509,3 +509,15 @@ This approach is **not recommended if you have a very large number of samples**,
 produce a huge report file with all of the embedded plot data and crash your browser when opening it.
 If you are running MultiQC for the `multiqc_data` folder and never intend to look at the report, it
 speed things up though.
+
+## Custom CSS files
+
+MultiQC generates an html report. You can include custom CSS in your final report.
+Simply add css files to the `custom_css_files` config option:
+```
+custom_css_files:
+  - myfile.css
+```
+
+Or pass `--custom-css-files` (multiple params accepted) and multiqc will include
+them in the final report html.

--- a/docs/config.md
+++ b/docs/config.md
@@ -520,5 +520,5 @@ custom_css_files:
   - myfile.css
 ```
 
-Or pass `--custom-css-files` (multiple params accepted) and multiqc will include
+Or pass `--custom-css-files` (can be specified multiple times) and MultiQC will include
 them in the final report html.

--- a/docs/config.md
+++ b/docs/config.md
@@ -512,7 +512,7 @@ speed things up though.
 
 ## Custom CSS files
 
-MultiQC generates an html report. You can include custom CSS in your final report.
+MultiQC generates HTML reports. You can include custom CSS in your final report if you wish.
 Simply add css files to the `custom_css_files` config option:
 
 ```yaml

--- a/docs/config.md
+++ b/docs/config.md
@@ -513,7 +513,7 @@ speed things up though.
 ## Custom CSS files
 
 MultiQC generates HTML reports. You can include custom CSS in your final report if you wish.
-Simply add css files to the `custom_css_files` config option:
+Simply add CSS files to the `custom_css_files` config option:
 
 ```yaml
 custom_css_files:

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -182,7 +182,7 @@ logger = config.logger
     "custom_css_files",
     type=click.Path(exists=True, readable=True),
     multiple=True,
-    help="Custom CSS files to add to the final report",
+    help="Custom CSS file to add to the final report",
 )
 @click.version_option(config.version, prog_name="multiqc")
 def run_cli(

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -329,7 +329,7 @@ def run(
     quiet=False,
     profile_runtime=False,
     no_ansi=False,
-    custom_css_files=None,
+    custom_css_files=(),
     kwargs={},
 ):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -177,8 +177,7 @@ logger = config.logger
 @click.option("--profile-runtime", is_flag=True, help="Add analysis of how long MultiQC takes to run to the report")
 @click.option("--no-ansi", is_flag=True, help="Disable coloured log output")
 @click.option(
-    "--custom-css-files",
-    "--custom-css-files",
+    "--custom-css-file",
     "custom_css_files",
     type=click.Path(exists=True, readable=True),
     multiple=True,
@@ -449,7 +448,7 @@ def run(
         config.exclude_modules = exclude
     if profile_runtime:
         config.profile_runtime = True
-    if custom_css_files is not None and len(custom_css_files) > 0:
+    if custom_css_files:
         config.custom_css_files.extend(custom_css_files)
     config.kwargs = kwargs  # Plugin command line options
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -176,6 +176,14 @@ logger = config.logger
 @click.option("-q", "--quiet", is_flag=True, help="Only show log warnings")
 @click.option("--profile-runtime", is_flag=True, help="Add analysis of how long MultiQC takes to run to the report")
 @click.option("--no-ansi", is_flag=True, help="Disable coloured log output")
+@click.option(
+    "--custom-css-files",
+    "--custom-css-files",
+    "custom_css_files",
+    type=click.Path(exists=True, readable=True),
+    multiple=True,
+    help="Custom CSS files to add to the final report",
+)
 @click.version_option(config.version, prog_name="multiqc")
 def run_cli(
     analysis_dir,
@@ -215,6 +223,7 @@ def run_cli(
     quiet,
     profile_runtime,
     no_ansi,
+    custom_css_files,
     **kwargs,
 ):
     # Main MultiQC run command for use with the click command line, complete with all click function decorators.
@@ -274,6 +283,7 @@ def run_cli(
         quiet=quiet,
         profile_runtime=profile_runtime,
         no_ansi=no_ansi,
+        custom_css_files=custom_css_files,
         kwargs=kwargs,
     )
 
@@ -320,6 +330,7 @@ def run(
     quiet=False,
     profile_runtime=False,
     no_ansi=False,
+    custom_css_files=None,
     kwargs={},
 ):
     """MultiQC aggregates results from bioinformatics analyses across many samples into a single report.
@@ -438,6 +449,8 @@ def run(
         config.exclude_modules = exclude
     if profile_runtime:
         config.profile_runtime = True
+    if custom_css_files is not None and len(custom_css_files) > 0:
+        config.custom_css_files.extend(custom_css_files)
     config.kwargs = kwargs  # Plugin command line options
 
     # Clean up analysis_dir if a string (interactive environment only)

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -32,6 +32,9 @@ it prints the contents of these files into the report.
     {{ include_file('assets/css/default_multiqc.css') }}
     {{ include_file('assets/css/jquery.toast.css') }}
 </style>
+{% for css_href in config.custom_css_files %}
+<style type="text/css">{{ include_file(css_href, None) }}</style>
+{% endfor %}
 {% set included_css = [] %}
 {%- for m in report.modules_output %}{% if m.css and m.css|length > 0 -%}{% for css_href in m.css.values() %}
 {% if css_href not in included_css -%}

--- a/multiqc/templates/simple/includes.html
+++ b/multiqc/templates/simple/includes.html
@@ -10,6 +10,9 @@ Also Glyphicons and the favicon images.
 <!-- Include CSS -->
 <style type="text/css">{{ include_file('assets/css/bootstrap.min.css') }}</style>
 <style type="text/css">{{ include_file('assets/css/default_multiqc.css') }}</style>
+{% for css_href in config.custom_css_files %}
+<style type="text/css">{{ include_file(css_href, None) }}</style>
+{% endfor %}
 {%- for m in report.modules_output %}{% if m.css and m.css|length > 0 -%}{% for css_href in m.css.values() %}
 <style type="text/css">{{ include_file(css_href, None) }}</style>
 {%- endfor %}{% endif %}{% endfor %}

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -156,7 +156,7 @@ def mqc_cl_config(cl_config):
 
 def mqc_add_config(conf, conf_path=None):
     """Add to the global config with given MultiQC config dict"""
-    global fn_clean_exts, fn_clean_trim
+    global custom_css_files, fn_clean_exts, fn_clean_trim
     for c, v in conf.items():
         if c == "sp":
             # Merge filename patterns instead of replacing
@@ -182,6 +182,19 @@ def mqc_add_config(conf, conf_path=None):
                 continue
             logger.debug("New config '{}': {}".format(c, fpath))
             update({c: fpath})
+        elif c == "custom_css_files":
+            for fpath in v:
+                if os.path.exists(fpath):
+                    fpath = os.path.abspath(fpath)
+                elif conf_path is not None and os.path.exists(os.path.join(os.path.dirname(conf_path), fpath)):
+                    fpath = os.path.abspath(os.path.join(os.path.dirname(conf_path), fpath))
+                else:
+                    logger.error("CSS path '{}' path not found, skipping ({})".format(c, fpath))
+                    continue
+                logger.debug("Adding css file '{}': {}".format(c, fpath))
+                if not custom_css_files:
+                    custom_css_files = []
+                custom_css_files.append(fpath)
         else:
             logger.debug("New config '{}': {}".format(c, v))
             update({c: v})

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -21,6 +21,7 @@ config_file: null
 custom_logo: null
 custom_logo_url: null
 custom_logo_title: null
+custom_css_files: []
 simple_output: false
 template: "default"
 profile_runtime: false

--- a/test/config_example.yaml
+++ b/test/config_example.yaml
@@ -98,6 +98,9 @@ custom_logo_title: null # 'Our Institute Name'
 subtitle: null # Grey text below title
 intro_text: null # Set to False to remove, or your own text
 
+# Specify custom css to add to the report
+custom_css_files: []
+
 # Add generic information to the top of reports
 report_header_info:
   - Example Config:: "This is arbitrary"


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

Adds the ability to specify CSS overrides. I know it's possible to add css to custom modules, but we'd like to do it for the simple/default reports, without specifying entirely new modules.

For example, I'd like to add css rules for the [css `print` media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media). I will merge these with upstream. But for the short term, it's useful to just specify a bunch of overrides, and then get them merged. This will allow for e.g. beautiful print exports of multiqc reports (currently e.g. background colours don't show up). Let me know what you think!

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

I tried this out with a few configurations:

```console
$ cat sample.css 
.side-nav {
  width: 800px;
}
$ cat other_sample.css 
.side-nav h1 img {
  height: 200px;
}
$ cat multiqc_config.yaml 
custom_css_files:
  - sample.css
  - other_sample.css
```
![Screenshot 2021-11-02 at 03-45-51 MultiQC Report](https://user-images.githubusercontent.com/6404517/139783882-ee39dea1-8101-4bc9-967e-06206970eaf8.png)

You can see the logo and sidebar are huge here.

Then I built/ran with cli flags:
```console
$ docker run -it --rm -v $(pwd):/work -w /work jchorl/multiqc --custom-css-files sample.css --custom-css-files other_sample.css .

  /// MultiQC 🔍 | v1.12.dev0

|           multiqc | Search path : /work
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 3/3  
|    custom_content | plasmid_table: Found 2 samples (table)
|           multiqc | Compressing plot data
|           multiqc | Report      : multiqc_report.html
|           multiqc | Data        : multiqc_data
|           multiqc | MultiQC complete
 j@bike  ~/third-party/MultiQC/testdata   jchorl/customcss ±  ls multiqc_config.yaml
ls: cannot access 'multiqc_config.yaml': No such file or directory
```
![Screenshot 2021-11-02 at 03-48-03 MultiQC Report](https://user-images.githubusercontent.com/6404517/139784030-1d985831-f8ab-4f0b-9cb3-221f0e5c5af2.png)


Finally, I removed the flags and config file:
![Screenshot 2021-11-02 at 03-49-47 MultiQC Report](https://user-images.githubusercontent.com/6404517/139784098-e36c450e-82da-4d41-9816-9b6ae9116c32.png)


We're back to normal looking reports.