### PR TITLE
fastp: use passed filter reads instead of after filter total reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
-- Update fastp to use passing filter reads from filtering results, rather than total reads after filtering ([relevant issue](https://github.com/OpenGene/fastp/issues/367))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
+- Update fastp to use passing filter reads from filtering results, rather than total reads after filtering ([relevant issue](https://github.com/OpenGene/fastp/issues/367))
 
 ### New Modules
 

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -324,7 +324,7 @@ class MultiqcModule(BaseMultiqcModule):
             "shared_key": "base_count",
             "hidden": True,
         }
-        headers["after_filtering_total_reads"] = {
+        headers["filtering_result_passed_filter_reads"] = {
             "title": "{} Reads After Filtering".format(config.read_count_prefix),
             "description": "Total reads after filtering ({})".format(config.read_count_desc),
             "min": 0,


### PR DESCRIPTION
Amends a PR I cut a while ago: https://github.com/ewels/MultiQC/pull/1744

Relevant issue: https://github.com/OpenGene/fastp/issues/367

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated