### PR TITLE
optimize linegraph category comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed edge-case bug in custom content where a `description` that doesn't terminate in `.` gave duplicate section descriptions.
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
 - Add timezone to time in reports
+- Optimize line-graph generation to remove an n^2 loop
 
 ### New Modules
 

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -392,14 +392,17 @@ def matplotlib_linegraph(plotdata, pconfig=None):
             sharedcats = True
             for d in pdata:
                 fdata[d["name"]] = OrderedDict()
+
+                # Check to see if all categories are the same
+                if len(d["data"]) > 0 and type(d["data"][0]) is list:
+                    if lastcats is None:
+                        lastcats = [x[0] for x in d["data"]]
+                    elif lastcats != [x[0] for x in d["data"]]:
+                        sharedcats = False
+
                 for i, x in enumerate(d["data"]):
                     if type(x) is list:
                         fdata[d["name"]][str(x[0])] = x[1]
-                        # Check to see if all categories are the same
-                        if lastcats is None:
-                            lastcats = [x[0] for x in d["data"]]
-                        elif lastcats != [x[0] for x in d["data"]]:
-                            sharedcats = False
                     else:
                         try:
                             fdata[d["name"]][pconfig["categories"][i]] = x


### PR DESCRIPTION
Optimizes the category comparison of the linegraph.

See the issue is, `d["data"]` does not change while looping through `d["data"]` as best I can tell. So every iteration, the result will be the same. The only thing we need to check is that the values are lists. Once we verify that, we just need to check categories once per dataset.

In one case, I was comparing a list of 68000 cats, 68000 times. This is an n^2 problem, no bueno.

The fix brought multiqc from not on a dataset to finishing in ~20s.

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

I didn't think this was worthy of CHANGELOG, lmk if you feel otherwise