### PR TITLE
use errno instead of os.errno

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1000,7 +1000,7 @@ def run(
             else:
                 logger.info("PDF Report  : {}".format(pdf_fn_name))
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
+            if e.errno == errno.ENOENT:
                 logger.error("Error creating PDF - pandoc not found. Is it installed? http://pandoc.org/")
             else:
                 logger.error(


### PR DESCRIPTION
Most `os.errno` calls were migrated to `errno`. Looks like this one was missed. It errored on me, just migrating it too.

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated