### PR TITLE
fix (dragen_fastqc): clear accumulators between samples and mates

### DIFF
--- a/multiqc/modules/dragen_fastqc/content_metrics.py
+++ b/multiqc/modules/dragen_fastqc/content_metrics.py
@@ -40,11 +40,11 @@ class DragenContentMetrics(BaseMultiqcModule):
     def n_content_plot(self):
         """Create the HTML for the per base N content plot"""
         data = dict()
-        totals = defaultdict(int)
-        non_n = defaultdict(int)
         GROUP = "POSITIONAL BASE CONTENT"
         for s_name in sorted(self.dragen_fastqc_data):
             for mate in sorted(self.dragen_fastqc_data[s_name]):
+                totals = defaultdict(int)
+                non_n = defaultdict(int)
 
                 # Count total bases
                 total_group_data = self.dragen_fastqc_data[s_name][mate][GROUP]


### PR DESCRIPTION
The existing implementation of the N content plot for dragen_fastqc incorrectly maintains counts between samples and mates, causing the computed per-site N rate to be order-dependent (typically on alphabetical ordering of input sample IDs), and to approach a cross-sample/read/lane/etc. average. This isn't immediately apparent from output plots when the QCed libraries are performing well, but becomes easily visible when one of the lanes, for example, has a large spike in N content.

Closes #1830 

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated
  - not including a change here, as dragen_fastqc itself is not released
  