### PR TITLE
Software versions 2.0

### DIFF
--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -639,7 +639,7 @@ The version number here (`0.1.22`) can be extracted using the regex pattern
 
 ```python
 for line in f.splitlines():
-    version = re.search(`r'Version\ (\d{1}.\d+.\d+)'`, line)
+    version = re.search(r'Version\ (\d{1}.\d+.\d+)', line)
     if version is not None:
         self.add_software_version(version.group(1))
 ```

--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -619,6 +619,40 @@ are as shown:
 self.add_data_source(f=None, s_name=None, source=None, module=None, section=None)
 ```
 
+### Saving version information
+
+Software version information may be present in the log files of some tools. The 
+version number can be included in the report by passing it to the method 
+`self.add_software_version`. Let's use this `samblaster` log below as an example.
+
+```bash
+samblaster: Version 0.1.22
+samblaster: Opening /home/vagrant/samblaster_standalone.sam for read.
+samblaster: Outputting to stdout
+samblaster: Loaded 86 header sequence entries.
+samblaster: Marked 0 of 117 (0.00%) read ids as duplicates using 2752k memory in 0.000S CPU seconds and 0S wall time.
+```
+
+The version number here (`0.1.22`) can be extracted using the regex pattern 
+`r'Version\ (\d{1}.\d+.\d+)'`. The we can use the input to call
+ `self.add_software_version`. 
+
+```python
+for line in f.splitlines():
+    version = re.search(`r'Version\ (\d{1}.\d+.\d+)'`, line)
+    if version is not None:
+        self.add_software_version(version.group(1))
+```
+
+The version number will now appear after the module header in the report as 
+well as in the section `Software Versions` in the end of the report. 
+
+:::tip
+For tools that don't output software versions in their logs these can instead 
+be provided in a separate YAML file. See [Customising Reports](https://multiqc.info/docs/reports/customisation/#listing-software-versions) 
+for details.
+:::
+
 ## Step 3 - Adding to the general statistics table
 
 Now that you have your parsed data, you can start inserting it into the

--- a/docs/core/reports/customisation.md
+++ b/docs/core/reports/customisation.md
@@ -84,6 +84,29 @@ Then this will be displayed at the top of reports:
 
 Note that you can also specify a path to a config file using `-c`.
 
+## Listing software versions
+
+For some modules the software version can be parsed from the log files. If version 
+information is not included in the log files you can instead add them by providing 
+a separate YAML file. By default MultiQC will look for a YAML file called 
+`multiqc_versions.yaml` in you current directory. You can also provide the path 
+the YAML file through the parameter `version_fn_name` in you configs, for example:
+
+```yaml
+version_fn_name: path/to/versions.yaml
+```
+
+Software versions are specified in the YAML as pairs of software names and version 
+strings. Multiple version of the same software are specified as lists. Example:
+
+```yaml
+samblaster: "0.1.24"
+samtools:
+  - "1.15"
+  - "1.10"
+some_other_tool: "2023-1"
+```
+
 ## Sample name replacement
 
 Occasionally, when you run MultiQC you may know that you want to change the resulting

--- a/multiqc/modules/samblaster/samblaster.py
+++ b/multiqc/modules/samblaster/samblaster.py
@@ -12,6 +12,8 @@ from multiqc.plots import bargraph
 # Initialise the logger
 log = logging.getLogger(__name__)
 
+VERSION_REGEX = r"Version\ (\d{1}.\d+.\d+)"
+
 
 class MultiqcModule(BaseMultiqcModule):
     """Samblaster"""
@@ -86,6 +88,9 @@ class MultiqcModule(BaseMultiqcModule):
         s_name = None
         fh = f["f"]
         for l in fh:
+            match = re.search(VERSION_REGEX, l)
+            if match is not None:
+                self.add_software_version(match.group(1))
             # try to find name from RG-tag. If bwa mem is used upstream samblaster with pipes, then the bwa mem command
             # including the read group will be written in the log
             match = re.search(rgtag_name_regex, l)

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -3,6 +3,7 @@
 """ MultiQC submodule to parse output from Samtools stats """
 
 import logging
+import re
 from collections import OrderedDict
 
 from multiqc import config
@@ -10,6 +11,9 @@ from multiqc.plots import bargraph, beeswarm
 
 # Initialise the logger
 log = logging.getLogger(__name__)
+
+# Regex to grab version number from samtools stats contents
+VERSION_REGEX = r"\((\d+.(\d+|\d+.\d+))\+"
 
 
 class StatsReportMixin:
@@ -22,6 +26,12 @@ class StatsReportMixin:
         for f in self.find_log_files("samtools/stats"):
             parsed_data = dict()
             for line in f["f"].splitlines():
+                # Get version number from file contents
+                if line.startswith("# This file was produced by samtools stats"):
+                    version_match = re.search(VERSION_REGEX, line)
+                    if version_match is not None:
+                        self.add_software_version(version_match.group(1))
+
                 if not line.startswith("SN"):
                     continue
                 sections = line.split("\t")

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -749,7 +749,7 @@ def run(
     # Parse software version from separate YAML file if it exists
     versions_from_file = software_versions.load_versions_from_yaml(config.version_fn_name)
     if versions_from_file:
-        name_to_module = {module.name: module for module in report.modules_output}
+        name_to_module = {module.anchor: module for module in report.modules_output}
         for software, versions in versions_from_file.items():
             # Try to find if the software is listed among the executed modules. Unlisted software are still
             # reported in the `Software Versions` section.

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -746,6 +746,12 @@ def run(
         report.runtimes["mods"][run_module_names[mod_idx]] = time.time() - mod_starttime
     report.runtimes["total_mods"] = time.time() - total_mods_starttime
 
+    # Add section for software versions if any are found
+    if report.software_versions:
+        from multiqc.utils import software_versions
+
+        report.modules_output.append(software_versions.MultiqcModule())
+
     # Special-case module if we want to profile the MultiQC running time
     if config.profile_runtime:
         from multiqc.utils import profile_runtime

--- a/multiqc/templates/default/assets/css/default_multiqc.css
+++ b/multiqc/templates/default/assets/css/default_multiqc.css
@@ -190,6 +190,10 @@ kbd {
   border-left: 5px solid #8eb9dd;
   background-color: #e8f1f8;
 }
+.mqc-module-title{
+  display: inline;
+  margin-right: 5px;
+}
 #analysis_dirs_wrapper {
   max-height: 80px;
   overflow: auto;

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -13,7 +13,10 @@ the output from each module and print it in sections.
     {% for s in m.sections %}
       {% if loop.first %}
       <div class="mqc-module-section-first">
-        <h2 id="{{ m.anchor }}">{{ m.name }}</h2>
+        <h2 class="mqc-module-title" id="{{ m.anchor }}">{{ m.name }}</h2>
+        {% if m.versions %}
+          <span><em>Version:</em> <code>{{m.versions|join("</code>, <code>")}}</code></span>
+        {% endif %}
         {{ m.intro if m.intro }}
         {% if m['comment'] %}<blockquote class="mqc-section-comment">{{ m['comment'] }}</blockquote>{% endif %}
       {% endif %}

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -38,6 +38,7 @@ base_count_desc: "millions"
 output_fn_name: "multiqc_report.html"
 data_dir_name: "multiqc_data"
 plots_dir_name: "multiqc_plots"
+versions_fn_name: "multiqc_versions.yaml"
 data_format: "tsv"
 module_tag: []
 force: false

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -38,7 +38,7 @@ base_count_desc: "millions"
 output_fn_name: "multiqc_report.html"
 data_dir_name: "multiqc_data"
 plots_dir_name: "multiqc_plots"
-versions_fn_name: "multiqc_versions.yaml"
+version_fn_name: "multiqc_versions.yaml"
 data_format: "tsv"
 module_tag: []
 force: false

--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -100,6 +100,10 @@ def init():
     global files
     files = dict()
 
+    # Map of software tools to a set of unique version strings
+    global software_versions
+    software_versions = defaultdict(list)
+
 
 def get_filelist(run_module_names):
     """

--- a/multiqc/utils/software_versions.py
+++ b/multiqc/utils/software_versions.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+""" Super Special-Case MultiQC module to produce report section on software versions """
+
+
+import logging
+
+from multiqc.modules.base_module import BaseMultiqcModule
+from multiqc.utils import report
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    def __init__(self):
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(
+            name="Software Versions",
+            anchor="multiqc_software_versions",
+            info="Versions of software tools extracted from file contents.",
+        )
+
+        # Don't repeat the Custom Content name in the subtext
+        if self.info or self.extra:
+            self.intro = "<p>{}</p>{}".format(self.info, self.extra)
+
+        self.report_software_versions()
+
+    def report_software_versions(self):
+        """Create section listing software versions."""
+        content = "<dl class=dl-horizontal>\n"
+        for tool_name in sorted(report.software_versions):
+            versions = [str(version) for version in report.software_versions[tool_name]]
+            versions_string = "</code>, <code>".join(versions)
+            content += f"  <dt>{tool_name}</dt><dd><code>{versions_string}</code></dd>\n"
+        content += "</dl>\n"
+
+        self.add_section(name=None, content=content)


### PR DESCRIPTION
This PR is inspired by https://github.com/ewels/MultiQC/pull/536 and is a first step to add software version information to the MultiQC report (see discussion in https://github.com/ewels/MultiQC/issues/290). 

So far I have only parsed version information from two tools (`samblaster` and `samtools stats`) but I figured it would be good to get some input on this before continuing. I have also added the ability to specify an auxiliary YAML file (default name `multiqc_versions.yaml`) with version information. 

**Examples**

Below is an example of how the version information is displayed in the report. Here the version are listed after the module section title. 

<img width="793" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/75a27e6f-5f56-4fd9-9046-a950ffb271d4">

Here is another example with multiple version of the same software.

<img width="820" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/72e89e55-d463-4d79-8fd0-0cbcd2f642bd">

After all module sections a new section called `Software Versions` is added. See image below for example.

<img width="762" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/515ed956-59b1-435b-bc2a-69f899f3cd23">

There will be quite some work to add version information for the other modules. I tired "grepping" the log files for version information and it seamed that at least 50% contained version info, so it will be quite a few. Possibly this could be done in separate PRs.

**Additional ideas**
- Some software that don't output version information to their statistics logs. For some of these you could probably get the version some other way, for example with bowtie2 you could call `bowtie2 --version > sample.version.txt` and parse this log for any discovered samples. Only downside is that MultiQC users would need to change their workflows. 
- List software version connected to each sample name. Something like the dropdown discussed in https://github.com/ewels/MultiQC/issues/290. 

**Summary of additions:**
- new `BaseMultiqcModule` method `add_software_version` to collect and report version extracted from logs
- new "special" module `software_versions` to for creating HTML for `Software Versions` section of the report. Also includes utility functions for loading version for a YAML file and matching softwares to executed multiqc modules.
- new config parameter `version_fn_name` that specifies the path to an auxiliary YAML with version information. 
- extract version info from `samtools stats` and `samblaster` modules. 
- updated docs

---

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated