### PR TITLE
Remove empty bcftools stats variant depths plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### MultiQC updates
 
+- Bugfix: Do not show empty bcftools stats variant depth plots[#1770](https://github.com/ewels/MultiQC/pull/1770)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - **Samtools**
   - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 - **Bcftools stats**
-  - Bugfix: Do not show empty bcftools stats variant depth plots[#1770](https://github.com/ewels/MultiQC/pull/1770)
+  - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### MultiQC updates
 
-- Bugfix: Do not show empty bcftools stats variant depth plots[#1770](https://github.com/ewels/MultiQC/pull/1770)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
@@ -38,6 +37,8 @@
   - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 - **Samtools**
   - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
+- **Bcftools stats**
+  - Bugfix: Do not show empty bcftools stats variant depth plots[#1770](https://github.com/ewels/MultiQC/pull/1770)
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -187,6 +187,7 @@ class StatsReportMixin:
         self.bcftools_stats_vqc_transi = {k: v for k, v in self.bcftools_stats_vqc_transi.items() if len(v) > 0}
         self.bcftools_stats_vqc_transv = {k: v for k, v in self.bcftools_stats_vqc_transv.items() if len(v) > 0}
         self.bcftools_stats_vqc_indels = {k: v for k, v in self.bcftools_stats_vqc_indels.items() if len(v) > 0}
+        depth_data = {k: v for k, v in depth_data.items() if len(v) > 0}
 
         # Filter to strip out ignored sample names
         self.bcftools_stats = self.ignore_samples(self.bcftools_stats)


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

The module bcftools stats would show empty variant depth plots if no data was there, but an extra line with a sample name. This can happen when there is no INFO/DP field in a vcf file. So this PR should solve the issue and avoid showing an empty plot in the MultiQC report. 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

