### PR TITLE
Edit bclconvert search pattern

### DIFF
--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -85,6 +85,7 @@ bcl2fastq:
   num_lines: 300
 bclconvert/runinfo:
   fn: "RunInfo.xml"
+  shared: true
 bclconvert/demux:
   fn: "Demultiplex_Stats.csv"
 bclconvert/quality_metrics:


### PR DESCRIPTION
- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

Set bclconvert search pattern for `RunInfo.xml` to shared, as it interferes with the function of the MultiQC_SAV plugin
