### PR TITLE
Issue #1558: Clarify documentation for the --ignore option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,14 +28,16 @@ multiqc data/*_fastqc.zip
 multiqc data/sample_1*
 ```
 
-You can also ignore files using the `-x`/`--ignore` flag (can be specified multiple
-times). This takes a string which it matches using glob expansion to filenames,
-directory names and entire paths:
+If the `--ignore-symlinks` flag is set, MultiQC will ignore symlinked directories and files.
+
+Furthermore, you can ignore files or directories using the `-x`/`--ignore` option. In order to exclude multiple files, you may either specify the option multiple times or use the `*` and `?` wildcards in its argument. The option's argument takes a string which it matches using glob expansion to filenames, directory names and entire paths:
 
 ```bash
-multiqc . --ignore *_R2*
-multiqc . --ignore run_two/
-multiqc . --ignore */run_three/*/fastqc/*_R2.zip
+multiqc . --ignore "file"
+multiqc . --ignore "fileA" --ignore "fileB"
+multiqc . --ignore "_R?.zip"
+multiqc . --ignore "run_two/*"
+multiqc . --ignore "*/run_three/*/fastqc/*_R2.zip"
 ```
 
 Some modules get sample names from the contents of the file and not the filename
@@ -43,7 +45,7 @@ Some modules get sample names from the contents of the file and not the filename
 skip samples by name instead:
 
 ```bash
-multiqc . --ignore-samples sample_3*
+multiqc . --ignore-samples "sample_3*"
 ```
 
 These strings are matched using glob logic (`*` and `?` are wildcards).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,12 @@ multiqc data/sample_1*
 
 If the `--ignore-symlinks` flag is set, MultiQC will ignore symlinked directories and files.
 
-Furthermore, you can ignore files or directories using the `-x`/`--ignore` option. In order to exclude multiple files, you may either specify the option multiple times or use the `*` and `?` wildcards in its argument. The option's argument takes a string which it matches using glob expansion to filenames, directory names and entire paths:
+You can also ignore files or directories using the `-x`/`--ignore` option.
+This can be specified multiple times and accepts glob patterns (eg. using the `*` and `?` wildcards).
+
+> Note that glob patterns should be enclosed in quotes to prevent them being expanded by bash
+
+The argument can match filenames, directory names and entire paths. For example:
 
 ```bash
 multiqc . --ignore "file"


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

This pull request updates `docs/usage.md` to clarify the section on the `--ignore` option. The documentation now also briefly mentions the `--ignore-symlinks` flag, which was introduced in [MultiQC v1.6](https://github.com/ewels/MultiQC/releases/tag/v1.6), but not yet covered. 

- [ ] `CHANGELOG.md` has been updated

Not applicable
