### PR TITLE
Add timezone to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added new config option `custom_table_header_config` to override any config for any table header
 - Fixed edge-case bug in custom content where a `description` that doesn't terminate in `.` gave duplicate section descriptions.
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
+- Add timezone to time in reports
 
 ### New Modules
 

--- a/multiqc/utils/config.py
+++ b/multiqc/utils/config.py
@@ -53,7 +53,7 @@ with open(searchp_fn) as f:
 # Other defaults that can't be set in YAML
 data_tmp_dir = "/tmp"  # will be overwritten by core script
 modules_dir = os.path.join(MULTIQC_DIR, "modules")
-creation_date = datetime.now().strftime("%Y-%m-%d, %H:%M")
+creation_date = datetime.now().astimezone().strftime("%Y-%m-%d, %H:%M %Z")
 working_dir = os.getcwd()
 analysis_dir = [os.getcwd()]
 output_dir = os.path.realpath(os.getcwd())


### PR DESCRIPTION
The time in reports is confusing because there is no timezone attached to it. This simply adds the timezone. An alternative approach would be to use ISO format, although this is slightly less human readable. We could also consider moving to UTC time.

```python3
# Current format
from datetime import datetime
datetime.now().strftime("%Y-%m-%d, %H:%M")
'2022-05-07, 14:47'
# New format
datetime.now().astimezone().strftime("%Y-%m-%d, %H:%M %Z")
'2022-05-07, 14:47 PDT'
# Alternative suggestion in UTC/ISO
import datetime
datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat(' ', timespec='minutes')
'2022-05-07 21:47+00:00'
```
- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated