### PR TITLE
Ensure logger removal is compatible with dictConfig configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Major spruce of the command line help, using the new [rich-click](https://github.com/ewels/rich-click) package
 - Drop some of the Python 2k compatability code (eg. custom requirements)
+- Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
+  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/ewels/MultiQC/issues/1643))
 
 ### New Modules
 

--- a/multiqc/utils/log.py
+++ b/multiqc/utils/log.py
@@ -38,7 +38,7 @@ def init_log(logger, loglevel=0, no_ansi=False):
     info_template = "|%(module)18s | %(message)s"
 
     # Remove log handlers left from previous calls to multiqc.run
-    while logger.hasHandlers():
+    while logger.handlers:
         logger.removeHandler(logger.handlers[0])
 
     # Base level setup


### PR DESCRIPTION
This includes a patch for a logger removal step bug that arose from using dictConfig to configure the root logger.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

