### PR TITLE
Handle too long and low complexity in fastp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ _nothing yet.._
   - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
 - **Somalier**
   - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
+- **Fastp**
+  - Include low complexity and too long reads in filtering bar chart
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -359,7 +359,9 @@ class MultiqcModule(BaseMultiqcModule):
         keys["filtering_result_passed_filter_reads"] = {"name": "Passed Filter"}
         keys["filtering_result_low_quality_reads"] = {"name": "Low Quality"}
         keys["filtering_result_too_many_N_reads"] = {"name": "Too Many N"}
-        keys["filtering_result_too_short_reads"] = {"name": "Too short"}
+        keys["filtering_result_low_complexity_reads"] = {"name": "Low Complexity"}
+        keys["filtering_result_too_short_reads"] = {"name": "Too Short"}
+        keys["filtering_result_too_long_reads"] = {"name": "Too Long"}
 
         # Config for the plot
         pconfig = {


### PR DESCRIPTION
Fastp can filter for many reasons. MultiQC previously plotted filtering reasons, but oddly omitted reads that were too long or low complexity from this plot. This was deceiving as you could have 99% of reads filtered because they were too long, but the plot would show 100% of reads passed filtering because we didn't include this field. This fixes that.

![image](https://user-images.githubusercontent.com/10245822/171043123-fc22c247-ebe2-4ef8-adbe-c35f4ce87731.png)


- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
