### PR TITLE
customize created date/dir with config in simple

### DIFF
--- a/multiqc/templates/simple/header.html
+++ b/multiqc/templates/simple/header.html
@@ -47,14 +47,24 @@ No offer to play a YouTube tutorial video and so on.
 </div>
 {% endif %}
 
+{% if config.show_analysis_time or config.show_analysis_paths %}
 <div id="analysis_dirs_wrapper">
-  <p>Report generated on {{ config.creation_date }} based on data in:<br>
-  {% if config.analysis_dir | length == 1 %}<code class="mqc_analysis_path">{{ config.analysis_dir[0] }}</code>
-  {% else %}
-  <ul>
-    {% for d in config.analysis_dir %}
-    <li><code class="mqc_analysis_path">{{ d }}</code></li>
-    {%  endfor %}
-  </ul>
+  <p>Report
+  {% if config.show_analysis_time %}
+    generated on {{ config.creation_date }}
+  {% endif %}
+  {% if config.show_analysis_paths %}
+    based on data in:
+    {% if config.analysis_dir | length == 1 %}
+      <code class="mqc_analysis_path">{{ config.analysis_dir[0] }}</code></p>
+    {% else %}
+      </p>
+      <ul>
+        {% for d in config.analysis_dir %}
+        <li><code class="mqc_analysis_path">{{ d }}</code></li>
+        {%  endfor %}
+      </ul>
+    {% endif %}
   {% endif %}
 </div>
+{% endif %}


### PR DESCRIPTION
Literally copied out of https://github.com/ewels/MultiQC/blob/f184b033385b5810adba102bdd63346f36adb67b/multiqc/templates/default/header.html into the simple template. Seems to work:
![report](https://user-images.githubusercontent.com/6404517/141724071-cd126999-a3d1-4475-a1ee-e315b0d05bb4.png)


- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

I dont _think_ this could be a breaking change (also, ran it locally), but give it a second set of eyes :)