### PR TITLE
Generate new screengrabs with rich-codex

### DIFF
--- a/docs/images/screenshots/fastqc-run.svg
+++ b/docs/images/screenshots/fastqc-run.svg
@@ -19,59 +19,59 @@
         font-weight: 700;
     }
 
-    .terminal-3604794008-matrix {
+    .terminal-2140784891-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3604794008-title {
+    .terminal-2140784891-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3604794008-r1 { fill: #c5c8c6 }
-.terminal-3604794008-r2 { fill: #608ab1 }
-.terminal-3604794008-r3 { fill: #98a84b }
-.terminal-3604794008-r4 { fill: #cc555a }
-.terminal-3604794008-r5 { fill: #c5c8c6;font-weight: bold }
-.terminal-3604794008-r6 { fill: #868887 }
+    .terminal-2140784891-r1 { fill: #c5c8c6 }
+.terminal-2140784891-r2 { fill: #608ab1 }
+.terminal-2140784891-r3 { fill: #98a84b }
+.terminal-2140784891-r4 { fill: #cc555a }
+.terminal-2140784891-r5 { fill: #c5c8c6;font-weight: bold }
+.terminal-2140784891-r6 { fill: #868887 }
     </style>
 
     <defs>
-    <clipPath id="terminal-3604794008-clip-terminal">
+    <clipPath id="terminal-2140784891-clip-terminal">
       <rect x="0" y="0" width="1304.3999999999999" height="267.4" />
     </clipPath>
-    <clipPath id="terminal-3604794008-line-0">
+    <clipPath id="terminal-2140784891-line-0">
     <rect x="0" y="1.5" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-1">
+<clipPath id="terminal-2140784891-line-1">
     <rect x="0" y="25.9" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-2">
+<clipPath id="terminal-2140784891-line-2">
     <rect x="0" y="50.3" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-3">
+<clipPath id="terminal-2140784891-line-3">
     <rect x="0" y="74.7" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-4">
+<clipPath id="terminal-2140784891-line-4">
     <rect x="0" y="99.1" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-5">
+<clipPath id="terminal-2140784891-line-5">
     <rect x="0" y="123.5" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-6">
+<clipPath id="terminal-2140784891-line-6">
     <rect x="0" y="147.9" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-7">
+<clipPath id="terminal-2140784891-line-7">
     <rect x="0" y="172.3" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-8">
+<clipPath id="terminal-2140784891-line-8">
     <rect x="0" y="196.7" width="1305.4" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3604794008-line-9">
+<clipPath id="terminal-2140784891-line-9">
     <rect x="0" y="221.1" width="1305.4" height="24.65"/>
             </clipPath>
     </defs>
@@ -83,20 +83,20 @@
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3604794008-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2140784891-clip-terminal)">
     
-    <g class="terminal-3604794008-matrix">
-    <text class="terminal-3604794008-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-3604794008-line-0)">$&#160;multiqc&#160;.</text><text class="terminal-3604794008-r1" x="1305.4" y="20" textLength="12.2" clip-path="url(#terminal-3604794008-line-0)">
-</text><text class="terminal-3604794008-r1" x="1305.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3604794008-line-1)">
-</text><text class="terminal-3604794008-r2" x="24.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3604794008-line-2)">/</text><text class="terminal-3604794008-r3" x="36.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3604794008-line-2)">/</text><text class="terminal-3604794008-r4" x="48.8" y="68.8" textLength="12.2" clip-path="url(#terminal-3604794008-line-2)">/</text><text class="terminal-3604794008-r5" x="73.2" y="68.8" textLength="85.4" clip-path="url(#terminal-3604794008-line-2)">MultiQC</text><text class="terminal-3604794008-r1" x="158.6" y="68.8" textLength="36.6" clip-path="url(#terminal-3604794008-line-2)">&#160;🔍&#160;</text><text class="terminal-3604794008-r6" x="207.4" y="68.8" textLength="146.4" clip-path="url(#terminal-3604794008-line-2)">|&#160;v1.13.dev0</text><text class="terminal-3604794008-r1" x="1305.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3604794008-line-2)">
-</text><text class="terminal-3604794008-r1" x="1305.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3604794008-line-3)">
-</text><text class="terminal-3604794008-r2" x="0" y="117.6" textLength="231.8" clip-path="url(#terminal-3604794008-line-4)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-3604794008-r1" x="231.8" y="117.6" textLength="1073.6" clip-path="url(#terminal-3604794008-line-4)">&#160;|&#160;Search&#160;path&#160;:&#160;/home/runner/work/MultiQC/MultiQC/test_data/data/modules/fastqc/v0.10.1</text><text class="terminal-3604794008-r1" x="1305.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3604794008-line-4)">
-</text><text class="terminal-3604794008-r1" x="0" y="142" textLength="890.6" clip-path="url(#terminal-3604794008-line-5)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;searching&#160;|&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;100%&#160;2/2&#160;&#160;</text><text class="terminal-3604794008-r1" x="1305.4" y="142" textLength="12.2" clip-path="url(#terminal-3604794008-line-5)">
-</text><text class="terminal-3604794008-r2" x="0" y="166.4" textLength="231.8" clip-path="url(#terminal-3604794008-line-6)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;fastqc</text><text class="terminal-3604794008-r1" x="231.8" y="166.4" textLength="219.6" clip-path="url(#terminal-3604794008-line-6)">&#160;|&#160;Found&#160;2&#160;reports</text><text class="terminal-3604794008-r1" x="1305.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3604794008-line-6)">
-</text><text class="terminal-3604794008-r2" x="0" y="190.8" textLength="231.8" clip-path="url(#terminal-3604794008-line-7)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-3604794008-r1" x="231.8" y="190.8" textLength="292.8" clip-path="url(#terminal-3604794008-line-7)">&#160;|&#160;Compressing&#160;plot&#160;data</text><text class="terminal-3604794008-r1" x="1305.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3604794008-line-7)">
-</text><text class="terminal-3604794008-r2" x="0" y="215.2" textLength="231.8" clip-path="url(#terminal-3604794008-line-8)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-3604794008-r1" x="231.8" y="215.2" textLength="439.2" clip-path="url(#terminal-3604794008-line-8)">&#160;|&#160;Report&#160;&#160;&#160;&#160;&#160;&#160;:&#160;multiqc_report.html</text><text class="terminal-3604794008-r1" x="1305.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3604794008-line-8)">
-</text><text class="terminal-3604794008-r2" x="0" y="239.6" textLength="231.8" clip-path="url(#terminal-3604794008-line-9)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-3604794008-r1" x="231.8" y="239.6" textLength="353.8" clip-path="url(#terminal-3604794008-line-9)">&#160;|&#160;Data&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;:&#160;multiqc_data</text><text class="terminal-3604794008-r1" x="1305.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3604794008-line-9)">
-</text><text class="terminal-3604794008-r2" x="0" y="264" textLength="231.8" clip-path="url(#terminal-3604794008-line-10)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-3604794008-r1" x="231.8" y="264" textLength="231.8" clip-path="url(#terminal-3604794008-line-10)">&#160;|&#160;MultiQC&#160;complete</text><text class="terminal-3604794008-r1" x="1305.4" y="264" textLength="12.2" clip-path="url(#terminal-3604794008-line-10)">
+    <g class="terminal-2140784891-matrix">
+    <text class="terminal-2140784891-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-2140784891-line-0)">$&#160;multiqc&#160;.</text><text class="terminal-2140784891-r1" x="1305.4" y="20" textLength="12.2" clip-path="url(#terminal-2140784891-line-0)">
+</text><text class="terminal-2140784891-r1" x="1305.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2140784891-line-1)">
+</text><text class="terminal-2140784891-r2" x="24.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2140784891-line-2)">/</text><text class="terminal-2140784891-r3" x="36.6" y="68.8" textLength="12.2" clip-path="url(#terminal-2140784891-line-2)">/</text><text class="terminal-2140784891-r4" x="48.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2140784891-line-2)">/</text><text class="terminal-2140784891-r5" x="73.2" y="68.8" textLength="85.4" clip-path="url(#terminal-2140784891-line-2)">MultiQC</text><text class="terminal-2140784891-r1" x="158.6" y="68.8" textLength="36.6" clip-path="url(#terminal-2140784891-line-2)">&#160;🔍&#160;</text><text class="terminal-2140784891-r6" x="207.4" y="68.8" textLength="85.4" clip-path="url(#terminal-2140784891-line-2)">|&#160;v1.13</text><text class="terminal-2140784891-r1" x="1305.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2140784891-line-2)">
+</text><text class="terminal-2140784891-r1" x="1305.4" y="93.2" textLength="12.2" clip-path="url(#terminal-2140784891-line-3)">
+</text><text class="terminal-2140784891-r2" x="0" y="117.6" textLength="231.8" clip-path="url(#terminal-2140784891-line-4)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-2140784891-r1" x="231.8" y="117.6" textLength="1073.6" clip-path="url(#terminal-2140784891-line-4)">&#160;|&#160;Search&#160;path&#160;:&#160;/home/runner/work/MultiQC/MultiQC/test_data/data/modules/fastqc/v0.10.1</text><text class="terminal-2140784891-r1" x="1305.4" y="117.6" textLength="12.2" clip-path="url(#terminal-2140784891-line-4)">
+</text><text class="terminal-2140784891-r1" x="0" y="142" textLength="890.6" clip-path="url(#terminal-2140784891-line-5)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;searching&#160;|&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;100%&#160;2/2&#160;&#160;</text><text class="terminal-2140784891-r1" x="1305.4" y="142" textLength="12.2" clip-path="url(#terminal-2140784891-line-5)">
+</text><text class="terminal-2140784891-r2" x="0" y="166.4" textLength="231.8" clip-path="url(#terminal-2140784891-line-6)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;fastqc</text><text class="terminal-2140784891-r1" x="231.8" y="166.4" textLength="219.6" clip-path="url(#terminal-2140784891-line-6)">&#160;|&#160;Found&#160;2&#160;reports</text><text class="terminal-2140784891-r1" x="1305.4" y="166.4" textLength="12.2" clip-path="url(#terminal-2140784891-line-6)">
+</text><text class="terminal-2140784891-r2" x="0" y="190.8" textLength="231.8" clip-path="url(#terminal-2140784891-line-7)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-2140784891-r1" x="231.8" y="190.8" textLength="292.8" clip-path="url(#terminal-2140784891-line-7)">&#160;|&#160;Compressing&#160;plot&#160;data</text><text class="terminal-2140784891-r1" x="1305.4" y="190.8" textLength="12.2" clip-path="url(#terminal-2140784891-line-7)">
+</text><text class="terminal-2140784891-r2" x="0" y="215.2" textLength="231.8" clip-path="url(#terminal-2140784891-line-8)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-2140784891-r1" x="231.8" y="215.2" textLength="439.2" clip-path="url(#terminal-2140784891-line-8)">&#160;|&#160;Report&#160;&#160;&#160;&#160;&#160;&#160;:&#160;multiqc_report.html</text><text class="terminal-2140784891-r1" x="1305.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2140784891-line-8)">
+</text><text class="terminal-2140784891-r2" x="0" y="239.6" textLength="231.8" clip-path="url(#terminal-2140784891-line-9)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-2140784891-r1" x="231.8" y="239.6" textLength="353.8" clip-path="url(#terminal-2140784891-line-9)">&#160;|&#160;Data&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;:&#160;multiqc_data</text><text class="terminal-2140784891-r1" x="1305.4" y="239.6" textLength="12.2" clip-path="url(#terminal-2140784891-line-9)">
+</text><text class="terminal-2140784891-r2" x="0" y="264" textLength="231.8" clip-path="url(#terminal-2140784891-line-10)">|&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;multiqc</text><text class="terminal-2140784891-r1" x="231.8" y="264" textLength="231.8" clip-path="url(#terminal-2140784891-line-10)">&#160;|&#160;MultiQC&#160;complete</text><text class="terminal-2140784891-r1" x="1305.4" y="264" textLength="12.2" clip-path="url(#terminal-2140784891-line-10)">
 </text>
     </g>
     </g>


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [ ] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
- [ ] Code is tested and works locally (including with `--lint` flag)
- [ ] `docs/README.md` is updated with link to below
- [ ] `docs/modulename.md` is created
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] Report sections have a description and help text (with `self.add_section`)
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [ ] Module does not do any significant computational work
