### PR TITLE
DRAGEN: update Ploidy-Estimation-Metrics module

### DIFF
--- a/multiqc/modules/dragen/ploidy_estimation_metrics.py
+++ b/multiqc/modules/dragen/ploidy_estimation_metrics.py
@@ -1,71 +1,673 @@
-#!/usr/bin/env python
+'''""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+This module gathers ploidy estimation data and prepares it for the output report.
+It relies on the following official sources:
+https://support-docs.illumina.com/SW/DRAGEN_v41/Content/SW/DRAGEN/PloidyEstimator_fDG.htm
+Section "Ploidy Calling" p.177:
+https://emea.support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/dragen-bio-it/Illumina-DRAGEN-Bio-IT-Platform-User-Guide-1000000141465-00.pdf
 
+
+You can define a closed interval [lower_limit, upper_limit] of acceptable values for the metrics:
+1 median / Autosomal median, 2 median / Autosomal median, ...,  22 median / Autosomal median
+
+Example: add multiqc_config.yaml file in your current working directory with this content:
+ploidy_estimation_user_configs:
+    lower_limit: 0.75
+    upper_limit: 1.25
+'''
 
 import logging
 import re
 from collections import OrderedDict, defaultdict
 
+from multiqc import config
 from multiqc.modules.base_module import BaseMultiqcModule
+from multiqc.plots import linegraph, table
+from multiqc.utils.util_functions import write_data_file
 
-# Initialise the logger
+from .utils import check_duplicate_samples, flatten_4D_data, make_gen_stats_headers, make_log_report, make_own_headers
+
+# Initialise the logger.
 log = logging.getLogger(__name__)
 
 
-NAMESPACE = "Ploidy estimation"
+NAMESPACE = "DRAGEN ploidy estimation"
+
+
+'''"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The SINGLE_HEADER is used to define common settings for all headers:
+https://multiqc.info/docs/development/plots/#creating-a-table
+'''
+SINGLE_HEADER = {
+    "namespace": NAMESPACE,  # Name for grouping. Prepends desc and is in Config Columns modal
+    "title": None,  # Short title, table column title
+    "description": None,  # Longer description, goes in mouse hover text
+    "max": None,  # Minimum value in range, for bar / colour coding
+    "min": 0,  # Maximum value in range, for bar / colour coding
+    "ceiling": None,  # Maximum value for automatic bar limit
+    "floor": None,  # Minimum value for automatic bar limit
+    "minRange": None,  # Minimum range for automatic bar
+    "scale": "GnBu",  # Colour scale for colour coding. False to disable.
+    "bgcols": None,  # Dict with values: background colours for categorical data.
+    "colour": "0, 0, 255",  # Colour for column grouping
+    "suffix": None,  # Suffix for value (eg. "%")
+    "format": "{:,.2f}",  # Value format string - default 2 decimal places
+    "cond_formatting_rules": None,  # Rules for conditional formatting table cell values.
+    "cond_formatting_colours": None,  # Styles for conditional formatting of table cell values
+    "shared_key": None,  # See the link for description
+    "modify": None,  # Lambda function to modify values
+    "hidden": True,  # Set to True to hide the column in the general table on page load.
+    "hidden_own": True,  # For non-general plots in the ploidy section.
+    "exclude": True,  # True to exclude all headers from the general html table.
+}
+'''""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The EXTRA_HEADER contains the logical keys of the SINGLE_HEADER. These are just extensions,
+but can be used as if they were a part of the SINGLE_HEADER. Extra configurations are not
+set by default. Only the SINGLE_HEADER is used as a basis for a header. But you can always
+append an extra config(eg hidden_own, exclude) to the SINGLE_HEADER to overcome this issue.
+
+Hints and rules:
+- "hidden" is used for own ploidy section if "hidden_own" is not provided.
+
+- "exclude" and "exclude_own" may be useful in cases where html size matters.
+  Eg. many samples but only few metrics of interest.
+
+- "order_priority" can be used to arrange table's columns. Only int and float are valid.
+'''
+EXTRA_HEADER = {
+    "hidden_own": None,  # For non-general plots in the ploidy section.
+    "exclude": None,  # True to exclude metric from the general html table.
+    "exclude_own": None,  # True to exclude from own ploidy section html table.
+    "order_priority": None,  # Used to specify columns' order in all tables.
+}
+
+'''"""""""""""""""""""""""""""""""""""""""""""""""
+Officially defined file format could not be found.
+The links above show only the general non-technical example.
+According to examined real data, there are 4 columns in total:
+Section    Void-column    Metric    Value
+
+The only section found in data was 'PLOIDY ESTIMATION'
+It is unknown if it is the only valid section or others already exist/will be added.
+The second column does not contain anything.
+It is unknown if it is the final constant structure or it was reserved for future use.
+
+Due to this uncertainty the following structure was chosen to store parsed ploidy data:
+{sample: {section: {Region_or_Sample: {metric: value}}}}
+
+Might look overcomplicated, but it conforms to the standard.
+
+If you wish to add new sections, take a look at the make_consistent_section.
+'''
+
+## Sections:
+PLOIDY_ESTIMATION = "PLOIDY ESTIMATION"
+ADDITIONAL_SECTION = "NON-STANDARD ADDITIONAL SECTION"  # For EXTRA_METRICS.
+
+## RG/Sample aka Second column:
+EMPTY = ""
+WGS = "WGS"  # Not detected/used. Just an example.
+
+## Special case. Token for any section/region/sample.
+ANY = object()
+
+"""
+Only INCLUDED_SECTIONS will be shown in html table.
+The parser supports only the first value (4th column).
+Can be used as a quick but unreliable way to control html table.
+"""
+INCLUDED_SECTIONS = {PLOIDY_ESTIMATION: [EMPTY], ADDITIONAL_SECTION: [ANY],}
+
+# INCLUDED_SECTIONS = {ANY:[ANY]}  # Include all sections/regions/samples.
+
+# Used to detect and report what is not properly supported by the module.
+# Works as INCLUDED_SECTIONS.
+SUPPORTED_SECTIONS = {PLOIDY_ESTIMATION: [EMPTY],}
+
+'''"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The STD_METRICS is the container for abstract representations of the standard metrics.
+They are designed to be seen as simple identifiers of the well known metrics.
+You can set any real/virtual configuration defined in the SINGLE_HEADER.
+
+Some rules:
+
+- "modify" must conform to the following general structure:
+  lambda x: (arbitrary expression) if isinstance(x, str) else (math expression)
+  The x is either number or string. The latter is some value, which could not be
+  converted to int or float. NA for instance. Such values can be modified in the
+  (arbitrary expression) if needed. If not then just return the input.
+
+- If you wish to add new metrics, take a look at the make_consistent_metric.
+'''
+
+RESERVED = 100  # Used for automatic ordering. Do not exceed it.
+
+STD_METRICS = {
+    "ploidy estimation": {
+        "order_priority": 1,
+        "exclude": False,
+        "hidden": False,
+        "hidden_own": False,
+        "title": "Sex",
+        "description": "Sex chromosome ploidy estimation (XX, XY, X0, 00, etc.)",
+        "scale": "Set3",
+        "colour": "255, 0, 0",
+        "cond_formatting_rules": {
+            # Each value is red/false by default
+            "red": [{"s_contains": ""}],
+            "green": [{"s_eq": "XX"}, {"s_eq": "XY"}, {"s_eq": "YX"}],
+        },
+        "cond_formatting_colours": [
+            {"red": "#FF0000"},
+            {"green": "#00FF00"},
+        ],
+    },
+    "autosomal median coverage": {
+        "order_priority": 3,
+        "hidden_own": False,
+        "title": "AutMedCov",
+        "scale": "YlOrRd",
+        "colour": "0, 0, 255",
+        "description": "Autosomal median coverage.",
+    },
+    "x median coverage": {
+        "order_priority": 4,
+        "hidden_own": False,
+        "title": "XMedCov",
+        "scale": "BrBG",
+        "colour": "0, 0, 255",
+        "description": "X median coverage.",
+    },
+    "y median coverage": {
+        "order_priority": 5,
+        "hidden_own": False,
+        "title": "YMedCov",
+        "scale": "Purples",
+        "colour": "0, 0, 255",
+        "description": "Y median coverage.",
+    },
+    "x median / autosomal median": {
+        "order_priority": 6,
+        "title": "XMed/AutMed",
+        "scale": "Greens",
+        "colour": "0, 0, 255",
+        "description": "X median coverage devided by autosomal median coverage.",
+    },
+    "y median / autosomal median": {
+        "order_priority": 7,
+        "title": "YMed/AutMed",
+        "scale": "Oranges",
+        "colour": "0, 0, 255",
+        "description": "Y median coverage devided by autosomal median coverage.",
+    },
+    # The set of "1,2,3,...,22 median / Autosomal median" metrics.
+    # title, description and order_priority are created automatically.
+    # Each single metric can be redefined in the "extra".
+    "autosome_n median / autosomal median": {
+        "hidden_own": True,
+        # "exclude_own": True,
+        "colour": "255, 255, 0",
+        "suffix": " %",
+        "extra": {
+            # "1 median / Autosomal median" metric:
+            "1": {
+                "description": "Median coverage of autosome 1 devided by autosomal median coverage.",
+            },
+            # "22 median / Autosomal median" metric:
+            "22": {
+                "description": "Median coverage of autosome 22 devided by autosomal median coverage.",
+            },
+        },
+    },
+}
+
+
+# User/Default settings for the EXTRA_METRICS.
+PLOIDY_MOD = getattr(config, "ploidy_estimation_user_configs", {})
+LOWER_LIMIT = PLOIDY_MOD.get("lower_limit", 0.95)
+UPPER_LIMIT = PLOIDY_MOD.get("upper_limit", 1.05)
+
+# The EXTRA_METRICS contains non-standard "metrics".
+# It is basically just a holder for some calculated results.
+EXTRA_METRICS = {
+    # Autosomes from "1,2,...,22 median / Autosomal median" metrics,
+    # whose values are out of user-defined/default valid range.
+    "autosome median to autosomal median ratios out of range": {
+        "order_priority": 2,
+        "hidden_own": False,
+        # "title" is wide to avoid overlapping of adjacent rows.
+        "title": "Autosomes out of range [{}, {}]".format(LOWER_LIMIT, UPPER_LIMIT),
+        "description": "Autosomes whose ratio of own median to autosomal median"
+        + " is out of valid range [{}, {}]".format(LOWER_LIMIT, UPPER_LIMIT),
+        "scale": "Accent",
+        "colour": "0, 255, 0",
+    },
+}
+
+
+# The TABLE_CONFIG defines configs for the whole table in own section.
+TABLE_CONFIG = {
+    "namespace": NAMESPACE,  # Name for grouping. Prepends desc and is in Config Columns modal
+    "id": "dragen_ploidy_estimation_metrics_table",  # ID used for the table
+    "table_title": "Ploidy estimation",  # Title of the table. Used in the column config modal
+    "save_file": False,  # Whether to save the table data to a file
+    "raw_data_fn": None,  # File basename to use for raw data file
+    "sortRows": True,  # Whether to sort rows alphabetically
+    "only_defined_headers": True,  # Only show columns that are defined in the headers config
+    "col1_header": None,  # The header used for the first column with sample names.
+    "no_beeswarm": False,  # Force a table to always be plotted (beeswarm by default if many rows)
+}
+
+'''""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The 'point.category' is used instead of 'point.x' in the 'tt_label' config, because the
+Highcharts stores the keys of each sample of the given input data in the 'category' attribute
+of each point object. The 'x' attribute can be seen as simple enumeration of sample's keys.
+If this explanation sounds strange, here is an example of how it works in our case:
+We want to plot the "1, 2, 3, ... , 22, X, Y median / Autosomal median" metrics in a linegraph.
+Hovering over a single point of a line shows a description, which is defined in the 'tt_label'.
+So, if we use the 'point.x' in the first curly braces, the following values will be inserted:
+0, 1, 2, 3, ... , 21, 22, 23
+But if we use the 'point.category' this preferable sequence is used instead:
+1, 2, 3, 4, ... , 22, X, Y
+
+More info here: https://api.highcharts.com/class-reference/Highcharts.Point#category
+
+More configs: https://multiqc.info/docs/development/plots/#line-graphs
+'''
+LINEGRAPH_CONFIG = {
+    "id": "dragen_ploidy_estimation_linegraph_with_ratios",
+    "title": "Dragen: Chromosome median / Autosomal median ratios",
+    "ylab": "Chromosome median / Autosomal median",
+    "xlab": "Chromosome",
+    "categories": True,  # Set to True to use x values as categories instead of numbers.
+    "tt_label": "{point.category} median / Autosomal median: {point.y:.2f}x",  # Use to customise tooltip label
+}
 
 
 class DragenPloidyEstimationMetrics(BaseMultiqcModule):
+    """Public members of the DragenPloidyEstimationMetrics module are available to other dragen modules.
+    To avoid cluttering up the global dragen space, only one method is defined."""
+
     def add_ploidy_estimation_metrics(self):
-        data_by_sample = dict()
+        """The main function of the dragen ploidy metrics module.
+        Public members of the BaseMultiqcModule and dragen modules defined in
+        MultiqcModule are available within it. Returns keys with sample names
+        or an empty set if no samples were found or all samples were ignored."""
 
-        for f in self.find_log_files("dragen/ploidy_estimation_metrics"):
-            s_name, data = parse_ploidy_estimation_metrics_file(f)
-            s_name = self.clean_s_name(s_name, f)
-            if s_name in data_by_sample:
-                log.debug(f"Duplicate sample name found! Overwriting: {s_name}")
-            self.add_data_source(f, section="stats")
-            data_by_sample[s_name] = data
+        ploidy_data = {}
 
-        # Filter to strip out ignored sample names:
-        data_by_sample = self.ignore_samples(data_by_sample)
-        if not data_by_sample:
+        # Stores cleaned sample names with references to file handlers.
+        # Used later to check for duplicates and inform about found ones.
+        all_samples = defaultdict(list)
+
+        # Metric IDs with original consistent metric strings.
+        all_metrics = {}
+
+        for file in self.find_log_files("dragen/ploidy_estimation_metrics"):
+            out = ploidy_parser(file)
+            if out["success"]:
+                self.add_data_source(file, section="stats")
+                cleaned_sample = self.clean_s_name(out["sample_name"], file)
+                all_samples[cleaned_sample].append(file)
+                ploidy_data[cleaned_sample] = out["data"]  # Add/overwrite the sample.
+                all_metrics.update(out["metric_IDs"])
+
+        # Filter to strip out ignored sample names.
+        ploidy_data = self.ignore_samples(ploidy_data)
+        if not ploidy_data:
             return set()
 
-        # Write data to file
-        self.write_data_file(data_by_sample, "dragen_ploidy")
+        check_duplicate_samples(all_samples, log, "dragen/ploidy_estimation_metrics")
 
-        headers = OrderedDict()
-        headers["Ploidy estimation"] = {
-            "title": "Sex",
-            "description": "Sex chromosome ploidy estimation (XX, XY, X0, 00, etc.)",
-            "scale": "Set3",
+        ploidy_headers = make_headers(all_metrics)
+
+        txt_out_data = flatten_4D_data(
+            ploidy_data,
+            metric_IDs=all_metrics,  # Original strings can be used instead of somewhat ugly metric IDs.
+            hide_single_section=True,  # True to exclude common single section from metric ID.
+        )
+        self.write_data_file(txt_out_data, "dragen_ploidy")  # Write data to file.
+
+        add_own_metrics(ploidy_data, ploidy_headers)
+
+        ploidy_data_table = make_data_for_table(ploidy_data)  # Prepare data for tables.
+        table_data, table_headers = flatten_4D_data(
+            ploidy_data_table,
+            headers=ploidy_headers,  # Adjust headers' metrics to data's structure.
+            metric_IDs=all_metrics,  # Original strings can be used instead of somewhat ugly IDs.
+            hide_single_section=True,  # True to exclude common single section from metric ID.
+        )
+        gen_headers = make_gen_stats_headers(table_headers)
+        # If gen_headers is empty, then all metrics from data will be included in table.
+        if gen_headers:
+            self.general_stats_addcols(table_data, gen_headers, namespace=NAMESPACE)
+
+        # Prepare html table.
+        own_table_headers = make_own_headers(table_headers)
+        self.add_section(
+            name="Ploidy Estimator",
+            anchor="dragen-ploidy-estimation-metrics-table",
+            description="The Ploidy Estimator results, including each normalized "
+            "per-contig median coverage. Press the `Help` button for details.",
+            helptext="The Ploidy Estimator runs by default. The Ploidy Estimator "
+            "uses reads from the mapper/aligner to calculate the sequencing depth of "
+            "coverage for each autosome and allosome in the human genome. The sex "
+            "karyotype of the sample is then estimated using the ratios of the median "
+            "sex chromosome coverages to the median autosomal coverage. The sex karyotype "
+            "is estimated based on the range the ratios fall in. If the ratios are outside "
+            "all expected ranges ,then the Ploidy Estimator does not determine a sex karyotype. "
+            "Ploidy estimation can fail if the type of input sequencing data cannot be "
+            "determined or if there is not sufficient sequencing coverage in the autosomes. "
+            "When ploidy estimation fails the estimated median coverage values will be zero. "
+            "When both tumor and matched normal reads are provided as input, the Ploidy Estimator "
+            "only estimates sequencing coverage and sex karyotype for the matched normal sample "
+            "and ignores the tumor reads. If only tumor reads are provided as input, the Ploidy "
+            "Estimator estimates sequencing coverage and sex karyotype for the tumor sample.",
+            plot=table.plot(
+                table_data,
+                own_table_headers,
+                {config: val for config, val in TABLE_CONFIG.items() if val is not None}
+            ),
+        )
+        # Add own section with linegraph for "Chromosome median / Autosomal median" metrics.
+        linegraph_section = make_data_for_linegraph_section(ploidy_data)
+        if linegraph_section["data"]:  # Append only if not empty.
+            self.add_section(
+                name="Chromosome median / Autosomal median",
+                anchor="dragen-ploidy-estimation-metrics-linegraph",
+                description="'Autosome|Allosome median / Autosomal median' ratios from .ploidy_estimation_metrics.csv files. "
+                + linegraph_section["description"],
+                plot=linegraph.plot(linegraph_section["data"], LINEGRAPH_CONFIG),
+            )
+        # Report found info/warnings/errors. You can disable it anytime, if it is not wanted.
+        make_log_report(log_data, log, "ploidy_estimation_metrics")
+
+        return ploidy_data.keys()
+
+
+def make_data_for_table(DATA):
+    """Modify parsed data before storing in tables."""
+
+    # Inner samples can be concatenated with file samples
+    # and replaced by empty string in the second column.
+
+    # Sections can be analyzed and restructured.
+
+    # Use INCLUDED_SECTIONS as inclusion checklist.
+    return {
+        sample: {
+            section: {
+                region: {metric: value for metric, value in data.items()}
+                for region, data in regions.items()
+                if (ANY in INCLUDED_SECTIONS and ANY in INCLUDED_SECTIONS[ANY])
+                or (
+                    section in INCLUDED_SECTIONS
+                    and (region in INCLUDED_SECTIONS[section] or ANY in INCLUDED_SECTIONS[section])
+                )
+            }
+            for section, regions in sections.items()
+            if ANY in INCLUDED_SECTIONS or section in INCLUDED_SECTIONS
         }
-        self.general_stats_addcols(data_by_sample, headers, namespace=NAMESPACE)
-        return data_by_sample.keys()
+        for sample, sections in DATA.items()
+    }
 
 
-def parse_ploidy_estimation_metrics_file(f):
-    """
-    T_SRR7890936_50pc.ploidy_estimation_metrics.csv
+def add_own_metrics(ploidy_data, ploidy_headers):
+    """Inserts calculated data into ploidy_data.
+    Appends new "metrics" to the ploidy_headers."""
 
-    PLOIDY ESTIMATION,,Autosomal median coverage,55.63
-    PLOIDY ESTIMATION,,X median coverage,27.44
-    PLOIDY ESTIMATION,,Y median coverage,0.00
-    PLOIDY ESTIMATION,,X median / Autosomal median,0.49
-    PLOIDY ESTIMATION,,Y median / Autosomal median,0.00
-    PLOIDY ESTIMATION,,Ploidy estimation,X0
-    """
+    metric_id = "autosome median to autosomal median ratios out of range"
+    header = {config: value for config, value in SINGLE_HEADER.items() if value is not None}
+    header.update(EXTRA_METRICS[metric_id])
+    ploidy_headers[metric_id] = header
 
-    s_name = re.search(r"(.*)\.ploidy_estimation_metrics.csv", f["fn"]).group(1)
+    # For the "1,2,3,...,22 median / autosomal median" metrics.
+    AUTOSOME_RGX = re.compile("^(\d+) median / autosomal median$")
 
-    data = defaultdict(dict)
+    for sample in ploidy_data:
+        if PLOIDY_ESTIMATION in ploidy_data[sample] and EMPTY in ploidy_data[sample][PLOIDY_ESTIMATION]:
+            metrics = ploidy_data[sample][PLOIDY_ESTIMATION][EMPTY]
+            value = ""
+            for metric in metrics:
+                autosome_match = AUTOSOME_RGX.search(metric)
+                if autosome_match:
+                    aut_val = metrics[metric]
+                    # Though checking the metric's value might seem redundant, it is necessary to guarantee
+                    # that MultiQC will not crash if some string (eg NA) is present instead of a number.
+                    if isinstance(aut_val, (float, int)) and (aut_val < LOWER_LIMIT or aut_val > UPPER_LIMIT):
+                        value += autosome_match.group(1) + "; "
+            if value:
+                # Delete the last space but not the semicolon. Without a semicolon at the
+                # end of the string a single found autosome would be converted to float.
+                # There is no need to check/create a key for ADDITIONAL_SECTION, because
+                # each sample references a defaultdict(lambda: defaultdict(dict)).
+                ploidy_data[sample][ADDITIONAL_SECTION][EMPTY][metric_id] = value[:-1]
+            else:
+                ploidy_data[sample][ADDITIONAL_SECTION][EMPTY][metric_id] = "None"
 
-    for line in f["f"].splitlines():
-        _, _, metric, stat = line.split(",")
-        try:
-            stat = float(stat)
-        except ValueError:
-            pass
-        data[metric] = stat
 
-    return s_name, data
+def make_data_for_linegraph_section(ploidy_data):
+    """Create data with '1,2,3,...,22 median / Autosomal median' metrics for linegraph."""
+
+    # OrderedDict to guarantee the order of metrics. Simple dict might cause wrong output
+    # if python implementation does not guarantee the preservation of order (eg python 3.6).
+    data = defaultdict(OrderedDict)
+
+    # Tell users how absent metrics are handled.
+    description = ""
+
+    # The CHROMS is a list of pairs with "1,2,...,22,x,y median / autosomal median" metrics and
+    # associated chromosomes. Must be in lower case, because of how make_consistent_metric works.
+    # The sole purpose of this array is to guarantee the sequence of metrics. Creating the output data
+    # by iterating through the input data would result in wrong output if the first catched sample has
+    # a sequence of metrics, which is distinct from the sequence of the same metrics in other samples.
+    CHROMS = [
+        (str(chrom) + " median / autosomal median", str(chrom).upper())
+        for chrom in list(range(1, 23)) + ["x", "y"]
+    ]
+    for sample in ploidy_data:
+        if PLOIDY_ESTIMATION in ploidy_data[sample] and EMPTY in ploidy_data[sample][PLOIDY_ESTIMATION]:
+            metrics = ploidy_data[sample][PLOIDY_ESTIMATION][EMPTY]
+            for metric, chrom in CHROMS:
+                # Check if metric is in the sample and its value is a number. MultiQC can crash without the latter.
+                if metric in metrics and isinstance(metrics[metric], (float, int)):
+                    data[sample][chrom] = metrics[metric]
+                # Additional safety measure to prevent producing broken output
+                # in case the first catched sample does not contain all metrics.
+                else:
+                    data[sample][chrom] = -1
+                    description = "Ratio of -1 means that metric is not present in the sample or its value is not a number."
+    return {"data": data, "description": description}
+
+
+'''"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The log_data is the container for found info, warnings and errors.
+Collected data is stored in groups to make the output log file more readable.
+
+warnings:
+- invalid_file_names, which do not conform to the:
+    <output-file-prefix>.ploidy_estimation_metrics.csv
+
+debug/info:
+- invalid_file_lines, which do not conform to:
+  <section>,<RG/Sample/Empty>,<metric>,<value>
+- unknown_sections are not present in the SUPPORTED_SECTIONS.
+- unknown_second_columns are not present in the SUPPORTED_SECTIONS.
+- unknown_metrics are those, which are not part of the STD_METRICS.
+  Their headers are incomplete, hence uninformative and ugly table's columns.
+- unusual_values are those except for int/float and a combo of X/Y/0.
+'''
+log_data = {
+    "invalid_file_names": defaultdict(list),
+    "invalid_file_lines": defaultdict(lambda: defaultdict(list)),
+    "unknown_metrics": [],
+    "unusual_values": defaultdict(lambda: defaultdict(dict)),
+    "unknown_second_columns": defaultdict(set),
+    "unknown_sections": set(),
+}
+
+
+def make_headers(metric_IDs):
+    """Build headers from metric_IDs."""
+    headers = {}
+
+    # The AUTOSOME_RGX is for the "1,2,3,...,22 median / autosomal median" metrics.
+    AUTOSOME_RGX = re.compile("^(\d+) median / autosomal median$")
+
+    for metric_id in metric_IDs:
+        original_metric = metric_IDs[metric_id]
+        configs = {config: val for config, val in SINGLE_HEADER.items() if val is not None}
+
+        median_ratio_match = AUTOSOME_RGX.search(metric_id)
+        if median_ratio_match:
+            autosome_n = median_ratio_match.group(1)
+            configs["order_priority"] = RESERVED + int(autosome_n)  # Order ascendingly.
+            configs["title"] = autosome_n + "Med/AutMed"
+            configs["description"] = (
+                "Median coverage of autosome "
+                + autosome_n
+                + " devided by the autosomal median coverage."
+            )
+            _configs = STD_METRICS["autosome_n median / autosomal median"]
+            configs.update(
+                {
+                    config: val
+                    for config, val in _configs.items()
+                    if config in SINGLE_HEADER or config in EXTRA_HEADER
+                }
+            )
+            if autosome_n in _configs["extra"] and _configs["extra"][autosome_n]:
+                configs.update(_configs["extra"][autosome_n])
+        else:
+            if metric_id in STD_METRICS:
+                configs.update(STD_METRICS[metric_id])
+            else:
+                log_data["unknown_metrics"].append(original_metric)
+                configs["title"] = original_metric
+                configs["description"] = original_metric
+
+        headers[metric_id] = configs
+
+    return headers
+
+
+def create_parser():
+    """Isolation for the parsing codeblock. Returns parse_ploidy_estimation_metrics_file closure."""
+
+    def make_consistent_metric(metric):
+        """Tries to guarantee consistency to a certain degree.
+        Metric-specific peculiarities can be handled here."""
+        # metric will be stored in .txt output.
+        metric = re.sub("\s+", " ", metric).strip()
+        # metric_id will be used for internal storage.
+        metric_id = metric.lower()
+        return metric, metric_id
+
+    def make_consistent_section(section):
+        """Improve consistency of section's string."""
+        return re.sub("\s+", " ", section).strip().upper()
+
+    # The official/accepted structure of the input file:
+    # <output-file-prefix>.ploidy_estimation_metrics.csv
+    FILE_RGX = re.compile("(.+)\.ploidy_estimation_metrics\.csv$")
+
+    # There is no officially defined line structure.
+    # The following regex is used to check input lines.
+    LINE_RGX = re.compile("^([^,]+),([^,]*),([^,]+),([^,]+)$")
+
+    def parse_ploidy_estimation_metrics_file(file_handler):
+        """
+        Parser for *.ploidy_estimation_metrics.csv files.
+
+        Input:  file_handler with necessary info - file name/content/root.
+
+        Output: {"success": False} if file name test failed. Otherwise:
+                {"success": False/True,
+                 "sample_name": <output-file-prefix>,
+                 "data": {section: {RG/Sample: {metric: value}}},
+                 "metric_IDs": {metric_ID: original_metric}
+                }, with success False if all file's lines are invalid.
+
+        File example:
+
+        T_SRR7890936_50pc.ploidy_estimation_metrics.csv
+        PLOIDY ESTIMATION,,Autosomal median coverage,55.63
+        PLOIDY ESTIMATION,,X median coverage,27.44
+        PLOIDY ESTIMATION,,Y median coverage,0.00
+        PLOIDY ESTIMATION,,X median / Autosomal median,0.49
+        PLOIDY ESTIMATION,,Y median / Autosomal median,0.00
+        PLOIDY ESTIMATION,,Ploidy estimation,X0
+        """
+        file, root = file_handler["fn"], file_handler["root"]
+
+        file_match = FILE_RGX.search(file)
+        if not file_match:
+            log_data["invalid_file_names"][root].append(file)
+            return {"success": False}
+
+        sample = file_match.group(1)
+
+        success = False
+        data = defaultdict(lambda: defaultdict(dict))
+        metric_IDs = {}
+
+        for line in file_handler["f"].splitlines():
+            # Check the general line structure.
+            line_match = LINE_RGX.search(line)
+
+            # If line is fine then extract the necessary fields.
+            if line_match:
+                success = True
+                section, region_sample, metric, value = line_match.groups()
+
+            # Otherwise check if line is empty. If not then report it. Go to the next line.
+            else:
+                if not re.search("^\s*$", line):
+                    log_data["invalid_file_lines"][root][file].append(line)
+                continue
+
+            # Modify extracted parts to improve consistency.
+            consistent_section = make_consistent_section(section)
+            consistent_metric, metric_id = make_consistent_metric(metric)
+
+            # Check support for sections/regions.
+            if not (ANY in SUPPORTED_SECTIONS or consistent_section in SUPPORTED_SECTIONS):
+                log_data["unknown_sections"].add(section)
+            if not (
+                ANY in SUPPORTED_SECTIONS and ANY in SUPPORTED_SECTIONS[ANY]
+                or (
+                    consistent_section in SUPPORTED_SECTIONS
+                    and (
+                        region_sample in SUPPORTED_SECTIONS[consistent_section]
+                        or ANY in SUPPORTED_SECTIONS[consistent_section]
+                    )
+                )
+            ):
+                log_data["unknown_second_columns"][section].add(region_sample)
+
+            # Check the extracted value. Float in most cases. And a single karyotype.
+            try:
+                value = float(value)
+            except ValueError:
+                # Int is also checked, though is was not found in real data.
+                try:
+                    value = int(value)
+                except ValueError:
+                    if not re.search("^[XY0]+$", value.strip(), re.IGNORECASE):
+                        log_data["unusual_values"][root][file][metric] = value
+
+            metric_IDs[metric_id] = consistent_metric
+            data[consistent_section][region_sample][metric_id] = value
+
+        # Return results of parsing the input file.
+        return {
+            "success": success,
+            "sample_name": sample,
+            "data": data,
+            "metric_IDs": metric_IDs,
+        }
+
+    # Return the parser closure.
+    return parse_ploidy_estimation_metrics_file
+
+
+ploidy_parser = create_parser()

--- a/multiqc/modules/dragen/utils.py
+++ b/multiqc/modules/dragen/utils.py
@@ -1,6 +1,105 @@
-from collections import OrderedDict
+'''"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Below is a set of common tools, which might help to write DRAGEN QC Metrics modules.
 
+This comment describes some construction components of a single dragen module.
+It also includes noticed common patterns, observations.
+
+
+Officially defined QC metrics output table format:
+Section    RG/Sample    Metric    Count/Ration/Time    Percentage/Seconds
+
+Source: https://support-docs.illumina.com/SW/DRAGEN_v41/Content/SW/DRAGEN/QCMetricsCoverageReports.htm
+
+Real files' formats can vary:
+
+- Sections have variations in composition and staticness.
+  * Can be constant: coverage_metrics with 'COVERAGE SUMMARY'
+  * Or quite variable:
+    * subsections/prefixes/suffixes (eg vc_metrics, mapping_metrics).
+    * phenotypes as extra prefixes: 'TUMOR', 'NORMAL'
+  * Some dont have a section:
+    Eg overall_mean_cov_metrics has the 'Average alignment coverage over <source>' metric in the 1st column.
+    But the 'TUMOR' and 'NORMAL' prefixes can be also appended to that metric.
+
+- RG/Sample can be either:
+  * DRAGEN-defined: empty or some static region (eg WGS).
+  * User-defined: sample names.
+  * Non existent (eg overall_mean_cov_metrics)
+
+- Metrics are also quite variant:
+  * Substrings:
+    * Varying regions/values/metainfo (eg mapping_metrics, coverage_metrics).
+    * Space padding within metrics (eg coverage_metrics).
+  * DRAGEN version dependency as stated in mapping_metrics.py:
+    "Dragen 3.9 has replaced 'rRNA filtered reads' with 'Adjustment of reads matching filter contigs'"
+  * User-defined sample names instead of metrics (eg cnv_metrics).
+  * Probably smth else.
+
+- Values are mostly int and float. NA, inf or karyotype(eg XX/XY/X0) are also present.
+  Extra padded space can be included (eg overall_mean_cov_metrics)
+
+
+DRAGEN QC Metrics Module includes:
+
+Main components:
+
+  - Main class:
+    interface to features provided by the BaseMultiqcModule and own functionality.
+    Methods and properties of DRAGEN modules defined in MultiqcModule(dragen.py) are also
+    available from the main dragen class through self. Unfortunately it is not possible
+    to completely isolate dragen modules from each other, so some cautiousness is needed:
+    * main class can overwrite public members of main classes from other modules.
+    * try to create as little methods/properties as possible. Especially those which can
+      consume a lot of space, because references to such members will still exist after
+      single module's execution has finished.
+    * use only explicitly defined internal dragen interface(eg getter methods) to quiry data.
+
+  - CSV Parser:
+    extracts data from specific CSV-file with metrics.
+    The structure of collected data depends on the file's format.
+
+  - Configurations:
+    Highcharts plots: headers for tables, configs for whole tables ...
+
+Optional components:
+
+  - Data transformator:
+    tools (eg util functions, own methods/global funcs) to restructure parsed data.
+    It might happen that a single file contains differently structured rows.
+    Internal data restructuring could be necessary in order to properly and nicely
+    present metrics in html table.
+    - Data flattener:
+      Transforms data from higher dimension to 2D - {sample: {metric: value}}
+      May be useful in writing a prototype.
+    - Transformation for storing in txt output.
+    - Transformation for tables/linegraphs/etc
+
+  - Headers creation:
+    the only plot which is available by default and can represent data completely is the table.
+    In some cases metrics/files can have varying and rather complicated structure. It might be
+    cumbersome to manually define configs in such cases, so additional functionality could help.
+
+  - Logging:
+    Collect and report found debug/info/warnings/errors according to some predefined schema.
+    Direct reporting can be also considered as a "component", a distributed one, sort of.
+    It is much easier than the former and reports with own module name, but can produce chaotic log.
+
+  - JSON Parser:
+    JSON data can be collected separately from CSV. After that it can be used to improve html output.
+
+  - Data checker:
+    It might happen that collected data needs to be thoroughly examined to guarantee data quality.
+    This component may be useful if many specific data aspects have to be checked.
+    Currently it is part of parser.
+
+This structuring is just an attempt to organize and simplify the whole dragen module, which
+could improve readability and make modules more extensible/maintainable in the long run.
+'''
+
+import re
+from collections import OrderedDict, defaultdict
 from multiqc import config
+
 
 read_format = "{:,.1f}"
 if config.read_count_multiplier == 1:
@@ -13,6 +112,9 @@ if config.base_count_multiplier == 1:
 elif config.base_count_multiplier == 0.000000001:
     base_format = "{:,.2f}"
 # base_format += '&nbsp;' + config.base_count_prefix
+
+
+"""______________________    Headers    ______________________"""
 
 
 class Metric:
@@ -139,5 +241,481 @@ def make_headers(parsed_metric_ids, metrics):
     return genstats_headers, own_tabl_headers
 
 
+def order_headers(headers):
+    """Produces a shallow copy with ordered single headers from the input.
+    Or returns the input if no header contains the 'order_priority' config."""
+    """
+    Collected "order_priority" values are stored as groups to resolve
+    conflicts, which may arise if several metrics have the same priority.
+    The order of headers within the same priority group is not specified.
+    """
+    indexes = set()
+    ordered_headers = defaultdict(list)
+    not_ordered_headers = {}
+    for metric in headers:
+        configs = headers[metric].copy()
+        if "order_priority" in headers[metric] and isinstance(headers[metric]["order_priority"], (int, float)):
+            order_priority = headers[metric]["order_priority"]
+            indexes.add(order_priority)
+            ordered_headers[order_priority].append((metric, configs))
+        else:
+            not_ordered_headers[metric] = configs
+
+    # Convert to list and sort in ascending order.
+    if indexes:
+        indexes = list(indexes)
+        indexes.sort()
+    # Otherwise there is nothing to order. Return the input.
+    else:
+        return headers
+
+    output_headers = OrderedDict()
+    for index in indexes:
+        for metric, configs in ordered_headers[index]:
+            output_headers[metric] = configs
+
+    output_headers.update(not_ordered_headers)
+    return output_headers
+
+
+# STD_TABLE_CONFIGS contains all standard table configurations:
+STD_TABLE_CONFIGS = [
+    "namespace",
+    "title",
+    "description",
+    "max",
+    "min",
+    "ceiling",
+    "floor",
+    "minRange",
+    "scale",
+    "bgcols",
+    "colour",
+    "suffix",
+    "format",
+    "cond_formatting_rules",
+    "cond_formatting_colours",
+    "shared_key",
+    "modify",
+    "hidden",
+    "bars_zero_centrepoint",
+]
+
+
+def clean_headers(headers):
+    """Include configurations only from STD_TABLE_CONFIGS. Extension-configurations will be excluded."""
+    cleaned_headers = OrderedDict()
+    for metric in headers:
+        cleaned_headers[metric] = {
+            config: val for config, val in headers[metric].items() if config in STD_TABLE_CONFIGS
+        }
+    return cleaned_headers
+
+
+def make_gen_stats_headers(headers):
+    gen_headers = {
+        metric: configs.copy()  # Copy to be able to modify them.
+        for metric, configs in headers.items()
+        if metric in
+        # Header is included only if "exclude" is not present or False/False-equivalent.
+        [
+            metric
+            for metric in headers
+            if not ("exclude" in headers[metric] and headers[metric]["exclude"])
+        ]
+    }
+    return clean_headers(order_headers(gen_headers))
+
+
+def make_own_headers(headers):
+    """Creates table's headers for non-general section."""
+    own_headers = {
+        metric: configs.copy()  # Copy to be able to modify them.
+        for metric, configs in headers.items()
+        if metric in
+        # Header is included only if "exclude_own" is not present or False/False-equivalent.
+        [
+            metric
+            for metric in headers
+            if not ("exclude_own" in headers[metric] and headers[metric]["exclude_own"])
+        ]
+    }
+    for metric in own_headers:
+        # "hidden_own" is an extension and must be stored in "hidden"
+        if "hidden_own" in own_headers[metric]:
+            own_headers[metric]["hidden"] = own_headers[metric]["hidden_own"]
+
+    unhide_single_metric(own_headers)
+    return clean_headers(order_headers(own_headers))
+
+
+"""______________________    Data transformation    ______________________"""
+
+
+def flatten_3D_data(data, **extra):
+    """
+    Reduces amount of dimensions in data to 2D by combining layers.
+
+    Input:
+      * data:
+        dictionary with parsed metrics from coverage reports in form:
+        {sample: {section: {metric_ID: value}}}
+
+      * extra:
+        includes additional parameters:
+        - hide_single_section: boolean to hide single common section.
+        - metric_IDs: dictionary with parsed metrics in form {metric_ID: original_metric}
+        - headers: dictionary in form {metric_ID: {configuration: value}}
+
+    Output:
+      * 2D data if key parameter headers is not provided.
+      * 2D data and headers if key parameter headers is provided.
+    """
+    out_data = defaultdict(dict)
+    headers = extra["headers"] if "headers" in extra else None
+    out_headers = {} if headers is not None else None
+
+    metric_IDs = extra["metric_IDs"] if "metric_IDs" in extra else None
+    hide_single_section = extra["hide_single_section"] if "hide_single_section" in extra else False
+    sections = len({section for sample in data for section in data[sample]})
+
+    for sample in data:
+        for section in data[sample]:
+            for metric in data[sample][section]:
+                original_metric = metric
+                # Try to extract the original metric.
+                if metric_IDs and metric in metric_IDs:
+                    original_metric = metric_IDs[metric]
+                # Create new metric-ID.
+                if hide_single_section and sections == 1:
+                    new_id = original_metric
+                else:
+                    # If section is not empty.
+                    if section:
+                        new_id = section + " " + original_metric
+                    else:
+                        new_id = original_metric
+                out_data[sample][new_id] = data[sample][section][metric]
+
+                if out_headers is None:
+                    continue
+
+                if metric in headers:
+                    out_headers[new_id] = headers[metric]
+
+    if out_headers is not None:
+        return out_data, out_headers
+    else:
+        return out_data
+
+
+def flatten_4D_data(data, **extra):
+    """
+    Reduces amount of dimensions in data to 2D by combining layers.
+
+    Input:
+      * data:
+        dictionary with parsed metrics from coverage reports in form:
+        {sample: {section: {region: {metric_ID: value}}}}
+
+      * extra:
+        includes additional parameters:
+        - hide_single_section: boolean to hide single common section.
+        - metric_IDs: dictionary with parsed metrics in form {metric_ID: original_metric}
+        - headers: dictionary in form {metric_ID: {configuration: value}}
+
+    Output:
+      * 2D data if key parameter headers is not provided.
+      * 2D data and headers if key parameter headers is provided.
+    """
+    out_data = defaultdict(dict)
+    headers = extra["headers"] if "headers" in extra else None
+    out_headers = {} if headers is not None else None
+
+    metric_IDs = extra["metric_IDs"] if "metric_IDs" in extra else None
+    hide_single_section = extra["hide_single_section"] if "hide_single_section" in extra else False
+    sections = len({section for sample in data for section in data[sample]})
+
+    for sample in data:
+        for section in data[sample]:
+            for region in data[sample][section]:
+                for metric in data[sample][section][region]:
+                    original_metric = metric
+                    # Try to extract the original metric.
+                    if metric_IDs and metric in metric_IDs:
+                        original_metric = metric_IDs[metric]
+                    # Create new metric-ID.
+                    if hide_single_section and sections == 1:
+                        # If region is not empty.
+                        if region:
+                            new_id = region + " " + original_metric
+                        else:
+                            new_id = original_metric
+                    else:
+                        # Section and region are not empty.
+                        if section and region:
+                            new_id = section + " " + region + " " + original_metric
+                        # Region is empty.
+                        elif section and not region:
+                            new_id = section + " " + original_metric
+                        # Section is empty.
+                        elif not section and region:
+                            new_id = region + " " + original_metric
+                        # Both are empty.
+                        else:
+                            new_id = original_metric
+                    out_data[sample][new_id] = data[sample][section][region][metric]
+
+                    if out_headers is None:
+                        continue
+
+                    if metric in headers:
+                        out_headers[new_id] = headers[metric]
+
+    if out_headers is not None:
+        return out_data, out_headers
+    else:
+        return out_data
+
+
+"""______________________    Logging component    ______________________"""
+
+
+def check_duplicate_samples(sample_names, logger, module):
+    """Check samples for duplicate names. Warn about found ones."""
+    message = ""
+    line1 = "\n  {} was built from the following samples:"
+    line2 = "\n    {} in {}"
+    for clean_sample_name in sample_names:
+        if len(sample_names[clean_sample_name]) > 1:
+            message += line1.format(clean_sample_name)
+            for file_handler in sample_names[clean_sample_name]:
+                message += line2.format(file_handler["fn"], file_handler["root"])
+    if message:
+        # Draw user's attention with error.
+        logger.error(module + ": duplicates found.")
+        # But print full info only in report.
+        message = "\n\nDuplicate sample names were found. The last one overwrites previous data." + message
+        logger.debug(message)
+
+
+# Used to define module-specific texts for the make_parsing_log_report.
+# Comments are used to separate keys. Though empty lines look better, they are removed by the "Black" formatter.
+DRAGEN_MODULE_TEXTS = {
+    "invalid_file_names": {
+        "coverage_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-prefix>.<coverage-region-prefix>_coverage_metrics<arbitrary-suffix>.csv\n\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "overall_mean_cov_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-prefix>_overall_mean_cov<arbitrary-suffix>.csv\n\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "cnv_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output prefix>.cnv_metrics.csv\n\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "ploidy_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-file-prefix>.ploidy_estimation_metrics.csv\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "roh_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-file-prefix>.roh_metrics.csv\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "sv_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-file-prefix>.sv_metrics.csv\n"
+        "The following files are not valid:\n",
+        # ------------- #
+        "vc_hethom_ratio_metrics": "\n\nThe file names must conform to the following structure:\n"
+        "<output-file-prefix>.vc_hethom_ratio_metrics.csv\n"
+        "The following files are not valid:\n",
+    },
+    "invalid_file_lines": {
+        "coverage_metrics": "\n\nThe lines in files must be:\n"
+        "COVERAGE SUMMARY,,<metric>,<value1> or "
+        "COVERAGE SUMMARY,,<metric>,<value1>,<value2>\n"
+        "The following files contain invalid lines:\n",
+        # ------------- #
+        "cnv_metrics": "\n\nThe lines in files must be:\n"
+        "<section>,<RG/Sample/Empty>,<sample>,<value> or "
+        "<section>,<RG/Sample/Empty>,<sample>,<value1>,<value2>\n"
+        "The following files contain invalid lines:\n",
+        # ------------- #
+        "ploidy_metrics": "\n\nThe lines in files must be:\n"
+        "<section>,<RG/Sample/Empty>,<metric>,<value>\n"
+        "The following files contain invalid lines:\n",
+        # ------------- #
+        "roh_metrics": "\n\nThe lines in files must be:\n"
+        "<section>,<RG/Sample/Empty>,<metric>,<value>\n"
+        "The following files contain invalid lines:\n",
+        # ------------- #
+        "sv_metrics": "\n\nThe lines in files must be:\n"
+        "<section>,<RG/Sample/Empty>,<metric>,<value> or "
+        "<section>,<RG/Sample/Empty>,<metric>,<value1>,<value2>\n"
+        "The following files contain invalid lines:\n",
+        # ------------- #
+        "vc_hethom_ratio_metrics": "\n\nThe lines in files must be:\n"
+        "<section>,<contig>,<metric>,<value>\n"
+        "The following files contain invalid lines:\n",
+    },
+    "unknown_sections": {},
+    "unknown_second_columns": {},
+    "unknown_metrics": {
+        "coverage_metrics": "\n\nThe following metrics could not be recognized. "
+        "Their headers might be incomplete, hence uninformative and ugly table's columns.\n",
+        # ------------- #
+        "overall_mean_cov_metrics": "\n\nOnly the 'Average alignment coverage over <file>' metric is supported.\n"
+        "The following metrics could not be recognized and are not included in the report.\n",
+        # ------------- #
+        "ploidy_metrics": "\n\nThe following metrics could not be recognized. "
+        "Their headers are incomplete, hence uninformative and ugly table's columns.\n",
+        # ------------- #
+        "roh_metrics": "\n\nThe following metrics could not be recognized. "
+        "Their headers are incomplete, hence uninformative and ugly table's columns.\n",
+        # ------------- #
+        "sv_metrics": "\n\nThe following metrics are not included in the report:\n",
+        # ------------- #
+        "vc_hethom_ratio_metrics": "\n\nThe following metrics are not included in the report:\n",
+    },
+    "unusual_values": {
+        "coverage_metrics": "\n\nAll metrics' values except for int, float and NA are non-standard.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "overall_mean_cov_metrics": "\n\nAll metrics' values except for float are non-standard.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "cnv_metrics": "\n\nThe CNV SUMMARY section shall contain only int and float.\n"
+        "The second value of the SEX GENOTYPER section shall be float.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "ploidy_metrics": "\n\nEach value shall be either int, float or a combination of X/Y/0 for the karyotype.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "roh_metrics": "\n\nEach value shall be either int or float.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "sv_metrics": "\n\nEach value shall be either int or float.\n"
+        "The following files contain non-standard values:\n",
+        # ------------- #
+        "vc_hethom_ratio_metrics": "\n\nEach value shall be either int, float or inf.\n"
+        "The following files contain non-standard values:\n",
+    },
+}
+
+
+def make_log_report(log_data, logger, module):
+    """The only purpose of this function is to create a readable and
+    informative log output about found debug/info/warnings/errors"""
+
+    if "invalid_file_names" in log_data and log_data["invalid_file_names"]:
+        if module in DRAGEN_MODULE_TEXTS["invalid_file_names"]:
+            log_message = DRAGEN_MODULE_TEXTS["invalid_file_names"][module]
+        else:
+            log_message = "\n\nThe following files are not valid:\n"
+
+        for root in log_data["invalid_file_names"]:
+            log_message += "  " + root + ":\n"
+            for file in log_data["invalid_file_names"][root]:
+                log_message += "    " + file + "\n"
+
+        # Draw user's attention with error.
+        logger.error("dragen/" + module + ": invalid file names found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+    if "unknown_sections" in log_data and log_data["unknown_sections"]:
+        if module in DRAGEN_MODULE_TEXTS["unknown_sections"]:
+            log_message = DRAGEN_MODULE_TEXTS["unknown_sections"][module]
+        else:
+            log_message = "\n\nThe following sections could not be recognized.\n"
+
+        for section in log_data["unknown_sections"]:
+            log_message += "  " + section + "\n"
+
+        # Draw user's attention with warning.
+        logger.warning("dragen/" + module + ": unknown sections found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+    if "unknown_second_columns" in log_data and log_data["unknown_second_columns"]:
+        if module in DRAGEN_MODULE_TEXTS["unknown_second_columns"]:
+            log_message = DRAGEN_MODULE_TEXTS["unknown_second_columns"][module]
+        else:
+            log_message = "\n\nThe following RG/Samples could not be recognized.\n"
+
+        for section in log_data["unknown_second_columns"]:
+            log_message += "  " + section + ":\n"
+            for rg_sample in log_data["unknown_second_columns"][section]:
+                rg_sample = rg_sample if rg_sample else "Empty region"
+                log_message += "    " + rg_sample + "\n"
+
+        # Draw user's attention with warning.
+        logger.warning("dragen/" + module + ": unknown RG/Samples found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+    if "invalid_file_lines" in log_data and log_data["invalid_file_lines"]:
+        if module in DRAGEN_MODULE_TEXTS["invalid_file_lines"]:
+            log_message = DRAGEN_MODULE_TEXTS["invalid_file_lines"][module]
+        else:
+            log_message = "\n\nThe following files contain invalid lines:\n"
+
+        for root in log_data["invalid_file_lines"]:
+            log_message += "  " + root + ":\n"
+            for file in log_data["invalid_file_lines"][root]:
+                log_message += "    " + file + ":\n"
+                for line in log_data["invalid_file_lines"][root][file]:
+                    log_message += "      " + line + "\n"
+
+        # Draw user's attention with warning.
+        logger.warning("dragen/" + module + ": invalid file lines found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+    if "unknown_metrics" in log_data and log_data["unknown_metrics"]:
+        if module in DRAGEN_MODULE_TEXTS["unknown_metrics"]:
+            log_message = DRAGEN_MODULE_TEXTS["unknown_metrics"][module]
+        else:
+            log_message = "\n\nThe following metrics could not be recognized:\n"
+
+        for metric in log_data["unknown_metrics"]:
+            log_message += "  " + metric + "\n"
+
+        # Draw user's attention with warning.
+        logger.warning("dragen/" + module + ": unknown metrics found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+    if "unusual_values" in log_data and log_data["unusual_values"]:
+        if module in DRAGEN_MODULE_TEXTS["unusual_values"]:
+            log_message = DRAGEN_MODULE_TEXTS["unusual_values"][module]
+        else:
+            log_message = "\n\nThe following files contain non-standard values:\n"
+
+        for root in log_data["unusual_values"]:
+            log_message += "  " + root + ":\n"
+            for file in log_data["unusual_values"][root]:
+                log_message += "    " + file + ":\n"
+                for metric in log_data["unusual_values"][root][file]:
+                    log_message += "      " + metric + " = " + log_data["unusual_values"][root][file][metric] + "\n"
+
+        # Draw user's attention with warning.
+        logger.warning("dragen/" + module + ": unusual values found.")
+        # But print full info only in report.
+        logger.debug(log_message + "\n")
+
+
+"""______________________    Miscellaneous    ______________________"""
+
+
 def exist_and_number(data, *metrics):
     return all(isinstance(data.get(m, None), int) or isinstance(data.get(m, None), float) for m in metrics)
+
+
+def unhide_single_metric(headers):
+    """Solve a table bug: if table has only 1 metric and this metric is hidden, then there
+    is no user-friendly way to show it, because the "Configure columns" button is absent."""
+    if len(headers) == 1:
+        metric = list(headers.keys())[0]
+        headers[metric]["hidden"] = False

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -16,6 +16,9 @@ bamtools/stats:
   contents: "Stats for BAM file(s):"
   shared: true
   num_lines: 10
+bbduk:
+  contents: "Executing jgi.BBDuk"
+  num_lines: 2
 bbmap/stats:
   contents: "#Name	Reads	ReadsPct"
   num_lines: 4
@@ -272,16 +275,20 @@ deeptools/plotPCAData:
 deeptools/plotProfile:
   contents: "bin labels"
   num_lines: 1
+diamond:
+  fn: "diamond.log"
 dragen/vc_metrics:
   fn: "*.vc_metrics.csv"
 dragen/ploidy_estimation_metrics:
-  fn: "*.ploidy_estimation_metrics.csv"
+  fn_re: '.*\.ploidy_estimation_metrics\.csv'
 dragen/wgs_contig_mean_cov:
   fn_re: '.*\.wgs_contig_mean_cov_?(tumor|normal)?\.csv'
 dragen/wgs_coverage_metrics:
   fn_re: '.*\.wgs_coverage_metrics_?(tumor|normal)?\.csv'
+dragen/target_bed_coverage_metrics:
+  fn_re: '.*\.target_bed_coverage_metrics_?(tumor|normal)?\.csv'
 dragen/qc_region_coverage_metrics:
-  fn_re: '.*\.qc-coverage-region-([^_]+)_coverage_metrics.csv'
+  fn_re: '.*\.qc-coverage-region-([^_]+)_coverage_metrics_?(tumor|normal)?\.csv'
 dragen/wgs_fine_hist:
   fn_re: '.*\.wgs_fine_hist_?(tumor|normal)?\.csv'
 dragen/fragment_length_hist:
@@ -327,6 +334,10 @@ fgbio/groupreadsbyumi:
 fgbio/errorratebyreadposition:
   contents: "read_number	position	bases_total	errors	error_rate	a_to_c_error_rate	a_to_g_error_rate	a_to_t_error_rate	c_to_a_error_rate	c_to_g_error_rate	c_to_t_error_rate"
   num_lines: 3
+filtlong:
+  contents: Scoring long reads
+  contents_re: ".*Filtering long reads.*"
+  num_lines: 5
 flash/log:
   contents: "[FLASH]"
   shared: true
@@ -349,6 +360,8 @@ goleft_indexcov/roc:
   fn: "*-indexcov.roc"
 goleft_indexcov/ped:
   fn: "*-indexcov.ped"
+gopeaks:
+  fn: "*_gopeaks.json"
 happy:
   fn: "*.summary.csv"
   contents: "Type,Filter,TRUTH"
@@ -370,6 +383,9 @@ hicpro/mRSstat:
   fn: "*.mRSstat"
 hicpro/assplit:
   fn: "*.assplit.stat"
+hifiasm:
+  contents: "[M::ha_analyze_count]"
+  num_lines: 1
 hisat2:
   contents: "HISAT2 summary stats:"
   shared: true
@@ -390,6 +406,10 @@ homer/FreqDistribution:
   fn: "petag.FreqDistribution_1000.txt"
 hops:
   fn: "heatmap_overview_Wevid.json"
+humid:
+  fn: "stats.dat"
+  contents: "total: "
+  num_lines: 1
 interop/summary:
   contents: "Level,Yield,Projected Yield,Aligned,Error Rate,Intensity C1,%>=Q30"
 interop/index-summary:
@@ -463,11 +483,17 @@ mosdepth/global_dist:
   fn: "*.mosdepth.global.dist.txt"
 mosdepth/region_dist:
   fn: "*.mosdepth.region.dist.txt"
+motus:
+  contents: "Reads are aligned (by BWA) to marker gene sequences in the reference database"
+  num_lines: 2
 multivcfanalyzer:
   fn: "MultiVCFAnalyzer.json"
 disambiguate:
   contents: "unique species A pairs"
   num_lines: 2
+nextclade:
+  contents: "seqName;clade;"
+  num_lines: 1
 ngsderive/strandedness:
   contents: "File	TotalReads	ForwardPct	ReversePct	Predicted"
   num_lines: 1
@@ -586,6 +612,9 @@ picard/extractilluminabarcodes:
 picard/markilluminaadapters:
   contents: "MarkIlluminaAdapters"
   shared: true
+porechop:
+  contents: "Looking for known adapter sets"
+  num_lines: 10
 preseq:
   - contents: "EXPECTED_DISTINCT"
     num_lines: 2
@@ -593,6 +622,9 @@ preseq:
     num_lines: 2
 preseq/real_counts:
   fn: "*preseq_real_counts*"
+prinseqplusplus:
+  - contents: "reads removed by -"
+    num_lines: 2
 prokka:
   contents: "contigs:"
   num_lines: 2
@@ -789,6 +821,9 @@ tophat:
 trimmomatic:
   contents: "Trimmomatic"
   shared: true
+umitools:
+  contents: "# UMI-tools version:"
+  num_lines: 3
 varscan2/mpileup2snp:
   contents: "Only SNPs will be reported"
   num_lines: 3


### PR DESCRIPTION
New version of dragen/ploidy_estimation_metrics module.
- Improved configurations.
- Dedicated table and linegraph.
- Additional non-standard column "Autosome median / Autosomal median" ratios out of defined range. The default range is [0.95, 1.05]. but user can set their own in yaml configs. This column can be quickly taken out of table if it is not needed.