### PR TITLE
fix: out of bounds error in bcftools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - **Bcftools stats**
   - Bugfix: Do not show empty bcftools stats variant depth plots[#1777](https://github.com/ewels/MultiQC/pull/1777)
+  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/ewels/MultiQC/issues/1832))
 - **BclConvert**
   - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
   - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/ewels/MultiQC/issues/1774))

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -119,7 +119,10 @@ class StatsReportMixin:
                         int(s[3].strip()) + int(s[4].strip()) + int(s[5].strip())
                     )
                     self.bcftools_stats_sample_variants[s_name][sample]["nIndels"] = int(s[8].strip())
-                    nMissing = int(s[13].strip())
+                    if len(s) >= 14:
+                        nMissing = int(s[13].strip())
+                    else:
+                        nMissing = 0
                     nPresent = self.bcftools_stats[s_name]["number_of_records"] - nMissing
                     self.bcftools_stats_sample_variants[s_name][sample]["nOther"] = (
                         nPresent


### PR DESCRIPTION
Add a bounds check for PSC nMissing, as this column might be unavailable on certain versions of bcftools.

Fixes #1832 