### PR TITLE
New module: Sentieon Dedup Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   - Added report section listing samples that had no adapters trimmed
 - **RSeQC**
   - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/ewels/MultiQC/issues/1735))
+- **Sentieon**
+  - Added support for metrics from Sentieon's DNAseq function Dedup (corresponding the Picard's Markduplicates). ([#1936](https://github.com/ewels/MultiQC/issues/1936))
 - **UMI-tools**
   - Fix bug that broke the module with paired-end data ([#1845](https://github.com/ewels/MultiQC/issues/1845))
 

--- a/docs/modules/sentieon.md
+++ b/docs/modules/sentieon.md
@@ -2,7 +2,7 @@
 name: Sentieon
 url: https://www.sentieon.com/products/
 description: >
-  Sentieon-dnaseq produces many outputs. This module deals with 3 Picard
+  Sentieon-dnaseq produces many outputs. This module deals with four Picard
   equivalents which do not transfer well to MultiQC. The code for each script
   is split into its own file and adds a section to the module output if
   logs are found.
@@ -16,6 +16,7 @@ sequencing data.
 
 Supported commands:
 
-- `InsertSizeMetrics`
-- `GcBiasMetrics`
 - `AlignmentSummaryMetrics`
+- `GcBiasMetrics`
+- `InsertSizeMetrics`
+- `SentieonDedupMetrics`

--- a/multiqc/modules/sentieon/DedupMetrics.py
+++ b/multiqc/modules/sentieon/DedupMetrics.py
@@ -1,0 +1,319 @@
+""" MultiQC submodule to parse output from Sentieon Dedup metrics """
+
+import logging
+import math
+import os
+import re
+from collections import OrderedDict
+
+from multiqc import config
+from multiqc.plots import bargraph
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+def parse_reports(
+    self,
+    log_key="sentieon/dedup",
+    section_name="Sention Dedup",
+    section_anchor="sentieon-dedup",
+    plot_title="Sentieon: Deduplication Stats",
+    plot_id="sentieon_deduplication",
+    data_filename="multiqc_sentieon_dups",
+):
+    """Find Sentieon Dedup reports and parse their dataself.
+    The code is borrowed from the corresponding function in the picard MarkDuplicates module.
+    """
+
+    # Set up vars
+    self.sentieon_dupMetrics_data = dict()
+
+    # Get custom config value
+    try:
+        merge_multiple_libraries = config.picard_config["dedup_merge_multiple_libraries"]
+    except (AttributeError, KeyError):
+        merge_multiple_libraries = True
+
+    # Function to save results at end of table
+    def save_table_results(s_name, base_s_name, keys, parsed_data, recompute_merged_metrics):
+        # No data
+        if len(keys) == 0 or len(parsed_data) == 0:
+            return
+
+        # User has requested each library is kept separate
+        # Update the sample name to append the library name
+        if not merge_multiple_libraries and len(parsed_data) > 0:
+            s_name = "{} - {}".format(s_name, parsed_data["LIBRARY"])
+
+        # Skip - No reads
+        try:
+            if parsed_data["READ_PAIRS_EXAMINED"] == 0 and parsed_data["UNPAIRED_READS_EXAMINED"] == 0:
+                log.warning("Skipping Dedup metrics for sample '{}' as log contained no reads".format(s_name))
+                return
+        # Skip - Missing essential fields
+        except KeyError:
+            log.warning("Skipping Dedup metrics for sample '{}' as missing essential fields".format(s_name))
+            return
+
+        # Recompute PERCENT_DUPLICATION and ESTIMATED_LIBRARY_SIZE
+        if recompute_merged_metrics:
+            parsed_data["PERCENT_DUPLICATION"] = calculatePercentageDuplication(parsed_data)
+            parsed_data["ESTIMATED_LIBRARY_SIZE"] = estimateLibrarySize(parsed_data)
+
+        # Save the data
+        if s_name in self.sentieon_dupMetrics_data:
+            log.debug("Duplicate sample name found in {}! Overwriting: {}".format(f["fn"], s_name))
+        self.sentieon_dupMetrics_data[s_name] = parsed_data
+        self.add_data_source(f, s_name, section="DuplicationMetrics")
+
+        # End of metrics table - reset for next sample
+        if len(vals) < 6:
+            return True
+
+        # On to the next library if not merging
+        else:
+            s_name = base_s_name
+            parsed_data = {}
+
+    # Go through logs and find Metrics
+    for f in self.find_log_files(log_key, filehandles=True):
+        s_name = f["s_name"]
+        base_s_name = f["s_name"]
+        parsed_data = {}
+        keys = None
+        in_stats_block = False
+        recompute_merged_metrics = False
+        for l in f["f"]:
+            #
+            # New log starting
+            #
+            if "markduplicates" in l.lower() and "input" in l.lower():
+                # Pull sample name from input
+                fn_search = re.search(r"INPUT(?:=|\s+)(\[?[^\s]+\]?)", l, flags=re.IGNORECASE)
+                if fn_search:
+                    s_name = os.path.basename(fn_search.group(1).strip("[]"))
+                    s_name = self.clean_s_name(s_name, f)
+                    base_s_name = s_name
+                continue
+
+            #
+            # Start of the METRICS table
+            #
+            if "UNPAIRED_READ_DUPLICATES" in l:
+                in_stats_block = True
+                keys = l.rstrip("\n").split("\t")
+                continue
+
+            #
+            # Currently parsing the METRICS table
+            #
+            if in_stats_block:
+                # Split the values columns
+                vals = l.rstrip("\n").split("\t")
+
+                # End of the METRICS table, or multiple libraries and we're not merging them
+                if len(vals) < 6 or (not merge_multiple_libraries and len(parsed_data) > 0):
+                    if save_table_results(s_name, base_s_name, keys, parsed_data, recompute_merged_metrics):
+                        # Reset for next file if returned True
+                        s_name = f["s_name"]
+                        base_s_name = f["s_name"]
+                        parsed_data = {}
+                        keys = None
+                        in_stats_block = False
+                        recompute_merged_metrics = False
+
+                #
+                # Parse the column values
+                #
+                if keys and vals and len(keys) == len(vals):
+                    for i, k in enumerate(keys):
+                        # More than one library present and merging stats
+                        if k in parsed_data:
+                            recompute_merged_metrics = True
+                            try:
+                                parsed_data[k] += float(vals[i])
+                            except (ValueError, TypeError):
+                                parsed_data[k] += " / " + vals[i]
+
+                        # First library
+                        else:
+                            try:
+                                parsed_data[k] = float(vals[i])
+                            except ValueError:
+                                parsed_data[k] = vals[i]
+
+        # Files with no extra lines after last library
+        if in_stats_block:
+            save_table_results(s_name, base_s_name, keys, parsed_data, recompute_merged_metrics)
+
+    #
+    # Filter to strip out ignored sample names
+    #
+    self.sentieon_dupMetrics_data = self.ignore_samples(self.sentieon_dupMetrics_data)
+
+    if len(self.sentieon_dupMetrics_data) > 0:
+        # Write parsed data to a file
+        self.write_data_file(self.sentieon_dupMetrics_data, data_filename)
+
+        # Add to general stats table
+        self.general_stats_headers["PERCENT_DUPLICATION"] = {
+            "title": "% Dups",
+            "description": "{} - Percent Duplication".format(section_name),
+            "max": 100,
+            "min": 0,
+            "suffix": "%",
+            "scale": "OrRd",
+            "modify": lambda x: self.multiply_hundred(x),
+        }
+        for s_name in self.sentieon_dupMetrics_data:
+            if s_name not in self.general_stats_data:
+                self.general_stats_data[s_name] = dict()
+            self.general_stats_data[s_name].update(self.sentieon_dupMetrics_data[s_name])
+
+        # Make the bar plot and add to the Dedup section
+        #
+        # The table in the Dedup metrics file contains some columns referring
+        # read pairs and some referring to single reads.
+        for s_name, metr in self.sentieon_dupMetrics_data.items():
+            metr["READS_IN_DUPLICATE_PAIRS"] = 2.0 * metr["READ_PAIR_DUPLICATES"]
+            metr["READS_IN_UNIQUE_PAIRS"] = 2.0 * (metr["READ_PAIRS_EXAMINED"] - metr["READ_PAIR_DUPLICATES"])
+            metr["READS_IN_UNIQUE_UNPAIRED"] = metr["UNPAIRED_READS_EXAMINED"] - metr["UNPAIRED_READ_DUPLICATES"]
+            metr["READS_IN_DUPLICATE_PAIRS_OPTICAL"] = 2.0 * metr["READ_PAIR_OPTICAL_DUPLICATES"]
+            metr["READS_IN_DUPLICATE_PAIRS_NONOPTICAL"] = (
+                metr["READS_IN_DUPLICATE_PAIRS"] - metr["READS_IN_DUPLICATE_PAIRS_OPTICAL"]
+            )
+            metr["READS_IN_DUPLICATE_UNPAIRED"] = metr["UNPAIRED_READ_DUPLICATES"]
+            metr["READS_UNMAPPED"] = metr["UNMAPPED_READS"]
+
+        keys = OrderedDict()
+        keys_r = [
+            "READS_IN_UNIQUE_PAIRS",
+            "READS_IN_UNIQUE_UNPAIRED",
+            "READS_IN_DUPLICATE_PAIRS_OPTICAL",
+            "READS_IN_DUPLICATE_PAIRS_NONOPTICAL",
+            "READS_IN_DUPLICATE_UNPAIRED",
+            "READS_UNMAPPED",
+        ]
+        for k in keys_r:
+            keys[k] = {"name": k.replace("READS_", "").replace("IN_", "").replace("_", " ").title()}
+
+        # Config for the plot
+        pconfig = {
+            "id": plot_id,
+            "title": plot_title,
+            "ylab": "# Reads",
+            "cpswitch_counts_label": "Number of Reads",
+            "cpswitch_c_active": False,
+        }
+
+        self.add_section(
+            name=section_name,
+            anchor=section_anchor,
+            description="Number of reads, categorised by duplication state. **Pair counts are doubled** - see help text for details.",
+            helptext="""
+            The table in the Sentieon metrics file contains some columns referring
+            read pairs and some referring to single reads.
+
+            To make the numbers in this plot sum correctly, values referring to pairs are doubled
+            according to the scheme below:
+
+            * `READS_IN_DUPLICATE_PAIRS = 2 * READ_PAIR_DUPLICATES`
+            * `READS_IN_UNIQUE_PAIRS = 2 * (READ_PAIRS_EXAMINED - READ_PAIR_DUPLICATES)`
+            * `READS_IN_UNIQUE_UNPAIRED = UNPAIRED_READS_EXAMINED - UNPAIRED_READ_DUPLICATES`
+            * `READS_IN_DUPLICATE_PAIRS_OPTICAL = 2 * READ_PAIR_OPTICAL_DUPLICATES`
+            * `READS_IN_DUPLICATE_PAIRS_NONOPTICAL = READS_IN_DUPLICATE_PAIRS - READS_IN_DUPLICATE_PAIRS_OPTICAL`
+            * `READS_IN_DUPLICATE_UNPAIRED = UNPAIRED_READ_DUPLICATES`
+            * `READS_UNMAPPED = UNMAPPED_READS`
+            """,
+            plot=bargraph.plot(self.sentieon_dupMetrics_data, keys, pconfig),
+        )
+
+    # Return the number of detected samples to the parent module
+    return len(self.sentieon_dupMetrics_data)
+
+
+def calculatePercentageDuplication(d):
+    """
+    Picard calculation to compute percentage duplication
+
+    Taken & translated from the Picard codebase:
+    https://github.com/broadinstitute/picard/blob/78ea24466d9bcab93db89f22e6a6bf64d0ad7782/src/main/java/picard/sam/DuplicationMetrics.java#L106-L110
+    """
+    try:
+        dups = d["UNPAIRED_READ_DUPLICATES"] + d["READ_PAIR_DUPLICATES"] * 2
+        examined = d["UNPAIRED_READS_EXAMINED"] + d["READ_PAIRS_EXAMINED"] * 2
+        if examined == 0:
+            return 0
+        return float(dups) / float(examined)
+    except KeyError:
+        return 0
+
+
+def estimateLibrarySize(d):
+    """
+    Picard calculation to estimate library size
+
+    Taken & translated from the Picard codebase:
+    https://github.com/broadinstitute/picard/blob/78ea24466d9bcab93db89f22e6a6bf64d0ad7782/src/main/java/picard/sam/DuplicationMetrics.java#L153-L164
+
+    Note: Optical duplicates are contained in duplicates and therefore do not enter the calculation here.
+    See also the computation of READ_PAIR_NOT_OPTICAL_DUPLICATES.
+
+     * Estimates the size of a library based on the number of paired end molecules observed
+     * and the number of unique pairs observed.
+     * <p>
+     * Based on the Lander-Waterman equation that states:
+     * C/X = 1 - exp( -N/X )
+     * where
+     * X = number of distinct molecules in library
+     * N = number of read pairs
+     * C = number of distinct fragments observed in read pairs
+    """
+
+    try:
+        readPairs = d["READ_PAIRS_EXAMINED"] - d["READ_PAIR_OPTICAL_DUPLICATES"]
+        uniqueReadPairs = d["READ_PAIRS_EXAMINED"] - d["READ_PAIR_DUPLICATES"]
+    except KeyError:
+        return None
+
+    readPairDuplicates = readPairs - uniqueReadPairs
+
+    if readPairs > 0 and readPairDuplicates > 0:
+        m = 1.0
+        M = 100.0
+
+        if uniqueReadPairs >= readPairs or f(m * uniqueReadPairs, uniqueReadPairs, readPairs) < 0:
+            logging.warning("Picard recalculation of ESTIMATED_LIBRARY_SIZE skipped - metrics look wrong")
+            return None
+
+        # find value of M, large enough to act as other side for bisection method
+        while f(M * uniqueReadPairs, uniqueReadPairs, readPairs) > 0:
+            M *= 10.0
+
+        # use bisection method (no more than 40 times) to find solution
+        for i in range(40):
+            r = (m + M) / 2.0
+            u = f(r * uniqueReadPairs, uniqueReadPairs, readPairs)
+            if u == 0:
+                break
+            elif u > 0:
+                m = r
+            elif u < 0:
+                M = r
+
+        return uniqueReadPairs * (m + M) / 2.0
+    else:
+        return None
+
+
+def f(x, c, n):
+    """
+    Picard calculation used when estimating library size
+
+    Taken & translated from the Picard codebase:
+    https://github.com/broadinstitute/picard/blob/78ea24466d9bcab93db89f22e6a6bf64d0ad7782/src/main/java/picard/sam/DuplicationMetrics.java#L172-L177
+
+    * Method that is used in the computation of estimated library size.
+    """
+    return c / x - 1 + math.exp(-n / x)

--- a/multiqc/modules/sentieon/DedupMetrics.py
+++ b/multiqc/modules/sentieon/DedupMetrics.py
@@ -15,7 +15,6 @@ log = logging.getLogger(__name__)
 
 def parse_reports(
     self,
-    log_key="sentieon/dedup",
     section_name="Sention Dedup",
     section_anchor="sentieon-dedup",
     plot_title="Sentieon: Deduplication Stats",
@@ -77,7 +76,7 @@ def parse_reports(
             parsed_data = {}
 
     # Go through logs and find Metrics
-    for f in self.find_log_files(log_key, filehandles=True):
+    for f in self.find_log_files("sentieon/dedup", filehandles=True):
         s_name = f["s_name"]
         base_s_name = f["s_name"]
         parsed_data = {}

--- a/multiqc/modules/sentieon/DedupMetrics.py
+++ b/multiqc/modules/sentieon/DedupMetrics.py
@@ -88,9 +88,9 @@ def parse_reports(
             #
             # New log starting
             #
-            if "markduplicates" in l.lower() and "input" in l.lower():
+            if "SentieonCommandLine" in l and "-i " in l and "--algo Dedup" in l:
                 # Pull sample name from input
-                fn_search = re.search(r"INPUT(?:=|\s+)(\[?[^\s]+\]?)", l, flags=re.IGNORECASE)
+                fn_search = re.search(r"-i(?:=|\s+)(\[?[^\s]+\]?)", l)
                 if fn_search:
                     s_name = os.path.basename(fn_search.group(1).strip("[]"))
                     s_name = self.clean_s_name(s_name, f)

--- a/multiqc/modules/sentieon/sentieon.py
+++ b/multiqc/modules/sentieon/sentieon.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from multiqc.modules.base_module import BaseMultiqcModule
 
 # Import the Sentieon submodules
-from . import AlignmentSummaryMetrics, GcBiasMetrics, InsertSizeMetrics
+from . import AlignmentSummaryMetrics, DedupMetrics, GcBiasMetrics, InsertSizeMetrics
 
 # Initialise the logger
 log = logging.getLogger(__name__)
@@ -38,6 +38,11 @@ class MultiqcModule(BaseMultiqcModule):
         n["AlignmentMetrics"] = AlignmentSummaryMetrics.parse_reports(self)
         if n["AlignmentMetrics"] > 0:
             log.info("Found {} AlignmentSummaryMetrics reports".format(n["AlignmentMetrics"]))
+
+        # Call submodule functions
+        n["DedupMetrics"] = DedupMetrics.parse_reports(self)
+        if n["DedupMetrics"] > 0:
+            log.info("Found {} DedupMetrics reports".format(n["DedupMetrics"]))
 
         n["GcBiasMetrics"] = GcBiasMetrics.parse_reports(self)
         if n["GcBiasMetrics"] > 0:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -730,6 +730,10 @@ sargasso:
 sentieon/alignment_metrics:
   contents: "--algo AlignmentStat"
   shared: true
+sentieon/dedup:
+  contents: "--algo Dedup"
+  num_lines: 3
+  shared: true
 sentieon/insertsize:
   contents: "--algo InsertSizeMetricAlgo"
   shared: true


### PR DESCRIPTION
Adding support for Sentieon Dedup Metrics (corresponding to picard MarkDuplicates)

Issue #1936 

As far as I could tell, we can't just call the MarkDuplicates MultiQC-module for the Sentieon-Dedup (as is done in the 
 [biobambam2/bamsormadup MultiQC-module ](https://github.com/asp8200/MultiQC/blob/sentieon_dedup/multiqc/modules/biobambam2/biobambam2.py)), since, for instance, parsing of the Sentieon-command is different from the parsing of the MarkDuplicates command. 

<img width="1300" alt="image" src="https://github.com/ewels/MultiQC/assets/37172585/c8ce616e-7122-4deb-986e-9ec689734c27">

This is how the Sentieon Dedup section looks if MultiQC findes to DedupMetrics-files:
<img width="1044" alt="image" src="https://github.com/ewels/MultiQC/assets/37172585/7c4b4684-2e21-4ba5-85d3-c0a1bd23e94d">
 
The Sentieon Dedup Metrics are displayed just like the corresponding metrics from Picard MarkDuplicates, and the module code was copied and adjusted from the Markduplicates MultiQC-module.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated


- [x] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository : [data/modules/sentieon/issue_1180/P150_PE.st.metrics.DeDup.txt](https://github.com/asp8200/MultiQC_TestData/blob/master/data/modules/sentieon/issue_1180/P150_PE.st.metrics.DeDup.txt)
- [x] Code is tested and works locally (including with `--lint` flag)
- [x] `docs/README.md` is updated with link to below
- [x] `docs/modules/sentieon.md` was already present but is now updated.
- [x] Everything that can be represented with a plot instead of a table is a plot
- [x] Report sections have a description and help text (with `self.add_section`)
- [x] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [x] Each table column has a different colour scale to its neighbour, which relates to the data (eg. if high numbers are bad, they're red)
- [x] Module does not do any significant computational work
