### PR TITLE
add fastp after filtering total reads to general stats table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
 - Add timezone to time in reports
 - Add nix flake support
+- Add total read count (after filtering) from fastp to general stats table
 
 ### New Modules
 

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -324,6 +324,14 @@ class MultiqcModule(BaseMultiqcModule):
             "shared_key": "base_count",
             "hidden": True,
         }
+        headers["after_filtering_total_reads"] = {
+            "title": "{} Reads After Filtering".format(config.read_count_prefix),
+            "description": "Total reads after filtering ({})".format(config.read_count_desc),
+            "min": 0,
+            "scale": "Blues",
+            "modify": lambda x: x * config.read_count_multiplier,
+            "shared_key": "read_count",
+        }
         headers["after_filtering_gc_content"] = {
             "title": "GC content",
             "description": "GC content after filtering",


### PR DESCRIPTION
It's useful to visualize total reads (after filtering).

Here's an example from the test-data repo:
![Screenshot 2022-08-14 at 22-50-43 MultiQC Report](https://user-images.githubusercontent.com/6404517/184557778-b498cd76-55e7-4048-9804-c0c1684bb7af.png)


- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated