### PR TITLE
bclconvert: handle different r1 and r2 lengths instead of assuming they're the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
   - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
-  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1174](https://github.com/ewels/MultiQC/issues/1174)) 
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1174](https://github.com/ewels/MultiQC/issues/1174))
 - **Bustools**
   - Show median reads per barcode statistic
 - **Custom content**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1174](https://github.com/ewels/MultiQC/issues/1174)) 
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
   - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))

--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -241,22 +241,32 @@ class MultiqcModule(BaseMultiqcModule):
             return True
         return False
 
+    def _get_r2_length(self, root):
+        for element in root.findall("./Run/Reads/Read"):
+            if element.get("Number") == "4" and element.get("IsIndexedRead") == "N":
+                return element.get("NumCycles")
+        log.error(
+            f"Expected RunInfo.xml file to have an element with property Number=4, IsIndexedRead=N, and a NumCycles property"
+        )
+        raise UserWarning
+
     def _parse_single_runinfo_file(self, runinfo_file):
-        # get run id and readlength from RunInfo.xml
+        # get run id and cluster length from RunInfo.xml
         try:
             root = ET.fromstring(runinfo_file["f"])
             run_id = root.find("Run").get("Id")
-            read_length = root.find("./Run/Reads/Read[1]").get(
+            read_length_r1 = root.find("./Run/Reads/Read[1]").get(
                 "NumCycles"
             )  # ET indexes first element at 1, so here we're getting the first NumCycles
         except:
             log.error(f"Could not parse RunInfo.xml to get RunID and read length in '{runinfo_file['root']}'")
             raise UserWarning
         if self._is_single_end_reads(root):
-            cluster_length = int(read_length)
+            cluster_length = int(read_length_r1)
         else:
-            cluster_length = int(read_length) * 2
-        return {"run_id": run_id, "read_length": int(read_length), "cluster_length": cluster_length}
+            read_length_r2 = self._get_r2_length(root)
+            cluster_length = int(read_length_r1) + int(read_length_r2)
+        return {"run_id": run_id, "cluster_length": cluster_length}
 
     def _find_log_files_and_sort(self, search_pattern, sort_field):
         logs = list()
@@ -281,6 +291,7 @@ class MultiqcModule(BaseMultiqcModule):
             raise UserWarning
 
         for idx, runinfo in enumerate(runinfos):
+
             rundata = self._parse_single_runinfo_file(runinfo)
 
             if runinfo["root"] != demuxes[idx]["root"]:
@@ -302,11 +313,12 @@ class MultiqcModule(BaseMultiqcModule):
 
             self.last_run_id = rundata["run_id"]
 
-            if self.cluster_length and rundata["cluster_length"] != self.cluster_length:
-                log.error(
-                    "Detected different read lengths across the RunXml files. This should not be - read length across all input directories must be the same."
-                )
-                raise UserWarning
+            if len(runinfos) > 1:
+                if self.cluster_length and rundata["cluster_length"] != self.cluster_length:
+                    log.error(
+                        "Detected different read lengths across the RunXml files. We cannot handle this - read length across all input directories must be the same."
+                    )
+                    raise UserWarning
             self.cluster_length = rundata["cluster_length"]
 
         return demuxes, qmetrics


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->
Relevant issue: https://github.com/ewels/MultiQC/issues/1774

For paired-end data, BclConvert now properly pulls out R1 and R2 read lengths from RunInfo.xml, and sums them to calculate cluster-length, instead of assuming the read lengths are identical and using R1*2 for cluster-length.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

