### PR TITLE
Make NanoStat module recognize more report flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/ewels/MultiQC/issues/1586))
 - **Lima**
   - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/ewels/MultiQC/pull/1483))
+- **NanoStat**
+  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/ewels/MultiQC/issues/1547))
 - **Qualimap**
   - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/ewels/MultiQC/issues/1492))
 - **QUAST**

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -238,10 +238,15 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Add the report section
         description = ""
+        if stat_type == "fasta":
+            description = "NanoStat statistics from FASTA files."
+        if stat_type == "fastq":
+            description = "NanoStat statistics from FastQ files."
         if stat_type == "aligned":
-            description = "NanoStat statistics from FastQ, FASTA or BAM files."
+            description = "NanoStat statistics from BAM files."
         if stat_type == "seq summary":
             description = "NanoStat statistics from albacore or guppy summary files."
+
         self.add_section(
             name="{} stats".format(stat_type.replace("_", " ").capitalize()),
             anchor="nanostat_{}_stats".format(stat_type.replace(" ", "_")),

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -80,7 +80,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.nanostat_stats_table("seq summary")
         if self.has_fastq:
             self.nanostat_stats_table("fastq")
-        if self.has_fastq:
+        if self.has_fasta:
             self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -283,6 +283,9 @@ class MultiqcModule(BaseMultiqcModule):
         }
         for s_name, data_dict in self.nanostat_data.items():
             reads_total, stat_type = _get_total_reads(data_dict)
+            if stat_type == "fasta":
+                log.debug("Sample '{s_name}' has no quality metrics - excluded from quality plot")
+                continue
             if s_name in bar_data and stat_type == "aligned":
                 log.debug("Sample '{s_name}' duplicated in the quality plot - ignoring aligned data")
                 continue

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -40,7 +40,7 @@ class MultiqcModule(BaseMultiqcModule):
         "&gt;Q12",
         "&gt;Q15",
     ]
-    _stat_types = ("aligned", "seq summary", "unrecognized")
+    _stat_types = ("aligned", "seq summary", "fastq", "fasta", "unrecognized")
 
     def __init__(self):
 
@@ -57,6 +57,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.nanostat_data = dict()
         self.has_aligned = False
         self.has_seq_summary = False
+        self.has_quality = False
         for f in self.find_log_files("nanostat", filehandles=True):
             self.parse_nanostat_log(f)
 
@@ -108,9 +109,16 @@ class MultiqcModule(BaseMultiqcModule):
         if "Total bases aligned" in nano_stats:
             stat_type = "aligned"
             self.has_aligned = True
+            self.has_quality = True
         elif "Active channels" in nano_stats:
             stat_type = "seq summary"
             self.has_seq_summary = True
+            self.has_quality = True
+        elif "Mean read quality" in nano_stats:
+            stat_type = "fastq"
+            self.has_quality = True
+        elif "Mean read length" in nano_stats:
+            stat_type = "fasta"
         else:
             log.debug(f"Did not recognise NanoStat file '{f['fn']}' - skipping")
             return

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -74,13 +74,13 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.nanostat_data, "multiqc_nanostat")
 
         # Stats Tables
-        if self.has_aligned == True:
+        if self.has_aligned:
             self.nanostat_stats_table("aligned")
-        if self.has_seq_summary == True:
+        if self.has_seq_summary:
             self.nanostat_stats_table("seq summary")
-        if self.has_fastq == True:
+        if self.has_fastq:
             self.nanostat_stats_table("fastq")
-        if self.has_fastq == True:
+        if self.has_fastq:
             self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -284,13 +284,13 @@ class MultiqcModule(BaseMultiqcModule):
         for s_name, data_dict in self.nanostat_data.items():
             reads_total, stat_type = _get_total_reads(data_dict)
             if stat_type == "fasta":
-                log.debug("Sample '{s_name}' has no quality metrics - excluded from quality plot")
+                log.debug(f"Sample '{s_name}' has no quality metrics - excluded from quality plot")
                 continue
             if s_name in bar_data and stat_type == "aligned":
-                log.debug("Sample '{s_name}' duplicated in the quality plot - ignoring aligned data")
+                log.debug(f"Sample '{s_name}' duplicated in the quality plot - ignoring aligned data")
                 continue
             elif s_name in bar_data and stat_type == "seq summary":
-                log.debug("Sample '{s_name}' duplicated in the quality plot - overwriting with seq summary data")
+                log.debug(f"Sample '{s_name}' duplicated in the quality plot - overwriting with seq summary data")
             bar_data[s_name] = {}
 
             prev_reads = reads_total

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -57,7 +57,8 @@ class MultiqcModule(BaseMultiqcModule):
         self.nanostat_data = dict()
         self.has_aligned = False
         self.has_seq_summary = False
-        self.has_quality = False
+        self.has_fastq = False
+        self.has_fasta = False
         for f in self.find_log_files("nanostat", filehandles=True):
             self.parse_nanostat_log(f)
 
@@ -73,17 +74,17 @@ class MultiqcModule(BaseMultiqcModule):
         self.write_data_file(self.nanostat_data, "multiqc_nanostat")
 
         # Stats Tables
-        if self.has_aligned:
+        if self.has_aligned == True:
             self.nanostat_stats_table("aligned")
-        elif self.has_seq_summary:
+        if self.has_seq_summary == True:
             self.nanostat_stats_table("seq summary")
-        elif self.has_quality:
+        if self.has_fastq == True:
             self.nanostat_stats_table("fastq")
-        else:
+        if self.has_fastq == True:
             self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot
-        if self.has_quality:
+        if self.has_aligned or self.has_seq_summary or self.has_fastq:
             self.reads_by_quality_plot()
 
     def parse_nanostat_log(self, f):
@@ -114,16 +115,15 @@ class MultiqcModule(BaseMultiqcModule):
         if "Total bases aligned" in nano_stats:
             stat_type = "aligned"
             self.has_aligned = True
-            self.has_quality = True
         elif "Active channels" in nano_stats:
             stat_type = "seq summary"
             self.has_seq_summary = True
-            self.has_quality = True
         elif "Mean read quality" in nano_stats:
             stat_type = "fastq"
-            self.has_quality = True
+            self.has_fastq = True
         elif "Mean read length" in nano_stats:
             stat_type = "fasta"
+            self.has_fasta = True
         else:
             log.debug(f"Did not recognise NanoStat file '{f['fn']}' - skipping")
             return

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -83,7 +83,8 @@ class MultiqcModule(BaseMultiqcModule):
             self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot
-        self.reads_by_quality_plot()
+        if self.has_quality:
+            self.reads_by_quality_plot()
 
     def parse_nanostat_log(self, f):
         """Parse output from NanoStat

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -75,8 +75,12 @@ class MultiqcModule(BaseMultiqcModule):
         # Stats Tables
         if self.has_aligned:
             self.nanostat_stats_table("aligned")
-        if self.has_seq_summary:
+        elif self.has_seq_summary:
             self.nanostat_stats_table("seq summary")
+        elif self.has_quality:
+            self.nanostat_stats_table("fastq")
+        else:
+            self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot
         self.reads_by_quality_plot()

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -366,7 +366,7 @@ kallisto:
   shared: true
 nanostat:
   max_filesize: 4096
-  contents: "General summary:         "
+  contents_re: "General summary:\\s*"
   num_lines: 1
 kat:
   fn: "*.dist_analysis.json"

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -366,8 +366,8 @@ kallisto:
   shared: true
 nanostat:
   max_filesize: 4096
-  contents: "Number, percentage and megabases of reads above quality cutoffs"
-  num_lines: 20
+  contents: "General summary:         "
+  num_lines: 1
 kat:
   fn: "*.dist_analysis.json"
 kraken:


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

---

As noted in #1547, the NanoStat module is currently ignoring NanoStat reports generated from fasta and fastq files. Fix that by

1. Broadening the modules search pattern to include fasta NanoStat reports
2. Adding logic to separate quality metrics from alignment and summary metrics
3. Bypassing the quality plot if adding a fasta NanoStat report

I have tested this PR with every test file contained in https://github.com/ewels/MultiQC_TestData/pull/221, and received output from every file.