### PR TITLE
Fix exception with Cell Ranger 7.x web_summary.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Module updates
 
+- **Cell Ranger**
+  - Bugfix: avoid `KeyError` exception when parsing Cell Ranger 7.x web_summary.html
+
 ## [MultiQC v1.14](https://github.com/ewels/MultiQC/releases/tag/v1.14) - 2023-01-08
 
 ### MultiQC new features

--- a/multiqc/modules/cellranger/count.py
+++ b/multiqc/modules/cellranger/count.py
@@ -242,6 +242,9 @@ class CellRangerCountMixin:
         warnings = dict()
         alarms_list = summary["alarms"].get("alarms", [])
         for alarm in alarms_list:
+            # "Intron mode used" alarm added in Cell Ranger 7.0 lacks id
+            if "id" not in alarm:
+                continue
             warnings[alarm["id"]] = "FAIL"
             self.count_warnings_headers[alarm["id"]] = {
                 "title": alarm["id"],


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.md` has been updated

The new Cell Ranger module in MultiQC v1.14 fails with a `KeyError` exception when reading the attached [web_summary.html](https://github.com/ewels/MultiQC/files/10383978/web_summary.html.gz) that was generated by Cell Ranger 7.1:

```
$ multiqc t

  /// MultiQC 🔍 | v1.15.dev0

|           multiqc | Search path : /workspaces/MultiQC/t
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1/1  
╭────────────────────────────────────────── Oops! The 'cellranger' MultiQC module broke... ───────────────────────────────────────────╮
│ Please copy this log and report it at https://github.com/ewels/MultiQC/issues                                                       │
│ Please attach a file that triggers the error. The last file found was: t/web_summary.html                                           │
│                                                                                                                                     │
│ Traceback (most recent call last):                                                                                                  │
│   File "/usr/local/python/3.10.4/lib/python3.10/site-packages/multiqc/multiqc.py", line 654, in run                                 │
│     output = mod()                                                                                                                  │
│   File "/usr/local/python/3.10.4/lib/python3.10/site-packages/multiqc/modules/cellranger/cellranger.py", line 39, in __init__       │
│     n["count"] = self.parse_count_html()                                                                                            │
│   File "/usr/local/python/3.10.4/lib/python3.10/site-packages/multiqc/modules/cellranger/count.py", line 30, in parse_count_html    │
│     self.parse_count_report(f)                                                                                                      │
│   File "/usr/local/python/3.10.4/lib/python3.10/site-packages/multiqc/modules/cellranger/count.py", line 245, in parse_count_report │
│     warnings[alarm["id"]] = "FAIL"                                                                                                  │
│ KeyError: 'id'                                                                                                                      │
│                                                                                                                                     │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
|           multiqc | No analysis results found. Cleaning up..
|           multiqc | MultiQC complete
```

Since Cell Ranger 7.0, the `cellranger count` web summary has an informational alert labeled `Intron mode used` that mentions [intronic reads are now counted by default](https://support.10xgenomics.com/docs/intron-mode-rec) in that Cell Ranger version. That alert lacks an `id` property, causing the above KeyError exception.

This PR proposes ignoring the alerts/alarms that don't have an `id` key/property.

Result after this patch has been applied:


```
$ multiqc t

  /// MultiQC 🔍 | v1.15.dev0

|           multiqc | Search path : /workspaces/MultiQC/t
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1/1  
|        cellranger | Found 1 Cell Ranger count reports
|           multiqc | Compressing plot data
|           multiqc | Report      : multiqc_report.html
|           multiqc | Data        : multiqc_data
|           multiqc | MultiQC complete
```