### PR TITLE
Corrected 'outdir' flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ multiqc --file-list my_file_list.txt
 The report is called `multiqc_report.html` by default. Tab-delimited data files
 are created in `multiqc_data/`, containing additional information.
 You can use a custom name for the report with the `-n`/`--filename` parameter, or instruct
-MultiQC to create them in a subdirectory using the `-o`/`-outdir` parameter.
+MultiQC to create them in a subdirectory using the `-o`/`--outdir` parameter.
 
 Note that different MultiQC templates may have different defaults.
 


### PR DESCRIPTION
Missing a dash for the flag to work.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [x] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [x] Code is tested and works locally (including with `--lint` flag)
- [x] `docs/README.md` is updated with link to below
- [x] `docs/modulename.md` is created
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
