### PR TITLE
Update Qualimap: add additional entries for qualimap when region stats present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 - **Samtools**
   - Added additional (by default hidden) column for `flagstat` that displays percentage of mapped reads in a bam ([#1733](https://github.com/ewels/MultiQC/issues/1733))
+- **Qualimap**
+  - Added additional (by default hidden) columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - **Samtools**
   - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 - **Qualimap**
-  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default)
+  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/ewels/MultiQC/pull/1798))
   - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780))
 
 ## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -81,41 +81,49 @@ def parse_reports(self):
 def parse_genome_results(self, f):
     """Parse the contents of the Qualimap BamQC genome_results.txt file"""
     regexes = {
-        "bam_file": r"bam file = (.+)",
-        "total_reads": r"number of reads = ([\d,]+)",
-        "mapped_reads": r"number of mapped reads = ([\d,]+)",
-        "mapped_bases": r"number of mapped bases = ([\d,]+)",
-        "sequenced_bases": r"number of sequenced bases = ([\d,]+)",
-        "mean_insert_size": r"mean insert size = ([\d,\.]+)",
-        "median_insert_size": r"median insert size = ([\d,\.]+)",
-        "mean_mapping_quality": r"mean mapping quality = ([\d,\.]+)",
-        "general_error_rate": r"general error rate = ([\d,\.]+)",
-        "mean_coverage": r"mean coverageData = ([\d,\.]+)",
-        "regions_size": r"regions size = ([\d,\.]+)",
-    }
-    regexes_secondary = {
-        "regions_mapped_reads": r"number of mapped reads = ([\d,]+)",
+        "Input": {
+            "bam_file": r"bam file = (.+)",
+        },
+        "Globals": {
+            "total_reads": r"number of reads = ([\d,]+)",
+            "mapped_reads": r"number of mapped reads = ([\d,]+)",
+            "mapped_bases": r"number of mapped bases = ([\d,]+)",
+            "sequenced_bases": r"number of sequenced bases = ([\d,]+)",
+        },
+        "Insert size": {
+            "mean_insert_size": r"mean insert size = ([\d,\.]+)",
+            "median_insert_size": r"median insert size = ([\d,\.]+)",
+        },
+        "Mapping quality": {
+            "mean_mapping_quality": r"mean mapping quality = ([\d,\.]+)",
+        },
+        "Mismatches and indels": {
+            "general_error_rate": r"general error rate = ([\d,\.]+)",
+        },
+        "Coverage": {
+            "mean_coverage": r"mean coverageData = ([\d,\.]+)",
+        },
+        "Globals inside": {
+            "regions_size": r"regions size = ([\d,\.]+)",
+            "regions_mapped_reads": r"number of mapped reads = ([\d,]+)",  # WARNING: Same as in Globals
+        },
     }
     d = dict()
-    for k, r in regexes.items():
-        r_search = re.search(r, f["f"], re.MULTILINE)
-        if r_search:
-            if "\d" in r:
-                try:
-                    d[k] = float(r_search.group(1).replace(",", ""))
-                except ValueError:
-                    d[k] = r_search.group(1)
-            else:
-                d[k] = r_search.group(1)
-
-    for k, r in regexes_secondary.items():
-        r_search = re.findall(r, f["f"], re.MULTILINE)
-        if len(r_search) > 1:
-            if "\d" in r:
-                try:
-                    d[k] = float(r_search[1].replace(",", ""))
-                except ValueError:
-                    d[k] = r_search[1]
+    section = None
+    for line in f["f"].splitlines():
+        if line.startswith(">>>>>>>"):
+            section = line[8:]
+        elif section:
+            for k, r in regexes.get(section, {}).items():
+                r_search = re.search(r, line)
+                if r_search:
+                    if "\d" in r:
+                        try:
+                            d[k] = float(r_search.group(1).replace(",", ""))
+                        except ValueError:
+                            d[k] = r_search.group(1)
+                    else:
+                        d[k] = r_search.group(1)
 
     # Check we have an input filename
     if "bam_file" not in d:

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -91,6 +91,10 @@ def parse_genome_results(self, f):
         "mean_mapping_quality": r"mean mapping quality = ([\d,\.]+)",
         "general_error_rate": r"general error rate = ([\d,\.]+)",
         "mean_coverage": r"mean coverageData = ([\d,\.]+)",
+        "regions_size": r"regions size = ([\d,\.]+)",
+    }
+    regexes_secondary = {
+        "regions_mapped_reads": r"number of mapped reads = ([\d,]+)",
     }
     d = dict()
     for k, r in regexes.items():
@@ -103,6 +107,17 @@ def parse_genome_results(self, f):
                     d[k] = r_search.group(1)
             else:
                 d[k] = r_search.group(1)
+
+    for k, r in regexes_secondary.items():
+        r_search = re.findall(r, f["f"], re.MULTILINE)
+        print(r_search)
+        if len(r_search) > 1:
+            if "\d" in r:
+                try:
+                    d[k] = float(r_search[1].replace(",", ""))
+                except ValueError:
+                    d[k] = r_search[1]
+
     # Check we have an input filename
     if "bam_file" not in d:
         log.debug("Couldn't find an input filename in genome_results file {}".format(f["fn"]))
@@ -119,6 +134,8 @@ def parse_genome_results(self, f):
         self.general_stats_data[s_name]["percentage_aligned"] = d["percentage_aligned"]
         self.general_stats_data[s_name]["general_error_rate"] = d["general_error_rate"] * 100
         self.general_stats_data[s_name]["mean_coverage"] = d["mean_coverage"]
+        self.general_stats_data[s_name]["regions_size"] = d["regions_size"]
+        self.general_stats_data[s_name]["regions_mapped_reads"] = d["regions_mapped_reads"]
     except KeyError:
         pass
 
@@ -590,6 +607,20 @@ def general_stats_headers(self):
         "suffix": "%",
         "scale": "OrRd",
         "format": "{0:.2f}",
+        "hidden": True,
+    }
+    self.general_stats_headers["regions_size"] = {
+        "title": "{} Region size".format(config.read_count_prefix),
+        "description": "Size of target region",
+        "suffix": " bp",
+        "scale": "RdYlGn",
+        "hidden": True,
+    }
+    self.general_stats_headers["regions_mapped_reads"] = {
+        "title": "{} Aligned".format(config.read_count_prefix),
+        "description": "Number of mapped reads on target region ({})".format(config.read_count_desc),
+        "scale": "RdYlGn",
+        "shared_key": "read_count",
         "hidden": True,
     }
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -110,7 +110,6 @@ def parse_genome_results(self, f):
 
     for k, r in regexes_secondary.items():
         r_search = re.findall(r, f["f"], re.MULTILINE)
-        print(r_search)
         if len(r_search) > 1:
             if "\d" in r:
                 try:
@@ -613,7 +612,7 @@ def general_stats_headers(self):
         "title": "{} Region size".format(config.read_count_prefix),
         "description": "Size of target region",
         "suffix": " bp",
-        "scale": "RdYlGn",
+        "scale": "PuBuGn",
         "hidden": True,
     }
     self.general_stats_headers["regions_mapped_reads"] = {

--- a/multiqc/modules/snippy/snippy.py
+++ b/multiqc/modules/snippy/snippy.py
@@ -54,7 +54,9 @@ class MultiqcModule(BaseMultiqcModule):
             if f["s_name"] in self.snippy_data:
                 log.debug("Duplicate sample name found for snippy! Overwriting: {}".format(f["s_name"]))
             # Add the file data under the key filename
-            self.snippy_data[f["s_name"]] = self.parse_snippy_txt(f["f"])
+            data = self.parse_snippy_txt(f["f"])
+            if data:
+                self.snippy_data[f["s_name"]] = data
 
             self.add_data_source(f, section="snippy")
 
@@ -99,6 +101,8 @@ class MultiqcModule(BaseMultiqcModule):
             split_line = line.strip().split("\t")
             if split_line[0] in self.snippy_col:
                 data[split_line[0]] = int(split_line[1])
+        if len(data) == 0:
+            return False
         for col in self.snippy_col:
             if col not in data:
                 data[col] = 0


### PR DESCRIPTION
The current Qualimap module does not pick up statistics relevant for when stats on  particular regions are generated via a bed file. This PR adds support for displaying these statistics in the general stats table (when the parrticular entries are present)

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

<!-- If this PR is for a NEW module - delete if not -->

- [x] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR: https://github.com/ewels/MultiQC_TestData/pull/246
