### PR TITLE
Fix jinja2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Major spruce of the command line help, using the new [rich-click](https://github.com/ewels/rich-click) package
 - Drop some of the Python 2k compatability code (eg. custom requirements)
+- Fix jinja2 version specification given incompatibility with >=3.1.0
 
 ### New Modules
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "click",
         "coloredlogs",
         "future>0.14.0",
-        "jinja2>=2.9",
+        "jinja2>=2.9,<=3.0.3",
         "lzstring",
         "markdown",
         "pyyaml>=4",


### PR DESCRIPTION
MultiQC errors with jinja2 version >3.1.0 that it cannot import `jinja2.escape`. Here we fix the jinja2 version to temporarily fix that.
Eventually, perhaps someone could look into what the replacement is.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
