### PR TITLE
mosdepth missing values imputed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   - Make heatmap full width
 - **malt**
   - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
+- **Mosdepth**
+  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/ewels/MultiQC/pull/1810))
 - **Picard**
   - HsMetrics: Allow custom columns in General Stats too, with `HsMetrics_genstats_table_cols` and `HsMetrics_genstats_table_cols_hidden`
 - **RSeQC**

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -292,13 +292,16 @@ class MultiqcModule(BaseMultiqcModule):
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):
         for s_name, d in cumcov_dist_data.items():
             dist_subset = {t: data for t, data in d.items() if t in threshs}
+            num_skipped = 0
             for t in threshs:
                 if int(t) in dist_subset:
                     genstats[s_name][f"{t}_x_pc"] = dist_subset[t]
                 else:
-                    log.debug(
-                        f"{t} not found in MosDepth output and will not be included in general stats table for sample {s_name}"
-                    )
+                    num_skipped += 1
+            if num_skipped > 0:
+                log.debug(
+                    f"{num_skipped} thresholds not found in MosDepth output and will not be included in general stats table for sample {s_name}"
+                )
 
         for t in threshs:
             genstats_headers[f"{t}_x_pc"] = {

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -292,16 +292,9 @@ class MultiqcModule(BaseMultiqcModule):
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):
         for s_name, d in cumcov_dist_data.items():
             dist_subset = {t: data for t, data in d.items() if t in threshs}
-            num_skipped = 0
             for t in threshs:
                 if int(t) in dist_subset:
                     genstats[s_name][f"{t}_x_pc"] = dist_subset[t]
-                else:
-                    num_skipped += 1
-            if num_skipped > 0:
-                log.debug(
-                    f"{num_skipped} thresholds not found in MosDepth output and will not be included in general stats table for sample {s_name}"
-                )
 
         for t in threshs:
             genstats_headers[f"{t}_x_pc"] = {

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -290,30 +290,12 @@ class MultiqcModule(BaseMultiqcModule):
         return genstats, cumcov_dist_data, cov_dist_data, xmax, perchrom_avg_data
 
     def genstats_cov_thresholds(self, genstats, genstats_headers, cumcov_dist_data, threshs, hidden_threshs):
-        def recursive_get_value(d: OrderedDict, t: int) -> int:
-            """
-            If the depth threshold (t) is not in the OrderedDict, iterate up the depth values.
-            This means the % at the threshold will be estimated slightly lower but prevents zero values.
-            """
-            depths = list(d.keys())
-            if t in d:
-                return d[t]
-            else:
-                greater_than_t = [x for x in depths if x > t]
-                if len(greater_than_t) == 0:
-                    # No depths available greater than t
-                    log.debug(f"No values found for threshold {t}, assuming 0%")
-                    return 0
-                else:
-                    greater_than_t.sort()
-                    return recursive_get_value(d, greater_than_t[0])
-
         for s_name, d in cumcov_dist_data.items():
+            dist_subset = {t: data for t, data in d.items() if t in threshs}
             for t in threshs:
-                try:
-                    genstats[s_name][f"{t}_x_pc"] = recursive_get_value(d, int(t))
-                except KeyError:
-                    # If value doesn't exist, use zero
+                if int(t) in dist_subset:
+                    genstats[s_name][f"{t}_x_pc"] = dist_subset[t]
+                else:
                     genstats[s_name][f"{t}_x_pc"] = 0
 
         for t in threshs:

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -296,7 +296,9 @@ class MultiqcModule(BaseMultiqcModule):
                 if int(t) in dist_subset:
                     genstats[s_name][f"{t}_x_pc"] = dist_subset[t]
                 else:
-                    genstats[s_name][f"{t}_x_pc"] = 0
+                    log.debug(
+                        f"{t} not found in MosDepth output and will not be included in general stats table for sample {s_name}"
+                    )
 
         for t in threshs:
             genstats_headers[f"{t}_x_pc"] = {


### PR DESCRIPTION
Changes:
 - Mosdepth output has missing values in `*.{region,global}.dist.txt`
 - This change to module fills any missing values with the next value
 - e.g., if there is 100% at 100X and 80% at 80X, the value at 90X will be recorded as 80X
 - Previously, this would have been recorded at 0%.
 - This may underestimate coverage slightly but it's not clear from MosDepth docs how it should be handled.
 - See https://github.com/brentp/mosdepth/issues/190

---

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated