### PR TITLE
Specify 64-bit images only for GH actions build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,8 @@ jobs:
         with:
           # All available with python:3.11-slim are:
           # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          # But 32-bit binaries likely require compilation from source so stick with linux/amd64 and linux/arm64 for now
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ewels/multiqc:dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,13 @@ WORKDIR /usr/src/multiqc
 RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/* && \
     pip install --upgrade pip && \
     pip install -v --no-cache-dir . && \
-    find /usr/local/lib/python3.11 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \) | xargs rm -r && \
+    apt-get clean -y && \
+    for cache_dir in $(find /usr/local/lib/python3.11 \( -iname '*.c' -o -iname '*.pxd' -o -iname '*.pyd' -o -iname '__pycache__' \)); do \
+      rm -rf "$cache_dir"; \
+    done; \
     rm -rf "/usr/src/multiqc/" && \
-    groupadd --gid 1000 multiqc && useradd -ms /bin/bash --create-home --gid multiqc --uid 1000 multiqc
+    groupadd --gid 1000 multiqc && \
+    useradd -ms /bin/bash --create-home --gid multiqc --uid 1000 multiqc
 
 # Set to be the new user
 USER multiqc


### PR DESCRIPTION
Some image cleaning - 
* Added apt-clean to image after apt installation
* Use for-loop over xargs for deleting cache dirs.
* Moved groupadd / useradd onto separate lines

