### PR TITLE
reset multiqc between runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Sort custom content bargraph data by default ([#1412](https://github.com/ewels/MultiQC/issues/1412))
 - Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/ewels/MultiQC/issues/761))
 - Added support for customising table column names ([#1255](https://github.com/ewels/MultiQC/issues/1255))
+- Init/reset global state between runs ([#1596](https://github.com/ewels/MultiQC/pull/1596))
 
 ### New Modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -373,6 +373,8 @@ def run(
     if len(cl_config) > 0:
         config.mqc_cl_config(cl_config)
 
+    report.init()
+
     # Log the command used to launch MultiQC
     report.multiqc_command = " ".join(sys.argv)
     logger.debug("Command used: {}".format(report.multiqc_command))

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -32,37 +32,67 @@ try:
 except NameError:
     pass  # Python 3
 
-# Set up global variables shared across modules
-general_stats_data = list()
-general_stats_headers = list()
-general_stats_html = ""
-data_sources = defaultdict(lambda: defaultdict(lambda: defaultdict()))
-plot_data = dict()
-html_ids = list()
-lint_errors = list()
-num_hc_plots = 0
-num_mpl_plots = 0
-saved_raw_data = dict()
-last_found_file = None
-runtimes = {
-    "total": 0,
-    "total_sp": 0,
-    "total_mods": 0,
-    "total_compression": 0,
-    "sp": defaultdict(),
-    "mods": defaultdict(),
-}
-file_search_stats = {
-    "skipped_symlinks": 0,
-    "skipped_not_a_file": 0,
-    "skipped_ignore_pattern": 0,
-    "skipped_filesize_limit": 0,
-    "skipped_no_match": 0,
-}
 
-# Make a dict of discovered files for each seach key
-searchfiles = list()
-files = dict()
+# Set up global variables shared across modules
+def init():
+    global general_stats_data
+    general_stats_data = list()
+
+    global general_stats_headers
+    general_stats_headers = list()
+
+    global general_stats_html
+    general_stats_html = ""
+
+    global data_sources
+    data_sources = defaultdict(lambda: defaultdict(lambda: defaultdict()))
+
+    global plot_data
+    plot_data = dict()
+
+    global html_ids
+    html_ids = list()
+
+    global lint_errors
+    lint_errors = list()
+
+    global num_hc_plots
+    num_hc_plots = 0
+
+    global num_mpl_plots
+    num_mpl_plots = 0
+
+    global saved_raw_data
+    saved_raw_data = dict()
+
+    global last_found_file
+    last_found_file = None
+
+    global runtimes
+    runtimes = {
+        "total": 0,
+        "total_sp": 0,
+        "total_mods": 0,
+        "total_compression": 0,
+        "sp": defaultdict(),
+        "mods": defaultdict(),
+    }
+
+    global file_search_stats
+    file_search_stats = {
+        "skipped_symlinks": 0,
+        "skipped_not_a_file": 0,
+        "skipped_ignore_pattern": 0,
+        "skipped_filesize_limit": 0,
+        "skipped_no_match": 0,
+    }
+
+    global searchfiles
+    searchfiles = list()
+
+    # Make a dict of discovered files for each seach key
+    global files
+    files = dict()
 
 
 def get_filelist(run_module_names):

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -34,6 +34,7 @@ except NameError:
 
 
 # Set up global variables shared across modules
+# Inside a function so that the global vars are reset if MultiQC is run more than once within a single session / environment
 def init():
     global general_stats_data
     general_stats_data = list()


### PR DESCRIPTION
Currently, multiqc leverages global state to store info. If you run it twice, you get weird results - e.g. table columns get duplicated. This moves the `init` logic into a re-callable function, such that multiqc can reset state between runs.

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

I wrote a couple quick scripts to test:
```console
$ cat other.py 
def init():
    global foo
    foo = ["bar"]

$ cat test.py 
import other

other.init()
print(other.foo)
other.foo.append("baz")
print(other.foo)
other.init()
print(other.foo)

$ python3 test.py 
['bar']
['bar', 'baz']
['bar']
```