### PR TITLE
Fix issue where bclconvert always assumed paired-end reads when setting cluster-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ _nothing yet.._
   - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
+- **BclConvert**
+  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 


### PR DESCRIPTION
This should resolve #1697 - we now set cluster length to read length, not read read length * 2, if we see from our RunInfo.xml that we have single-end reads.
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x ] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
