### PR TITLE
Improve speed of parsing output file headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
+- Parsing output file column headers is much faster.
 
 ### New Modules
 

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -73,12 +73,19 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
             try:
                 # Convert keys to strings
                 data = {str(k): v for k, v in data.items()}
-                # Get all headers
-                h = ["Sample"]
-                for sn in sorted(data.keys()):
-                    for k in data[sn].keys():
-                        if type(data[sn][k]) is not dict and k not in h:
-                            h.append(str(k))
+                # Get all headers from the data, except if data is a dictionary (i.e. has >1 dimensions)
+                # Use list -> set -> list to get only unique values
+                h = list(
+                    set(
+                        [
+                            str(data_header)
+                            for sample_data in data.values()
+                            for data_header in sample_data.keys()
+                            if type(sample_data[data_header]) is not dict
+                        ]
+                    )
+                )
+                h += ["Sample"]
                 if sort_cols:
                     h = sorted(h)
 

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -74,9 +74,9 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
                 # Convert keys to strings
                 data = {str(k): v for k, v in data.items()}
                 # Get all headers from the data, except if data is a dictionary (i.e. has >1 dimensions)
-                # Use list -> set -> list to get only unique values
+                # Use list -> dict -> list to get only unique values
                 h = list(
-                    set(
+                    dict.fromkeys(
                         [
                             str(data_header)
                             for sample_data in data.values()
@@ -85,7 +85,8 @@ def write_data_file(data, fn, sort_cols=False, data_format=None):
                         ]
                     )
                 )
-                h += ["Sample"]
+                # Add Sample header in to first element
+                h.insert(0, "Sample")
                 if sort_cols:
                     h = sorted(h)
 


### PR DESCRIPTION
Parsing the output data file headers was using a nested loop. This was quite slow, so I replaced it with a list comprehension. This works much, much faster but is harder to read. I've added some comments to explain what it is doing.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
