### PR TITLE
Extend kallisto module regex to recognize newer output

### DIFF
--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -57,7 +57,7 @@ class MultiqcModule(BaseMultiqcModule):
         for l in f["f"]:
 
             # Get input filename
-            match = re.search(r"\[quant\] will process (pair|file) 1: (\S+)", l)
+            match = re.search(r"\[quant\] will process (pair|file|sample) 1: (\S+)", l)
             if match:
                 s_name = self.clean_s_name(os.path.basename(match.group(2)), f)
 


### PR DESCRIPTION
I've noticed multiqc (v 1.12) didn't recognise some kallisto output (I'm using kb_python 0.26.4).
Having digged a bit, it seems to not work with more recent kallisto output, i.e. this snippet taken from here:
https://github.com/pachterlab/GRNP_2020/blob/daed9c2f204f1c3f6ee0e864c3db93b0baadfc8a/notebooks/FASTQ_processing/ProcessPBMC_NG.ipynb
```
[index] k-mer length: 31
[index] number of targets: 187,626
[index] number of k-mers: 108,619,921
tcmalloc: large alloc 3221225472 bytes == 0x556459b7e000 @  0x7feac4ab5887 0x556458814ad2 0x55645880d061 0x5564587e1372 0x7feac3935bf7 0x5564587e60da
[index] number of equivalence classes: 752,021
[quant] will process sample 1: A_R1.gz
                               A_R2.gz
[quant] will process sample 2: B_R1.gz
                               B_R2.gz
[quant] finding pseudoalignments for the reads ... done
[quant] processed 170,526,037 reads, 98,632,205 reads pseudoaligned
```
Turns out multiqc only looks for `pair|file` but not sample. Replacing sample for file did do the trick, hence I suggest to add `sample` in the regex pattern.
I haven't tested this, but it should work now.

Here is the code which generates this output:
https://github.com/pachterlab/kallisto/blob/83bde908c403ea4014b5092a243e5c7240f48dd5/src/ProcessReads.cpp#L235

This is the commit which introduced it (already in 2018, so not sure why this hasn't been caught yet)
https://github.com/pachterlab/kallisto/commit/62e946498486222d881133119212553f143eda76

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

