### PR TITLE
Update gene_body_coverage.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### MultiQC updates
 
-- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself (https://github.com/ewels/MultiQC/pull/1792). 
+- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself (https://github.com/ewels/MultiQC/pull/1792)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### MultiQC updates
 
-- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself. 
+- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself (https://github.com/ewels/MultiQC/pull/1792). 
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### MultiQC updates
 
+- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself. 
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### MultiQC updates
 
-- Update geneBody_coverage from RSeQC module. Normalized coverages ( ie, y-axis values) are computing using a similar formula used by RSeQC itself (https://github.com/ewels/MultiQC/pull/1792)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
@@ -26,6 +25,8 @@
 
 ### Module updates
 
+- **Bcftools stats**
+  - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
 - **Custom content**
@@ -34,12 +35,12 @@
   - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
 - **malt**
   - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
+- **RSeQC**
+  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/ewels/MultiQC/pull/1792))
 - **Sambamba Markdup**
   - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 - **Samtools**
   - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
-- **Bcftools stats**
-  - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 

--- a/multiqc/modules/rseqc/gene_body_coverage.py
+++ b/multiqc/modules/rseqc/gene_body_coverage.py
@@ -87,14 +87,16 @@ def parse_reports(self):
         for s_name in self.gene_body_cov_hist_counts:
             self.gene_body_cov_hist_percent[s_name] = OrderedDict()
             total = sum(self.gene_body_cov_hist_counts[s_name].values())
+            min_cov = min(self.gene_body_cov_hist_counts[s_name].values())
+            max_cov = max(self.gene_body_cov_hist_counts[s_name].values())
             for k, v in self.gene_body_cov_hist_counts[s_name].items():
-                self.gene_body_cov_hist_percent[s_name][k] = (v / total) * 100
+                self.gene_body_cov_hist_percent[s_name][k] = (v - min_cov) / (max_cov - min_cov)
 
         # Add line graph to section
         pconfig = {
             "id": "rseqc_gene_body_coverage_plot",
             "title": "RSeQC: Gene Body Coverage",
-            "ylab": "% Coverage",
+            "ylab": "Coverage",
             "xlab": "Gene Body Percentile (5' -> 3')",
             "xmin": 0,
             "xmax": 100,

--- a/multiqc/modules/rseqc/gene_body_coverage.py
+++ b/multiqc/modules/rseqc/gene_body_coverage.py
@@ -83,10 +83,11 @@ def parse_reports(self):
         # Write data to file
         self.write_data_file(self.gene_body_cov_hist_counts, "rseqc_gene_body_cov")
 
-        # Make a normalised percentage version of the data
+        # Make a normalised coverage for plotting using the formula (cov - min_cov) / (max_cov - min_cov)
         for s_name in self.gene_body_cov_hist_counts:
             self.gene_body_cov_hist_percent[s_name] = OrderedDict()
             total = sum(self.gene_body_cov_hist_counts[s_name].values())
+            # min_cov and max_cov are required to compute the normalized coverage
             min_cov = min(self.gene_body_cov_hist_counts[s_name].values())
             max_cov = max(self.gene_body_cov_hist_counts[s_name].values())
             for k, v in self.gene_body_cov_hist_counts[s_name].items():


### PR DESCRIPTION
Using a normalized coverage to make genebody coverage plot ( similar to the method used by RSeQC).

Uses the formula `norm_cov = ( cov - min(cov ) / ( max(cov) - min(cov) )` to compute normalized coverage.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
