### PR TITLE
fix duplicate heatmap for kraken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
+- Fix Kraken duplicate heatmap to account for missing taxons
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
 - **Kraken**
   - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/ewels/MultiQC/pull/1779))
+  - Make heatmap full width
 - **malt**
   - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
 - **RSeQC**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
-- Fix Kraken duplicate heatmap to account for missing taxons
 
 ### New Modules
 
@@ -37,6 +36,8 @@
   - Create a report even if there's only Custom Content General Stats there
   - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
   - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
+- **Kraken**
+  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/ewels/MultiQC/pull/1779))
 - **malt**
   - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
 - **RSeQC**

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -413,7 +413,12 @@ class MultiqcModule(BaseMultiqcModule):
         """Add a heatmap showing the minimizer duplication top-5 species"""
 
         duplication = list()
-        pconfig = {"id": "kraken-topfive-duplication_plot", "title": f"Kraken 2: Top {self.top_n} species duplication"}
+        pconfig = {
+            "id": "kraken-topfive-duplication_plot",
+            "title": f"Kraken 2: Top {self.top_n} species duplication",
+            "square": False,
+            "xcats_samples": False,
+        }
 
         rank_code = "S"
         rank_data = dict()

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -440,7 +440,7 @@ class MultiqcModule(BaseMultiqcModule):
                     counts_shown[s_name] = 0
 
                 if classif not in rank_data[s_name]:
-                    rank_data[s_name][classif] = 0
+                    rank_data[s_name][classif] = None
 
                 try:
                     row = next(row for row in d if row["rank_code"] == rank_code and row["classif"] == classif)

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -438,18 +438,24 @@ class MultiqcModule(BaseMultiqcModule):
                     rank_data[s_name] = dict()
                 if s_name not in counts_shown:
                     counts_shown[s_name] = 0
-                for row in d:
-                    if row["rank_code"] == rank_code:
-                        if row["classif"] == classif:
-                            if classif not in rank_data[s_name]:
-                                rank_data[s_name][classif] = 0
-                            try:
-                                rank_data[s_name][classif] = row["minimizer_duplication"]
-                            except KeyError:
-                                del rank_data[s_name]
-                                if not showed_warning:
-                                    log.warning("Kraken2 reports of different versions were found")
-                                    showed_warning = True
+
+                if classif not in rank_data[s_name]:
+                    rank_data[s_name][classif] = 0
+
+                try:
+                    row = next(row for row in d if row["rank_code"] == rank_code and row["classif"] == classif)
+                except StopIteration:
+                    # if nothing is found at the rank + classification, leave as 0
+                    continue
+
+                try:
+                    rank_data[s_name][classif] = row["minimizer_duplication"]
+                except KeyError:
+                    del rank_data[s_name]
+                    if not showed_warning:
+                        log.warning("Kraken2 reports of different versions were found")
+                        showed_warning = True
+
         # Strip empty samples
         for sample, vals in dict(rank_data).items():
             if len(vals) == 0:

--- a/multiqc/plots/heatmap.py
+++ b/multiqc/plots/heatmap.py
@@ -52,10 +52,11 @@ def highcharts_heatmap(data, xcats, ycats, pconfig=None):
     for i, arr in enumerate(data):
         for j, val in enumerate(arr):
             pdata.append([j, i, val])
-            if minval is None or val < minval:
-                minval = val
-            if maxval is None or val > maxval:
-                maxval = val
+            if val is not None:
+                if minval is None or val < minval:
+                    minval = val
+                if maxval is None or val > maxval:
+                    maxval = val
 
     if "min" not in pconfig:
         pconfig["min"] = minval


### PR DESCRIPTION
The kraken module takes the top 5 taxons and shows duplication across samples.

The problem is when some samples don't include those taxons. The heatmap "collapses left" because of how the dict is turned into a list:
![Screenshot 2022-10-13 at 14-49-41 Screenshot 2022-10-12 at 16-20-36 MultiQC Report png (PNG Image 590 × 508 pixels)](https://user-images.githubusercontent.com/6404517/195630700-b25d14d0-8c09-4798-a5b4-f992890b396f.png)

This means the duplication amount shown on the second row is actually for the wrong taxon!

Really, we should fill in `None` (or 0?) when a taxon isn't present in a sample. After fixing:
![Screenshot 2022-10-13 at 15-52-49 MultiQC Report](https://user-images.githubusercontent.com/6404517/195645330-faefd384-b4b6-453f-a1f3-cb9c3c19bf63.png)



- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
