### PR TITLE
Update rna quant metrics for dragen 4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/ewels/MultiQC/issues/1853), [#1871](https://github.com/ewels/MultiQC/issues/1871))
 - **DRAGEN**
   - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/ewels/MultiQC/issues/1844))
+  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/ewels/MultiQC/pull/1958))
 - **filtlong**
   - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/ewels/MultiQC/issues/1843))
 - **HUMID**

--- a/multiqc/modules/dragen/rna_quant_metrics.py
+++ b/multiqc/modules/dragen/rna_quant_metrics.py
@@ -83,7 +83,7 @@ def parse_time_metrics_file(f):
     RUN TIME,,Time sorting and marking duplicates,00:00:07.368,7.37
     RUN TIME,,Time DRAGStr calibration,00:00:07.069,7.07
     """
-    s_name = re.search(r"(.*).quant.metrics.csv", f["fn"]).group(1)
+    s_name = re.search(r"(.*).quant[.|_]metrics.csv", f["fn"]).group(1)
 
     data = {}
     for line in f["f"].splitlines():


### PR DESCRIPTION
Dragen 4.2 uses suffix `.quant_metrics.csv` as opposed to previous versions `.quant.metrics.csv`.  

