### PR TITLE
Fixed bug when other fields also have a "-" instead of an integer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _nothing yet.._
 
 - **AdapterRemoval**
   - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
+  ** VEP **
+  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
 - **Custom content**
   - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _nothing yet.._
 
 - **AdapterRemoval**
   - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
-  **VEP**
+- **VEP**
   - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
 - **Custom content**
   - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _nothing yet.._
 
 - **AdapterRemoval**
   - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
-  ** VEP **
+  **VEP**
   - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
 - **Custom content**
   - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -125,18 +125,16 @@ class MultiqcModule(BaseMultiqcModule):
                 if len(cells) == 2:
                     key = cells[0][4:-5]
                     value = cells[1][4:-5]
+                    if value == "-":
+                        continue
                     if key == "Novel / existing variants":
-                        if value == "-":
-                            self.vep_data[f["s_name"]][title]["Novel variants"] = None
-                            self.vep_data[f["s_name"]][title]["Existing variants"] = None
-                            continue
                         values = value.split("/")
                         novel = values[0].split("(")[0].replace(" ", "")
                         existing = values[1].split("(")[0].replace(" ", "")
                         self.vep_data[f["s_name"]][title]["Novel variants"] = int(novel)
                         self.vep_data[f["s_name"]][title]["Existing variants"] = int(existing)
                     else:
-                        self.vep_data[f["s_name"]][title][key] = None if value == "-" else int(value)
+                        self.vep_data[f["s_name"]][title][key] = int(value)
 
     def parse_vep_txt(self, f):
         """This Function will parse VEP summary files with plain text format"""
@@ -155,18 +153,16 @@ class MultiqcModule(BaseMultiqcModule):
                 txt_data[title] = {}
                 continue
             key, value = line.split("\t")
+            if value == "-":
+                continue
             if key == "Novel / existing variants":
-                if value == "-":
-                    txt_data[title]["Novel variants"] = None
-                    txt_data[title]["Existing variants"] = None
-                    continue
                 values = value.split("/")
                 novel = values[0].split("(")[0].replace(" ", "")
                 existing = values[1].split("(")[0].replace(" ", "")
                 txt_data[title]["Novel variants"] = int(novel)
                 txt_data[title]["Existing variants"] = int(existing)
             elif title != "VEP run statistics":
-                txt_data[title][key] = None if value == "-" else int(value)
+                txt_data[title][key] = int(value)
             else:
                 txt_data[title][key] = value
 

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -127,8 +127,8 @@ class MultiqcModule(BaseMultiqcModule):
                     value = cells[1][4:-5]
                     if key == "Novel / existing variants":
                         if value == "-":
-                            self.vep_data[f["s_name"]][title]["Novel variants"] = 0
-                            self.vep_data[f["s_name"]][title]["Existing variants"] = 0
+                            self.vep_data[f["s_name"]][title]["Novel variants"] = None
+                            self.vep_data[f["s_name"]][title]["Existing variants"] = None
                             continue
                         values = value.split("/")
                         novel = values[0].split("(")[0].replace(" ", "")
@@ -136,7 +136,7 @@ class MultiqcModule(BaseMultiqcModule):
                         self.vep_data[f["s_name"]][title]["Novel variants"] = int(novel)
                         self.vep_data[f["s_name"]][title]["Existing variants"] = int(existing)
                     else:
-                        self.vep_data[f["s_name"]][title][key] = 0 if value == "-" else int(value)
+                        self.vep_data[f["s_name"]][title][key] = None if value == "-" else int(value)
 
     def parse_vep_txt(self, f):
         """This Function will parse VEP summary files with plain text format"""
@@ -157,8 +157,8 @@ class MultiqcModule(BaseMultiqcModule):
             key, value = line.split("\t")
             if key == "Novel / existing variants":
                 if value == "-":
-                    txt_data[title]["Novel variants"] = 0
-                    txt_data[title]["Existing variants"] = 0
+                    txt_data[title]["Novel variants"] = None
+                    txt_data[title]["Existing variants"] = None
                     continue
                 values = value.split("/")
                 novel = values[0].split("(")[0].replace(" ", "")
@@ -166,7 +166,7 @@ class MultiqcModule(BaseMultiqcModule):
                 txt_data[title]["Novel variants"] = int(novel)
                 txt_data[title]["Existing variants"] = int(existing)
             elif title != "VEP run statistics":
-                txt_data[title][key] = 0 if value == "-" else int(value)
+                txt_data[title][key] = None if value == "-" else int(value)
             else:
                 txt_data[title][key] = value
 

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -125,18 +125,18 @@ class MultiqcModule(BaseMultiqcModule):
                 if len(cells) == 2:
                     key = cells[0][4:-5]
                     value = cells[1][4:-5]
-                    try:
-                        if key == "Novel / existing variants":
-                            values = value.split("/")
-                            novel = values[0].split("(")[0].replace(" ", "")
-                            existing = values[1].split("(")[0].replace(" ", "")
-                            self.vep_data[f["s_name"]][title]["Novel variants"] = int(novel)
-                            self.vep_data[f["s_name"]][title]["Existing variants"] = int(existing)
-                        else:
-                            self.vep_data[f["s_name"]][title][key] = int(value)
-                    except (IndexError, ValueError):
-                        # Table cells can just have "-". Don't log values if so. See issue #1597
-                        pass
+                    if key == "Novel / existing variants":
+                        if value == "-":
+                            txt_data[title]["Novel variants"] = 0
+                            txt_data[title]["Existing variants"] = 0
+                            continue
+                        values = value.split("/")
+                        novel = values[0].split("(")[0].replace(" ", "")
+                        existing = values[1].split("(")[0].replace(" ", "")
+                        self.vep_data[f["s_name"]][title]["Novel variants"] = int(novel)
+                        self.vep_data[f["s_name"]][title]["Existing variants"] = int(existing)
+                    else:
+                        self.vep_data[f["s_name"]][title][key] = 0 if value == "-" else int(value)
 
     def parse_vep_txt(self, f):
         """This Function will parse VEP summary files with plain text format"""
@@ -166,7 +166,7 @@ class MultiqcModule(BaseMultiqcModule):
                 txt_data[title]["Novel variants"] = int(novel)
                 txt_data[title]["Existing variants"] = int(existing)
             elif title != "VEP run statistics":
-                txt_data[title][key] = int(value)
+                txt_data[title][key] = 0 if value == "-" else int(value)
             else:
                 txt_data[title][key] = value
 

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -127,8 +127,8 @@ class MultiqcModule(BaseMultiqcModule):
                     value = cells[1][4:-5]
                     if key == "Novel / existing variants":
                         if value == "-":
-                            txt_data[title]["Novel variants"] = 0
-                            txt_data[title]["Existing variants"] = 0
+                            self.vep_data[f["s_name"]][title]["Novel variants"] = 0
+                            self.vep_data[f["s_name"]][title]["Existing variants"] = 0
                             continue
                         values = value.split("/")
                         novel = values[0].split("(")[0].replace(" ", "")


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

While parsing a VEP stats file from SV calls, got an error:
```
ValueError: invalid literal for int() with base 10: '-'
```
It seems it was due to a line in the stats file that had:
```
Overlapped regulatory features	-
```

The fix was to always check if the value is `-` before converting to `int`.


- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
