### PR TITLE
AdapterRemoval: fixes number of reads that are discarded/collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ _nothing yet.._
 
 ### Module updates
 
-- Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
+- **AdapterRemoval**
+  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
+- **Custom content**
+  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -178,10 +178,19 @@ class MultiqcModule(BaseMultiqcModule):
         self.result_data["unaligned_total"] = unaligned_total
         self.result_data["reads_total"] = reads_total
         self.result_data["discarded_total"] = reads_total - self.result_data["retained"]
-
-        self.result_data["retained_reads"] = (
-            self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
-        )
+        if self.__read_type == "paired":
+          if not self.__collapsed:
+              self.result_data["paired_reads"] = (
+              self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+              )
+          else:
+              self.result_data["paired_reads"] = (
+              self.result_data["retained"] - self.result_data["full-length_cp"] - self.result_data["truncated_cp"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+              )
+          full_length_cp = self.result_data["full-length_cp"] * 2
+          truncated_cp = self.result_data["truncated_cp"] * 2
+          self.result_data["full-length_cp"] = full_length_cp
+          self.result_data["truncated_cp"] = truncated_cp
         try:
             self.result_data["percent_aligned"] = (
                 float(self.result_data["aligned"]) * 100.0 / float(self.result_data["total"])
@@ -270,7 +279,7 @@ class MultiqcModule(BaseMultiqcModule):
         cats_pec = OrderedDict()
 
         if self.__any_paired:
-            cats_pec["retained_reads"] = {"name": "Retained Read Pairs"}
+            cats_pec["paired_reads"] = {"name": "Paired Reads"}
 
         cats_pec["singleton_m1"] = {"name": "Singleton R1"}
 
@@ -278,8 +287,8 @@ class MultiqcModule(BaseMultiqcModule):
             cats_pec["singleton_m2"] = {"name": "Singleton R2"}
 
             if self.__any_collapsed:
-                cats_pec["full-length_cp"] = {"name": "Full-length Collapsed Pairs"}
-                cats_pec["truncated_cp"] = {"name": "Truncated Collapsed Pairs"}
+                cats_pec["full-length_cp"] = {"name": "Full-length Collapsed Reads"}
+                cats_pec["truncated_cp"] = {"name": "Truncated Collapsed Reads"}
 
         cats_pec["discarded_m1"] = {"name": "Discarded R1"}
 

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -218,7 +218,7 @@ class MultiqcModule(BaseMultiqcModule):
             )
         except ZeroDivisionError:
             self.result_data["percent_discarded"] = 0
-            
+
     def set_len_dist(self, len_dist_data):
 
         for line in len_dist_data[1:]:
@@ -304,7 +304,6 @@ class MultiqcModule(BaseMultiqcModule):
             "scale": "RdYlGn-rev",
             "shared_key": "percent_discarded",
         }
-
         self.general_stats_addcols(self.adapter_removal_data, headers)
 
     def adapter_removal_retained_chart(self):

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -181,7 +181,9 @@ class MultiqcModule(BaseMultiqcModule):
         if self.__read_type == "paired":
           if not self.__collapsed:
               self.result_data["paired_reads"] = (
-              self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+              self.result_data["retained"] 
+              - self.result_data["singleton_m1"] 
+              - self.result_data["singleton_m2"]
               )
           else:
               self.result_data["paired_reads"] = (

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -201,7 +201,24 @@ class MultiqcModule(BaseMultiqcModule):
             )
         except ZeroDivisionError:
             self.result_data["percent_aligned"] = 0
-
+        if self.__collapsed:
+            try:
+                self.result_data["percent_collapsed"] = (
+                    float(self.result_data["full-length_cp"] + self.result_data["truncated_cp"])
+                    * 100.0
+                    / float(self.result_data["reads_total"])
+                )
+            except ZeroDivisionError:
+                self.result_data["percent_collapsed"] = 0
+        try:
+            self.result_data["percent_discarded"] = (
+                float(self.result_data["discarded_m1"] + self.result_data["discarded_m2"])
+                * 100.0
+                / float(self.result_data["reads_total"])
+            )
+        except ZeroDivisionError:
+            self.result_data["percent_discarded"] = 0
+            
     def set_len_dist(self, len_dist_data):
 
         for line in len_dist_data[1:]:
@@ -268,6 +285,26 @@ class MultiqcModule(BaseMultiqcModule):
             "scale": "PuBu",
             "shared_key": "read_count",
         }
+        if self.__any_collapsed:
+            headers["percent_collapsed"] = {
+                "title": "% Collapsed",
+                "description": "% collapsed reads",
+                "max": 100,
+                "min": 0,
+                "suffix": "%",
+                "scale": "RdYlGn-rev",
+                "shared_key": "percent_aligned",
+            }
+        headers["percent_discarded"] = {
+            "title": "% Discarded",
+            "description": "% discarded reads",
+            "max": 100,
+            "min": 0,
+            "suffix": "%",
+            "scale": "RdYlGn-rev",
+            "shared_key": "percent_discarded",
+        }
+
         self.general_stats_addcols(self.adapter_removal_data, headers)
 
     def adapter_removal_retained_chart(self):

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -185,7 +185,11 @@ class MultiqcModule(BaseMultiqcModule):
               )
           else:
               self.result_data["paired_reads"] = (
-              self.result_data["retained"] - self.result_data["full-length_cp"] - self.result_data["truncated_cp"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+              self.result_data["retained"] 
+              - self.result_data["full-length_cp"] 
+              - self.result_data["truncated_cp"] 
+              - self.result_data["singleton_m1"] 
+              - self.result_data["singleton_m2"]
               )
           full_length_cp = self.result_data["full-length_cp"] * 2
           truncated_cp = self.result_data["truncated_cp"] * 2

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -179,24 +179,22 @@ class MultiqcModule(BaseMultiqcModule):
         self.result_data["reads_total"] = reads_total
         self.result_data["discarded_total"] = reads_total - self.result_data["retained"]
         if self.__read_type == "paired":
-          if not self.__collapsed:
-              self.result_data["paired_reads"] = (
-              self.result_data["retained"] 
-              - self.result_data["singleton_m1"] 
-              - self.result_data["singleton_m2"]
-              )
-          else:
-              self.result_data["paired_reads"] = (
-              self.result_data["retained"] 
-              - self.result_data["full-length_cp"] 
-              - self.result_data["truncated_cp"] 
-              - self.result_data["singleton_m1"] 
-              - self.result_data["singleton_m2"]
-              )
-          full_length_cp = self.result_data["full-length_cp"] * 2
-          truncated_cp = self.result_data["truncated_cp"] * 2
-          self.result_data["full-length_cp"] = full_length_cp
-          self.result_data["truncated_cp"] = truncated_cp
+            if not self.__collapsed:
+                self.result_data["paired_reads"] = (
+                    self.result_data["retained"] - self.result_data["singleton_m1"] - self.result_data["singleton_m2"]
+                )
+            else:
+                self.result_data["paired_reads"] = (
+                    self.result_data["retained"]
+                    - self.result_data["full-length_cp"]
+                    - self.result_data["truncated_cp"]
+                    - self.result_data["singleton_m1"]
+                    - self.result_data["singleton_m2"]
+                )
+            full_length_cp = self.result_data["full-length_cp"] * 2
+            truncated_cp = self.result_data["truncated_cp"] * 2
+            self.result_data["full-length_cp"] = full_length_cp
+            self.result_data["truncated_cp"] = truncated_cp
         try:
             self.result_data["percent_aligned"] = (
                 float(self.result_data["aligned"]) * 100.0 / float(self.result_data["total"])

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -299,9 +299,7 @@ class MultiqcModule(BaseMultiqcModule):
         if self.__any_paired:
             cats_pec["discarded_m2"] = {"name": "Discarded R2"}
         if self.__any_collapsed:
-            retained_chart_description = "The number of input sequences that were retained, collapsed, and discarded. Be aware that t
-he number of collapsed reads in the output FASTQ will be half of the numbers displayed in this plot, because both R1 and R2 of
-the collapsed sequences are counted here."
+            retained_chart_description = "The number of input sequences that were retained, collapsed, and discarded. Be aware that the number of collapsed reads in the output FASTQ will be half of the numbers displayed in this plot, because both R1 and R2 of the collapsed sequences are counted here."
         else:
             retained_chart_description = "The number of input sequences that were retained and discarded."
         self.add_section(

--- a/multiqc/modules/adapterRemoval/adapterRemoval.py
+++ b/multiqc/modules/adapterRemoval/adapterRemoval.py
@@ -283,7 +283,7 @@ class MultiqcModule(BaseMultiqcModule):
         cats_pec = OrderedDict()
 
         if self.__any_paired:
-            cats_pec["paired_reads"] = {"name": "Paired Reads"}
+            cats_pec["paired_reads"] = {"name": "Uncollapsed Paired Reads"}
 
         cats_pec["singleton_m1"] = {"name": "Singleton R1"}
 
@@ -298,11 +298,16 @@ class MultiqcModule(BaseMultiqcModule):
 
         if self.__any_paired:
             cats_pec["discarded_m2"] = {"name": "Discarded R2"}
-
+        if self.__any_collapsed:
+            retained_chart_description = "The number of input sequences that were retained, collapsed, and discarded. Be aware that t
+he number of collapsed reads in the output FASTQ will be half of the numbers displayed in this plot, because both R1 and R2 of
+the collapsed sequences are counted here."
+        else:
+            retained_chart_description = "The number of input sequences that were retained and discarded."
         self.add_section(
-            name="Retained and Discarded Paired-End Collapsed",
+            name="Retained and Discarded Reads",
             anchor="adapter_removal_retained_plot",
-            description="The number of retained and discarded reads.",
+            description=retained_chart_description,
             plot=bargraph.plot(self.adapter_removal_data, cats_pec, pconfig),
         )
 
@@ -345,7 +350,7 @@ class MultiqcModule(BaseMultiqcModule):
         pconfig["data_labels"] = data_labels
 
         self.add_section(
-            name="Length Distribution Paired End Collapsed",
+            name="Length Distribution",
             anchor="ar_length_count",
             description="The length distribution of reads after processing adapter alignment.",
             plot=linegraph.plot(lineplot_data, pconfig),


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

This is following a discussion with @jfy133.
Like #1386 and #1423, this should fix issue #1005 and now display the correct number/proportion of **reads** that are collapsed/discarded/paired.

On the test dataset the output used to look like this, where "Retained Read Pairs" contains e.g. collapsed/truncated read pairs: 

![ar_retained_plot (1)](https://user-images.githubusercontent.com/69033839/158400373-92640a33-3256-4bed-9d34-701737be2da4.svg)

With my edits the plot looks like this now, where the categories are non-overlapping and proportional to the input data, making it easy to see what proportion of the data was collapsed and discarded: 

![ar_retained_plot](https://user-images.githubusercontent.com/69033839/158400171-df321016-b27d-40b9-af58-7d1d78f3b518.svg)

