### PR TITLE
Only set id for custom content when id not set by metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _nothing yet.._
 
 ### Module updates
 
-_nothing yet.._
+- Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -172,9 +172,10 @@ def custom_module_classes():
                         s_name = f["s_name"]
 
                     # Guess c_id if no information known
-                    if k == "custom_content" and not m_config.get("id"):
+                    if k == "custom_content":
                         c_id = s_name
-                        m_config["id"] = c_id
+                        if not m_config.get("id"):
+                            m_config["id"] = c_id
 
                     # Merge with config from a MultiQC config file if we have it
                     m_config.update(mod_cust_config.get(c_id, {}))

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -172,7 +172,7 @@ def custom_module_classes():
                         s_name = f["s_name"]
 
                     # Guess c_id if no information known
-                    if k == "custom_content":
+                    if k == "custom_content" and not m_config.get("id"):
                         c_id = s_name
                         m_config["id"] = c_id
 


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [x] Code is tested and works locally (including with `--lint` flag)

Closes #1629
https://github.com/ewels/MultiQC/issues/1550 set the id for all custom content.
Now only when id not already in metadata
