### PR TITLE
Somalier: fix division by zero in sex ploidy plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ _nothing yet.._
   - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
 - **Pangolin**
   - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
+- **Somalier**
+  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -545,9 +545,13 @@ class MultiqcModule(BaseMultiqcModule):
 
         for s_name, d in self.somalier_data.items():
             if "X_depth_mean" in d and "original_pedigree_sex" in d:
+                if d["gt_depth_mean"] == 0:
+                    y = 0
+                else:
+                    y = 2 * d["X_depth_mean"] / d["gt_depth_mean"]
                 data[s_name] = {
                     "x": (random.random() - 0.5) * 0.1 + sex_index.get(d["original_pedigree_sex"], 2),
-                    "y": 2 * d["X_depth_mean"] / d["gt_depth_mean"],
+                    "y": y,
                 }
 
         if len(data) > 0:


### PR DESCRIPTION
Avoiding division by zero error. If the mean GT for some reason is zero, it's reasonable to set scaled depth to zero as well.

Added test example into MultiQC_TestData.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

Test data: https://github.com/ewels/MultiQC_TestData/pull/230