### PR TITLE
update bustools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
+- **Bustools**
+  - Show median reads per barcode statistic
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
   - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))

--- a/multiqc/modules/bustools/bustools.py
+++ b/multiqc/modules/bustools/bustools.py
@@ -81,6 +81,12 @@ class MultiqcModule(BaseMultiqcModule):
             "format": "{:,.0f}",
             "shared_key": "barcodes",
         }
+        self.headers["medianReadsPerBarcode"] = {
+            "title": "Median reads per barcode",
+            "scale": "RdYlGn",
+            "min": 0,
+            "format": "{:,.2f}",
+        }
         self.headers["meanReadsPerBarcode"] = {
             "title": "Mean reads per barcode",
             "scale": "BuGn",


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated

So I realized I simply forgot to add the median reads metric :facepalm:...

It's always reported in the output: https://github.com/ewels/MultiQC_TestData/blob/master/data/modules/bustools/0.40.0/inspect.json#L5 and I've tested the PR
![image](https://user-images.githubusercontent.com/15323399/203510367-bae7d15f-b20d-456a-934f-8624a65f51ab.png)
