### PR TITLE
fix string and array comp

### DIFF
--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -57,7 +57,7 @@ class BaseMultiqcModule(object):
         if self.info is None:
             self.info = ""
         # Always finish with a ".", as we may add a DOI after the intro.
-        if len(self.info) > 0 and self.info[:-1] != ".":
+        if len(self.info) > 0 and self.info[-1] != ".":
             self.info += "."
         if self.extra is None:
             self.extra = ""


### PR DESCRIPTION
Subtle bug here. The `if` is always `True`, which had weird subtle bugs downstream. Somehow this caused descriptions to be duplicated, I have no idea why.

```
$ python3
>>> a = "."
>>> a[:-1] == "."
False
```

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated
