### PR TITLE
Bclconvert handle single index paired end data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
   - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
-  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1174](https://github.com/ewels/MultiQC/issues/1174)) 
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/ewels/MultiQC/issues/1774)) 
+  - Handle single-index paired-end data correctly
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
   - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))

--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -243,14 +243,12 @@ class MultiqcModule(BaseMultiqcModule):
 
     def _get_r2_length(self, root):
         for element in root.findall("./Run/Reads/Read"):
-            if element.get("Number") == "3" and element.get("IsIndexedRead") == "N": # single-index paired-end data 
-                return element.get("NumCycles") 
+            if element.get("Number") == "3" and element.get("IsIndexedRead") == "N":
+                return element.get("NumCycles")  # single-index paired-end data
             if element.get("Number") == "4" and element.get("IsIndexedRead") == "N":
                 return element.get("NumCycles")
-        
-        log.error(
-            f"Expected RunInfo.xml file to have an element with property Number=4, IsIndexedRead=N, and a NumCycles property"
-        )
+
+        log.error(f"Could not figure out read 2 length from RunInfo.xml")
         raise UserWarning
 
     def _parse_single_runinfo_file(self, runinfo_file):

--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -243,8 +243,11 @@ class MultiqcModule(BaseMultiqcModule):
 
     def _get_r2_length(self, root):
         for element in root.findall("./Run/Reads/Read"):
+            if element.get("Number") == "3" and element.get("IsIndexedRead") == "N": # single-index paired-end data 
+                return element.get("NumCycles") 
             if element.get("Number") == "4" and element.get("IsIndexedRead") == "N":
                 return element.get("NumCycles")
+        
         log.error(
             f"Expected RunInfo.xml file to have an element with property Number=4, IsIndexedRead=N, and a NumCycles property"
         )


### PR DESCRIPTION
This ought to fix the issue outlined by Alexis in https://github.com/ewels/MultiQC/pull/1803 - single index paired end data now appropriately handled.

Also fixed a typo in changelog.md from that PR (issue 1774 was "bclconvert handles differnet R1 and R2 readlength correctly", but changelog said 1174)

- [x ] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
