### PR TITLE
Fix module crashing due to missing field in report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ _nothing yet.._
   - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
+- **miRTop**
+  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/ewels/MultiQC/issues/1712))
 
 ## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 

--- a/multiqc/modules/mirtop/mirtop.py
+++ b/multiqc/modules/mirtop/mirtop.py
@@ -98,7 +98,8 @@ class MultiqcModule(BaseMultiqcModule):
             if cleaned_s_name in self.mirtop_data:
                 log.debug("Duplicate sample name found! Overwriting: {}".format(cleaned_s_name))
             parsed_data = content["metrics"][s_name]
-            parsed_data["read_count"] = parsed_data["isomiR_sum"] + parsed_data["ref_miRNA_sum"]
+            # Sum the isomiR and ref_miRNA counts. Ignore ref_miRNA if it is not present.
+            parsed_data["read_count"] = parsed_data["isomiR_sum"] + parsed_data.get("ref_miRNA_sum", 0)
             parsed_data["isomiR_perc"] = (parsed_data["isomiR_sum"] / parsed_data["read_count"]) * 100
             self.mirtop_data[cleaned_s_name] = parsed_data
 


### PR DESCRIPTION
The miRTop module was crashing due to `ref_miRNA_sum` missing in some cases as was reported in nf-core/smrnaseq#137 and #1712. This fixes this by defaulting to zero reads if the field is not present in the file. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
