### PR TITLE
1813 Remove Python 3.6 from testing

### DIFF
--- a/.github/workflows/multiqc_linux.yml
+++ b/.github/workflows/multiqc_linux.yml
@@ -45,7 +45,7 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     timeout-minutes: 10
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add CI testing for Python 3.10 and 3.11
 - Add new code formatting tool [isort](https://pycqa.github.io/isort/) to standardise the order and formatting of Python module imports
 - Remove Python 2-3 compatability `from __future__` imports
+- Removed CI testing for Python 3.6
 
 ### New Modules
 


### PR DESCRIPTION
Python 3.6 is unavailable on Ubuntu 20.04.1, which prevents any testing occurring. This removes Python 3.6 from the testing framework on linux.

Fixes #1813 

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
