### PR TITLE
fix zero division error in sambamba markdup module #1654

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ _nothing yet.._
   - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
+- **Sambamba Markdup**
+  - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/sambamba/markdup.py
+++ b/multiqc/modules/sambamba/markdup.py
@@ -84,14 +84,18 @@ class SambambaMarkdupMixin:
             if m:
                 d[key] = int(m[1])
         if len(d) != len(regexes):
-            log.debug("Could not find all markdup fields for '{}' - skippiung".format(f["fn"]))
+            log.debug("Could not find all markdup fields for '{}' - skipping".format(f["fn"]))
             return None
 
         # Calculate duplicate rate
         # NB: Single-end data will have 0 for sorted_end_pairs and single_unmatched_pairs
-        d["duplicate_rate"] = (
+        try:
+            d["duplicate_rate"] = (
             d["duplicate_reads"] / ((d["sorted_end_pairs"] * 2) + (d["single_ends"] - d["single_unmatched_pairs"]))
         ) * 100.0
+        except ZeroDivisionError:
+            d["duplicate_rate"] = 0
+            log.debug("Sambamba Markdup: zero division error for '{}'".format(f["fn"]))
 
         # Calculate some read counts from pairs - Paired End
         if d["sorted_end_pairs"] > 0:

--- a/multiqc/modules/sambamba/markdup.py
+++ b/multiqc/modules/sambamba/markdup.py
@@ -91,8 +91,8 @@ class SambambaMarkdupMixin:
         # NB: Single-end data will have 0 for sorted_end_pairs and single_unmatched_pairs
         try:
             d["duplicate_rate"] = (
-            d["duplicate_reads"] / ((d["sorted_end_pairs"] * 2) + (d["single_ends"] - d["single_unmatched_pairs"]))
-        ) * 100.0
+                d["duplicate_reads"] / ((d["sorted_end_pairs"] * 2) + (d["single_ends"] - d["single_unmatched_pairs"]))
+            ) * 100.0
         except ZeroDivisionError:
             d["duplicate_rate"] = 0
             log.debug("Sambamba Markdup: zero division error for '{}'".format(f["fn"]))


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [x] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [x] Code is tested and works locally (including with `--lint` flag)
- [x] `docs/README.md` is updated with link to below
- [x] `docs/modulename.md` is created
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work

This PR helps catch the zero-division problem in the sambamba markdup module referenced in https://github.com/ewels/MultiQC/issues/1654