### PR TITLE
Bugfix: Remove filtered samples from general stats table for Qualimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### MultiQC updates
 
-- Bugfix: Remove Qualimap results for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
@@ -42,6 +41,8 @@
   - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 - **Samtools**
   - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
+- **Qualimap**
+  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780))
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### MultiQC updates
 
+- Bugfix: Remove Qualimap results for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780)
 - Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
 - Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
 - Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))

--- a/multiqc/modules/qualimap/qualimap.py
+++ b/multiqc/modules/qualimap/qualimap.py
@@ -52,6 +52,9 @@ class MultiqcModule(BaseMultiqcModule):
         if sum(n.values()) == 0:
             raise UserWarning
 
+        # Remove filtered samples from general stats table
+        self.general_stats_data = self.ignore_samples(self.general_stats_data)
+
         # Add to the General Stats table (has to be called once per MultiQC module)
         self.general_stats_addcols(self.general_stats_data, self.general_stats_headers)
 


### PR DESCRIPTION
This fixes #1780

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated