### PR TITLE
update busco colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
   - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1174](https://github.com/ewels/MultiQC/issues/1174))
+- **BUSCO**
+  - Update BUSCO pass/warning/fail scheme to be more clear for users
 - **Bustools**
   - Show median reads per barcode statistic
 - **Custom content**

--- a/multiqc/modules/busco/busco.py
+++ b/multiqc/modules/busco/busco.py
@@ -86,8 +86,8 @@ class MultiqcModule(BaseMultiqcModule):
             if self.busco_data[s_name].get("lineage_dataset") == lin:
                 data[s_name] = self.busco_data[s_name]
 
-        plot_keys = ["complete_single_copy", "complete_duplicated", "fragmented", "missing"]
-        plot_cols = ["#7CB5EC", "#434348", "#F7A35C", "#FF3C50"]
+        plot_keys = ["complete_single_copy", "fragmented", "complete_duplicated", "missing"]
+        plot_cols = ["#31a354", "#fee8c8", "#fdbb84", "#e34a33"]
         keys = OrderedDict()
         for k, col in zip(plot_keys, plot_cols):
             keys[k] = {"name": self.busco_keys[k], "color": col}


### PR DESCRIPTION
I've changed the colours to more closely resemble a pass/warning/fail scheme to make it clearer for users of the module that there should only be single copies of the single copy orthologs. I have also changed the order that items are plotted to reflect the severity of the warning/failure and match the colour gradient. In general, we feel that duplicated BUSCOs is a more severe error than fragmented BUSCOs, as "fragmentation" is a common finding on nanopore sequencing data and rather reflects frameshifts/erroneous stop codons, rather than duplicated BUSCOs which is usually from erroneous binning, barcode crosstalk or contamination. Feel free to suggest other colours.

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
