### PR TITLE
class/styling improvements

### DIFF
--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -237,7 +237,7 @@ def make_table(dt):
 
                 # Categorical backgorund colours supplied
                 if val in header.get("bgcols", {}).keys():
-                    col = 'style="background-color:{};"'.format(header["bgcols"][val])
+                    col = 'style="background-color:{} !important;"'.format(header["bgcols"][val])
                     if s_name not in t_rows:
                         t_rows[s_name] = dict()
                     t_rows[s_name][rid] = '<td class="{rid} {h}" {c}>{v}</td>'.format(
@@ -247,7 +247,7 @@ def make_table(dt):
                 # Build table cell background colour bar
                 elif header["scale"]:
                     if c_scale is not None:
-                        col = " background-color:{};".format(c_scale.get_colour(val))
+                        col = " background-color:{} !important;".format(c_scale.get_colour(val))
                     else:
                         col = ""
                     bar_html = '<span class="bar" style="width:{}%;{}"></span>'.format(percentage, col)

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -10,41 +10,46 @@ the output from each module and print it in sections.
 {% for m in report.modules_output %}
   {% if m.sections | length > 0 %}
   <div id="mqc-module-section-{{ m.anchor }}" class="mqc-module-section">
-    <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
-    {{ m.intro if m.intro }}
-    {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
-    {% for s in m.sections %}
-      {% if s['print_section'] %}
-        {% if (s['name'] is none or s['name'] | length == 0) and s['helptext'] is not none and s['helptext'] | length > 0 %}
-          <button class="btn btn-default btn-sm pull-right" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">
-            <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-            Help
-          </button>
+    <div class="mqc-module-section-first">
+      <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
+      {{ m.intro if m.intro }}
+      {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
+      {% for s in m.sections %}
+        {% if s['print_section'] %}
+          {% if (s['name'] is none or s['name'] | length == 0) and s['helptext'] is not none and s['helptext'] | length > 0 %}
+            <button class="btn btn-default btn-sm pull-right btn-help" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">
+              <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+              Help
+            </button>
+          {% endif %}
+          <div class="mqc-section mqc-section-{{ m.anchor }}">
+            {% if s['name'] is not none and s['name'] | length > 0 %}
+              <h3 id="{{ s['anchor'] }}">
+                  {{ s['name'] }}
+                  {% if s['helptext'] is not none and s['helptext'] | length > 0 %}
+                    <button class="btn btn-default btn-sm pull-right btn-help" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">
+                      <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
+                      Help
+                    </button>
+                  {% endif %}
+              </h3>
+            {% endif %}
+            {% if s['description'] is not none and s['description'] | length > 0 %}<div class="mqc-section-description">{{ s['description'] }}</div>{% endif %}
+            {% if s['comment'] is not none and s['comment'] | length > 0 %}<blockquote class="mqc-section-comment">{{ s['comment'] }}</blockquote>{% endif %}
+            {% if s['helptext'] is not none and s['helptext'] | length > 0 %}
+              <div class="collapse mqc-section-helptext " id="{{ s['anchor'] }}_helptext">
+                <div class="well">{{ s['helptext'] }}</div>
+              </div>
+            {% endif %}
+            {% if s['plot'] is not none %}<div class="mqc-section-plot">{{ s['plot'] }}</div>{% endif %}
+            {{ s['content'] if s['content'] }}
+
+            {{ '<hr>' if not loop.last }}
+          </div>
         {% endif %}
-        <div class="mqc-section mqc-section-{{ m.anchor }}">
-          {% if s['name'] is not none and s['name'] | length > 0 %}
-            <h3 id="{{ s['anchor'] }}">
-                {{ s['name'] }}
-                {% if s['helptext'] is not none and s['helptext'] | length > 0 %}
-                  <button class="btn btn-default btn-sm pull-right" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">
-                    <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
-                    Help
-                  </button>
-                {% endif %}
-            </h3>
-          {% endif %}
-          {% if s['description'] is not none and s['description'] | length > 0 %}<div class="mqc-section-description">{{ s['description'] }}</div>{% endif %}
-          {% if s['comment'] is not none and s['comment'] | length > 0 %}<blockquote class="mqc-section-comment">{{ s['comment'] }}</blockquote>{% endif %}
-          {% if s['helptext'] is not none and s['helptext'] | length > 0 %}
-            <div class="collapse mqc-section-helptext " id="{{ s['anchor'] }}_helptext">
-              <div class="well">{{ s['helptext'] }}</div>
-            </div>
-          {% endif %}
-          {% if s['plot'] is not none %}<div class="mqc-section-plot">{{ s['plot'] }}</div>{% endif %}
-          {{ s['content'] if s['content'] }}
-          {{ '<hr>' if not loop.last }}
-        </div>
-      {% endif %}
+    {% if loop.first %}
+    </div> <!-- end mqc-module-section-first -->
+    {% endif %}
   {% endfor %}
   </div>
   {{ '<hr>' if not loop.last }}

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -11,12 +11,12 @@ the output from each module and print it in sections.
   {% if m.sections | length > 0 %}
   <div id="mqc-module-section-{{ m.anchor }}" class="mqc-module-section">
     {% for s in m.sections %}
-    {% if loop.first %}
-    <div class="mqc-module-section-first">
-      <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
-      {{ m.intro if m.intro }}
-      {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
-    {% endif %}
+      {% if loop.first %}
+      <div class="mqc-module-section-first">
+        <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
+        {{ m.intro if m.intro }}
+        {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
+      {% endif %}
         {% if s['print_section'] %}
           {% if (s['name'] is none or s['name'] | length == 0) and s['helptext'] is not none and s['helptext'] | length > 0 %}
             <button class="btn btn-default btn-sm pull-right btn-help" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -10,11 +10,13 @@ the output from each module and print it in sections.
 {% for m in report.modules_output %}
   {% if m.sections | length > 0 %}
   <div id="mqc-module-section-{{ m.anchor }}" class="mqc-module-section">
+    {% for s in m.sections %}
+    {% if loop.first %}
     <div class="mqc-module-section-first">
       <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
       {{ m.intro if m.intro }}
       {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
-      {% for s in m.sections %}
+    {% endif %}
         {% if s['print_section'] %}
           {% if (s['name'] is none or s['name'] | length == 0) and s['helptext'] is not none and s['helptext'] | length > 0 %}
             <button class="btn btn-default btn-sm pull-right btn-help" type="button" data-toggle="collapse" data-target="#{{ s['anchor'] }}_helptext" aria-expanded="false" aria-controls="{{ s['anchor'] }}_helptext">

--- a/multiqc/templates/simple/header.html
+++ b/multiqc/templates/simple/header.html
@@ -11,7 +11,7 @@ No offer to play a YouTube tutorial video and so on.
     {% if config.custom_logo is not none %}
       <div class="pull-right">
       {{ '<a href="'+config.custom_logo_url+'" target="_blank">' if config.custom_logo_url is not none }}
-        <img src="data:image/png;base64,{{ include_file(config.custom_logo, b64=True) }}" title="{{ config.custom_logo_title if config.custom_logo_title is not none }}">
+        <img src="data:image/png;base64,{{ include_file(config.custom_logo, b64=True) }}" title="{{ config.custom_logo_title if config.custom_logo_title is not none }}" class="custom_logo">
       {{ '</a>' if config.custom_logo_url is not none }}
       </div>
     {% endif %}


### PR DESCRIPTION
I'd recommend reviewing without whitespace, because one file was largely indented. GH has that option, add `&w=1` at the end of the URL.

Few minor styling tweaks here:
1. Add `!important` to some background colors. This is critical to get chrome to print those background colors in PDFs. Right now, chrome still won't print those background colors, that's a CSS config that can be made separately.
2. Add a special `mqc-module-section-first` css class to the first mqc section. This is important for print styling - it allows you to utilize the CSS [`break-after`](https://developer.mozilla.org/en-US/docs/Web/CSS/break-after) property to keep the title/first section together. It makes printed pages look substantially better. Again, this doesn't include the CSS, it just enables the customization.
3. Add a `custom_logo` css class to the custom logo. This will allow for customizing size of the logo when printing.

Note that there is a [css media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) for printing, so adding styling later for printing will not impact multiqc styling as-is today.

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated