### PR TITLE
Fix recognition of recent sambamba markdup version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### MultiQC updates
 
+- Fixed issue with format sambamba markdup 0.8.1 ([#1617](https://github.com/ewels/MultiQC/issues/1617))
 - Added option to customise default plot height in plot config ([#1432](https://github.com/ewels/MultiQC/issues/1432))
 - Added `--no-report` flag to skip report generation ([#1462](https://github.com/ewels/MultiQC/issues/1462))
 - Added support for priting tool DOI in report sections ([#1177](https://github.com/ewels/MultiQC/issues/1177))

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -642,7 +642,7 @@ salmon/fld:
   fn: "flenDist.txt"
 sambamba/markdup:
   contents: "finding positions of the duplicate reads in the file"
-  num_lines: 10
+  num_lines: 50
 samblaster:
   contents: "samblaster: Version"
   shared: true

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -642,7 +642,7 @@ salmon/fld:
   fn: "flenDist.txt"
 sambamba/markdup:
   contents: "finding positions of the duplicate reads in the file"
-  num_lines: 5
+  num_lines: 10
 samblaster:
   contents: "samblaster: Version"
   shared: true


### PR DESCRIPTION
We simply check more lines before we give up, since the new format has additional newlines. See #1617 for details.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated