### PR TITLE
upsize label sizing in bar/line charts

### DIFF
--- a/docs/plots.md
+++ b/docs/plots.md
@@ -109,6 +109,7 @@ config = {
     'title': None,                          # Plot title - should be in format "Module Name: Plot Title"
     'xlab': None,                           # X axis label
     'ylab': None,                           # Y axis label
+    'labelSize': None,                      # Axis label size - should be an integer (default: 8)
     'ymax': None,                           # Max y limit
     'ymin': None,                           # Min y limit
     'yCeiling': None,                       # Maximum value for automatic axis limit (good for percentages)
@@ -236,6 +237,7 @@ config = {
     'title': None,               # Plot title - should be in format "Module Name: Plot Title"
     'xlab': None,                # X axis label
     'ylab': None,                # Y axis label
+    'labelSize': None,           # Axis label size - should be an integer (default: 8)
     'xCeiling': None,            # Maximum value for automatic axis limit (good for percentages)
     'xFloor': None,              # Minimum value for automatic axis limit
     'xMinRange': None,           # Minimum range for axis

--- a/docs/plots.md
+++ b/docs/plots.md
@@ -109,7 +109,7 @@ config = {
     'title': None,                          # Plot title - should be in format "Module Name: Plot Title"
     'xlab': None,                           # X axis label
     'ylab': None,                           # Y axis label
-    'labelSize': None,                      # Axis label size - should be an integer (default: 8)
+    'labelSize': 8,                         # Axis label font size
     'ymax': None,                           # Max y limit
     'ymin': None,                           # Min y limit
     'yCeiling': None,                       # Maximum value for automatic axis limit (good for percentages)
@@ -237,7 +237,7 @@ config = {
     'title': None,               # Plot title - should be in format "Module Name: Plot Title"
     'xlab': None,                # X axis label
     'ylab': None,                # Y axis label
-    'labelSize': None,           # Axis label size - should be an integer (default: 8)
+    'labelSize': 8,              # Axis label font size
     'xCeiling': None,            # Maximum value for automatic axis limit (good for percentages)
     'xFloor': None,              # Minimum value for automatic axis limit
     'xMinRange': None,           # Minimum range for axis

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -474,7 +474,7 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
                 prev_values = values
 
             # Tidy up axes
-            axes.tick_params(labelsize=8, direction="out", left=False, right=False, top=False, bottom=False)
+            axes.tick_params(labelsize=12, direction="out", left=False, right=False, top=False, bottom=False)
             axes.set_xlabel(pconfig.get("ylab", ""))  # I know, I should fix the fact that the config is switched
             axes.set_ylabel(pconfig.get("xlab", ""))
             axes.set_yticks(y_ind)  # Specify where to put the labels
@@ -516,7 +516,7 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
                 bbox_to_anchor=(0, bottom_gap, 1, 0.102),
                 ncol=5,
                 mode="expand",
-                fontsize=8,
+                fontsize=12,
                 frameon=False,
             )
 

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -474,7 +474,7 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
                 prev_values = values
 
             # Tidy up axes
-            axes.tick_params(labelsize=12, direction="out", left=False, right=False, top=False, bottom=False)
+            axes.tick_params(labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False)
             axes.set_xlabel(pconfig.get("ylab", ""))  # I know, I should fix the fact that the config is switched
             axes.set_ylabel(pconfig.get("xlab", ""))
             axes.set_yticks(y_ind)  # Specify where to put the labels
@@ -516,7 +516,7 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
                 bbox_to_anchor=(0, bottom_gap, 1, 0.102),
                 ncol=5,
                 mode="expand",
-                fontsize=12,
+                fontsize=pconfig.get("labelSize", 8),
                 frameon=False,
             )
 

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -474,7 +474,9 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
                 prev_values = values
 
             # Tidy up axes
-            axes.tick_params(labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False)
+            axes.tick_params(
+                labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False
+            )
             axes.set_xlabel(pconfig.get("ylab", ""))  # I know, I should fix the fact that the config is switched
             axes.set_ylabel(pconfig.get("xlab", ""))
             axes.set_yticks(y_ind)  # Specify where to put the labels

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -444,7 +444,7 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                 )
 
         # Tidy up axes
-        axes.tick_params(labelsize=12, direction="out", left=False, right=False, top=False, bottom=False)
+        axes.tick_params(labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False)
         axes.set_xlabel(pconfig.get("xlab", ""))
         axes.set_ylabel(pconfig.get("ylab", ""))
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -444,7 +444,7 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                 )
 
         # Tidy up axes
-        axes.tick_params(labelsize=8, direction="out", left=False, right=False, top=False, bottom=False)
+        axes.tick_params(labelsize=12, direction="out", left=False, right=False, top=False, bottom=False)
         axes.set_xlabel(pconfig.get("xlab", ""))
         axes.set_ylabel(pconfig.get("ylab", ""))
 
@@ -545,7 +545,7 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                 bbox_to_anchor=(0, -0.22, 1, 0.102),
                 ncol=5,
                 mode="expand",
-                fontsize=8,
+                fontsize=12,
                 frameon=False,
             )
             plt.tight_layout(rect=[0, 0.08, 1, 0.92])

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -444,7 +444,9 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                 )
 
         # Tidy up axes
-        axes.tick_params(labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False)
+        axes.tick_params(
+            labelsize=pconfig.get("labelSize", 8), direction="out", left=False, right=False, top=False, bottom=False
+        )
         axes.set_xlabel(pconfig.get("xlab", ""))
         axes.set_ylabel(pconfig.get("ylab", ""))
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -545,7 +545,7 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                 bbox_to_anchor=(0, -0.22, 1, 0.102),
                 ncol=5,
                 mode="expand",
-                fontsize=12,
+                fontsize=pconfig.get("labelSize", 8),
                 frameon=False,
             )
             plt.tight_layout(rect=[0, 0.08, 1, 0.92])


### PR DESCRIPTION
Just upsizes some label sizing in the bar/line charts. I understand there is no optimal size for everyone. However I find 8 point font _very_ small, and can't imagine many folks would complain with slightly bigger font sizing. Thoughts?

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated