### PR TITLE
nanostat: add check for quality scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _nothing yet.._
   - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/ewels/MultiQC/issues/1686))
 - **Nanostat**
   - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
-  - Fix bug where module would crash if input does not contain quality scores ([#1717]https://github.com/ewels/MultiQC/issues/1717)
+  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/ewels/MultiQC/issues/1717))
 - **Pangolin**
   - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
 - **Somalier**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ _nothing yet.._
   - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/ewels/MultiQC/issues/1686))
 - **Nanostat**
   - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
+  - Fix bug where module would crash if input does not contain quality scores ([#1717]https://github.com/ewels/MultiQC/issues/1717)
 - **Pangolin**
   - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
 - **Somalier**

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -54,6 +54,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Find and load any NanoStat reports
         self.nanostat_data = dict()
+        self.has_qscores = False
         self.has_aligned = False
         self.has_seq_summary = False
         self.has_fastq = False
@@ -83,7 +84,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.nanostat_stats_table("fasta")
 
         # Quality distribution Plot
-        if self.has_aligned or self.has_seq_summary or self.has_fastq:
+        if self.has_qscores:
             self.reads_by_quality_plot()
 
     def parse_nanostat_log(self, f):
@@ -109,6 +110,9 @@ class MultiqcModule(BaseMultiqcModule):
                 # Number of reads above Q score cutoff
                 val = int(parts[1].strip().split()[0])
                 nano_stats[key] = val
+
+        if ">Q5" in nano_stats:
+            self.has_qscores = True
 
         if "Total bases aligned" in nano_stats:
             stat_type = "aligned"


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/1717

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

Currently, the Nanostat module only checks if data was obtained from alignments, and then assumes that it contains quality scores.
With this change, it instead checks if the data actually contains quality scores, and skips plotting them if it's not the case.