### PR TITLE
Bugfix for Issue 1588: `multiqc_general_stats.txt` is empty

### DIFF
--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from collections import OrderedDict
 import io
 import json
-from logging import NullHandler
 import os
 import yaml
 import time

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from collections import OrderedDict
 import io
 import json
+from logging import NullHandler
 import os
 import yaml
 import time
@@ -13,6 +14,38 @@ import shutil
 import sys
 
 from multiqc import config
+
+
+def tab_separated_output(data, sort_cols):
+    """Subfunction of write_data_file() below
+    Some metrics, in particular those of the custom content module
+    can't be written cleanly to tab-separated output. Now failure
+    can trigger the use of a more suitable export format.
+    """
+    try:
+        # Convert keys to strings
+        data = {str(k): v for k, v in data.items()}
+        # Get all headers
+        h = ["Sample"]
+        for sn in sorted(data.keys()):
+            for k in data[sn].keys():
+                if type(data[sn][k]) is not dict and k not in h:
+                    h.append(str(k))
+        if sort_cols:
+            h = sorted(h)
+
+        # Get the rows
+        rows = ["\t".join(h)]
+        for sn in sorted(data.keys()):
+            # Make a list starting with the sample name, then each field in order of the header cols
+            l = [str(sn)] + [str(data[sn].get(k, "")) for k in h[1:]]
+            rows.append("\t".join(l))
+
+        body = "\n".join(rows)
+
+        return body, True
+    except:
+        return None, False
 
 
 def robust_rmtree(path, logger=None, max_retries=10):
@@ -51,10 +84,13 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
 
     if config.data_dir is not None:
 
-        # Add relevant file extension to filename
+        # Initialise variables
+        fallback = False
+        success = False
+
+        # Get data format from config
         if data_format is None:
             data_format = config.data_format
-        fn = "{}.{}".format(fn, config.data_format_extensions[data_format])
 
         # JSON encoder class to handle lambda functions
         class MQCJSONEncoder(json.JSONEncoder):
@@ -66,37 +102,57 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
                         return None
                 return json.JSONEncoder.default(self, obj)
 
-        # some metrics can't be coerced to tab-separated output (omit those and write separately to YAML)
-        if data_format not in ["json", "yaml"] and len(data) > 1:
-            aberrant_data = list()
-            for _, key in zip(range(len(data)), data):
-                if type(data[key]) is not dict and type(data[key]) is not OrderedDict:
-                    aberrant_data.append(key)
+        # Some metrics can't be coerced to tab-separated output, test and handle exceptions
+        if data_format not in ["json", "yaml"]:
 
-            for key in aberrant_data:
-                with io.open(os.path.join(config.data_dir, fn + "_" + str(key)), "w", encoding="utf-8") as f:
-                    yaml.dump(data[key], f, default_flow_style=False)
-                    config.logger.debug(
-                        "Some metrics could not be coerced into tab-separated output and were written as YAML instead to "
-                        + fn
-                    )
-                del data[key]
+            # attempt to reshape data to tsv
+            data_tsv, success = tab_separated_output(data, sort_cols=sort_cols)
 
-            if not data:  # no items left for regular export
-                return
+            if not success:
+                # Unsuccessful TSV reshape: Try to remove malformed data and export remainders.
+                aberrant_data = list()
+                regular_data = list()
 
-        elif (
-            data_format not in ["json", "yaml"]
-            and len(data) == 1
-            and type(data) is not dict
-            and type(data) is not OrderedDict
-        ):
-            config.logger.debug(
-                "Metrics of " + fn + "can't be saved as tab-separated output. Choose JSON or YAML output instead."
+                try:
+                    for _, key in zip(range(len(data)), data):
+                        _, success = tab_separated_output([data[key]], sort_cols=sort_cols)
+                        if success:
+                            regular_data.append(data[key])
+                        else:
+                            aberrant_data.append(data[key])
+
+                    if regular_data:
+                        # Final, now hopefully working reshape
+                        data_tsv, success = tab_separated_output(regular_data, sort_cols=sort_cols)
+
+                        if success:
+                            # Separate export for what didn't work.
+                            for key in aberrant_data:
+                                adf = str(fn + "_" + str(key) + config.data_format_extensions["yaml"])
+                                with io.open(os.path.join(config.data_dir, adf), "w", encoding="utf-8") as g:
+                                    yaml.dump(aberrant_data[key], g, default_flow_style=False)
+                                    config.logger.info(
+                                        "Some metrics could not be coerced into tab-separated output and were instead written as YAML to "
+                                        + adf
+                                    )
+                        else:  # Reshaping remainder failed.
+                            fallback = True
+                    else:  # No regular data: Rather export everything as YAML.
+                        fallback = True
+                except:
+                    # Subsetting doesn't work, e.g. because key is a list for scatterplots
+                    fallback = True
+
+        if fallback:
+            data_format = "yaml"
+            config.logger.warning(
+                "Metrics of "
+                + fn
+                + " could not be saved as tab-separated output. Choose JSON or YAML output instead. Falling back to YAML."
             )
-            return
 
-        # Save file
+        # Add relevant file extension to filename, save file.
+        fn = "{}.{}".format(fn, config.data_format_extensions[data_format])
         with io.open(os.path.join(config.data_dir, fn), "w", encoding="utf-8") as f:
             if data_format == "json":
                 jsonstr = json.dumps(data, indent=4, cls=MQCJSONEncoder, ensure_ascii=False)
@@ -105,28 +161,7 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
                 yaml.dump(data, f, default_flow_style=False)
             else:
                 # Default - tab separated output
-
-                # Convert keys to strings
-                data = {str(k): v for k, v in data.items()}
-                # Get all headers
-                h = ["Sample"]
-                for sn in sorted(data.keys()):
-                    for k in data[sn].keys():
-                        if type(data[sn][k]) is not dict and k not in h:
-                            h.append(str(k))
-                if sort_cols:
-                    h = sorted(h)
-
-                # Get the rows
-                rows = ["\t".join(h)]
-                for sn in sorted(data.keys()):
-                    # Make a list starting with the sample name, then each field in order of the header cols
-                    l = [str(sn)] + [str(data[sn].get(k, "")) for k in h[1:]]
-                    rows.append("\t".join(l))
-
-                body = "\n".join(rows)
-
-                print(body.encode("utf-8", "ignore").decode("utf-8"), file=f)
+                print(data_tsv.encode("utf-8", "ignore").decode("utf-8"), file=f)
 
 
 def view_all_tags(ctx, param, value):

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -92,10 +92,7 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
 
             except:
                 data_format = "yaml"
-                config.logger.warning(
-                    fn
-                    + " could not be saved as tab-separated output. Choose JSON or YAML output instead. Falling back to YAML."
-                )
+               logger.debug(f"{fn} could not be saved as tsv/csv. Falling back to YAML.")
 
         # Add relevant file extension to filename, save file.
         fn = "{}.{}".format(fn, config.data_format_extensions[data_format])

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -92,7 +92,7 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
 
             except:
                 data_format = "yaml"
-               logger.debug(f"{fn} could not be saved as tsv/csv. Falling back to YAML.")
+                config.logger.debug(f"{fn} could not be saved as tsv/csv. Falling back to YAML.")
 
         # Add relevant file extension to filename, save file.
         fn = "{}.{}".format(fn, config.data_format_extensions[data_format])

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -85,7 +85,12 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
             if not data:  # no items left for regular export
                 return
 
-        elif len(data) == 1 and type(data) is not dict and type(data) is not OrderedDict:
+        elif (
+            data_format not in ["json", "yaml"]
+            and len(data) == 1
+            and type(data) is not dict
+            and type(data) is not OrderedDict
+        ):
             config.logger.debug(
                 "Metrics of " + fn + "can't be saved as tab-separated output. Choose JSON or YAML output instead."
             )


### PR DESCRIPTION
Commit 40a4d18 / #1528 introduced a return statement to `util_functions.write_data_file` that would skip writing data to a file which is not an OrderedDict. This however also affected the _general_stats_data_, which is of type list and thus caused #1588.

This commit addresses this bug and wraps the reshape operation into a try statement. Instead of returning, it will now try and otherwise fall back to YAML export. 

Additionally, based on the false assumption that the `multiqc_general_stats.txt` would collect all modules' output, I have also come up with a rescue effort to remove aberrant items and proceed with the regular ones. However, this bloats the function quite heavily and it does not help with the heatmaps and scatterplots nonetheless. So I guess, it should be removed again, unless there is a future feature in planning that could make good use of that functionality?  

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated (_Not applicable since bug was fixed before release_)