### PR TITLE
Upgrade pip before installing multiqc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/src/multiqc
 # - Remove MultiQC source directory
 # - Add custom group and user
 RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/* && \
+    pip install --upgrade pip && \
     pip install -v --no-cache-dir . && \
     find /usr/local/lib/python3.11 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | xargs rm -r && \
     rm -rf "/usr/src/multiqc/" && \


### PR DESCRIPTION
Patch to allow multi-platform build based on https://stackoverflow.com/a/70196702/6946787.  

Should resolve error found at https://github.com/ewels/MultiQC/actions/runs/3825879135/jobs/6509196703#step:7:7882 but can't test this locally myself on all platforms
