### PR TITLE
Add additional samtools flagstat column '% Mapped Reads'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
   - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
   - Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
+  - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 - **sortmerna**
   - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
 - **sexdeterrmine**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
 - **Sambamba Markdup**
   - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
+- **Samtools**
+  - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 
@@ -579,7 +581,6 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
   - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
   - Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
-  - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 - **sortmerna**
   - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
 - **sexdeterrmine**

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -36,14 +36,13 @@ class FlagstatReportMixin:
             self.write_data_file(self.samtools_flagstat, "multiqc_samtools_flagstat")
 
             # General Stats Table
-            flagstats_headers = dict()
+            flagstats_headers = OrderedDict()
             flagstats_headers["flagstat_total"] = {
                 "title": "{} Reads".format(config.read_count_prefix),
                 "description": "Total reads in the bam file ({})".format(config.read_count_desc),
                 "min": 0,
                 "modify": lambda x: x * config.read_count_multiplier,
                 "shared_key": "read_count",
-                "placement": 100.0,
                 "hidden": True,
             }
             flagstats_headers["mapped_passed"] = {
@@ -52,14 +51,12 @@ class FlagstatReportMixin:
                 "min": 0,
                 "modify": lambda x: x * config.read_count_multiplier,
                 "shared_key": "read_count",
-                "placement": 101.0,
             }
             flagstats_headers["mapped_passed_pct"] = {
                 "title": "% Reads Mapped",
                 "description": "% Reads Mapped in the bam file",
                 "min": 0,
                 "max": 100,
-                "placement": 102.0,
                 "suffix": "%",
                 "scale": "RdYlGn",
                 "hidden": True,

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -54,6 +54,16 @@ class FlagstatReportMixin:
                 "shared_key": "read_count",
                 "placement": 101.0,
             }
+            flagstats_headers["mapped_passed_pct"] = {
+                "title": "% Reads Mapped",
+                "description": "% Reads Mapped in the bam file",
+                "min": 0,
+                "max": 100,
+                "placement": 102.0,
+                "suffix": "%",
+                "scale": "RdYlGn",
+                "hidden": True,
+            }
             self.general_stats_addcols(self.samtools_flagstat, flagstats_headers)
 
             # Make dot plot of counts


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->
This pull request adds an optional additional column to the General Stats table of '% Mapped Reads' in BAM file. This percentage  can be useful to evaluate exhaustivity of metagenomics assemblies. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
