### PR TITLE
When exporting plots, make a more clear error message for unsupported FastQC dot plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Removed `simplejson` unused dependency ([#1973](https://github.com/ewels/MultiQC/pull/1973))
 - Give config `custom_plot_config` priority over column-specific settings set by modules
+- When exporting plots, make a more clear error message for unsupported FastQC dot plot [#1976](https://github.com/ewels/MultiQC/pull/1976)
 
 ### New Modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -51,4 +51,8 @@ script-src 'self'
     'sha256-1pWjCVoi5AoQvT52zb72qGCpIpfJzlc9trKcbcarXUY=' # multiqc_toolbox.js
     'sha256-gB0osLOAZOyj1tcLhUs/xzf98qK3dfViuIJdX0lI8xA=' # multiqc_fastqc.js
     'unsafe-eval'
+    
+    # 1.16
+    'sha256-wlLs2UDz7n3cvWqY0PTazlKGYhGTOPH77vsElgE7pFw=' # multiqc_fastqc.js
+    'sha256-GueuiCxuV8FbnCv7Txho8dTrz3HODU6GH40tvy5kMks=' # multiqc_dragen_fastqc.js
 ;

--- a/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
+++ b/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
@@ -420,7 +420,9 @@ function fastqc_module(module_element, module_key) {
 
   // Export plot
   module_element.find(".dragen_fastqc_per_base_sequence_content_plot").on("mqc_plotexport_image", function (e, cfg) {
-    alert("Apologies, it's not yet possible to export this plot.\nPlease take a screengrab or export the JSON data.");
+    alert(
+      "Apologies, it's not yet possible to export the DRAGEN-FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data."
+    );
   });
   module_element.find(".dragen_fastqc_per_base_sequence_content_plot").on("mqc_plotexport_data", function (e, cfg) {
     if (cfg["ft"] == "json") {
@@ -428,7 +430,7 @@ function fastqc_module(module_element, module_key) {
       var blob = new Blob([json_str], { type: "text/plain;charset=utf-8" });
       saveAs(blob, cfg["fname"]);
     } else {
-      alert("Apologies, this plot can only be exported as JSON currently.");
+      alert("Apologies, the DRAGEN-FastQC per-base sequence content plot can only be exported as JSON currently.");
     }
   });
 

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -421,7 +421,9 @@ function fastqc_module(module_element, module_key) {
 
   // Export plot
   module_element.find(".fastqc_per_base_sequence_content_plot").on("mqc_plotexport_image", function (e, cfg) {
-    alert("Apologies, it's not yet possible to export this plot.\nPlease take a screengrab or export the JSON data.");
+    alert(
+      "Apologies, it's not yet possible to export the FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data."
+    );
   });
   module_element.find(".fastqc_per_base_sequence_content_plot").on("mqc_plotexport_data", function (e, cfg) {
     if (cfg["ft"] == "json") {
@@ -429,7 +431,7 @@ function fastqc_module(module_element, module_key) {
       var blob = new Blob([json_str], { type: "text/plain;charset=utf-8" });
       saveAs(blob, cfg["fname"]);
     } else {
-      alert("Apologies, this plot can only be exported as JSON currently.");
+      alert("Apologies, the FastQC per-base sequence content plot can only be exported as JSON currently.");
     }
   });
 

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -131,7 +131,7 @@ def make_table(dt):
         )
 
         # Make a colour scale
-        if header["scale"] == False:
+        if header["scale"] is False:
             c_scale = None
         else:
             c_scale = mqc_colour.mqc_colour_scale(header["scale"], header["dmin"], header["dmax"], id=table_id)
@@ -162,7 +162,7 @@ def make_table(dt):
                     dmin = header["dmin"]
                     dmax = header["dmax"]
                     percentage = ((float(val) - dmin) / (dmax - dmin)) * 100
-                    # Treat 0 as 0-width and make bars width of absoluate value
+                    # Treat 0 as 0-width and make bars width of absolute value
                     if header.get("bars_zero_centrepoint"):
                         dmax = max(abs(header["dmin"]), abs(header["dmax"]))
                         dmin = 0

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -61,6 +61,7 @@ it prints the contents of these files into the report.
 <script type="text/javascript">{{ include_file('assets/js/multiqc_tables.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_plotting.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_mpl.js') }}</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js"></script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_toolbox.js') }}</script>
 {% set included_js = [] %}
 {%- for m in report.modules_output %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js.values() %}

--- a/multiqc/templates/default/includes.html
+++ b/multiqc/templates/default/includes.html
@@ -61,7 +61,6 @@ it prints the contents of these files into the report.
 <script type="text/javascript">{{ include_file('assets/js/multiqc_tables.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_plotting.js') }}</script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_mpl.js') }}</script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.5/jszip.min.js"></script>
 <script type="text/javascript">{{ include_file('assets/js/multiqc_toolbox.js') }}</script>
 {% set included_js = [] %}
 {%- for m in report.modules_output %}{% if m.js and m.js|length > 0 -%}{% for js_href in m.js.values() %}

--- a/test/print_missing_csp.py
+++ b/test/print_missing_csp.py
@@ -22,7 +22,8 @@ def is_executable(script):
     executable_types = {
         "text/javascript",
         "application/javascript",
-        "module" "text/ecmascript",
+        "module",
+        "text/ecmascript",
         "application/ecmascript",
     }
     script_type = script.attrs.get("type", "text/javascript")


### PR DESCRIPTION
Some refactoring while debugging https://github.com/ewels/MultiQC/issues/1873

Per-base content FastQC plot is not supported for export, and currently, there are alert messages shown to warn the user about that. I think one quick improvement here is to specify what type of plot exactly is failing, in case the user would export multiple plots at once.

Further improvements would be to perhaps replace the alert with a more friendly inline warning, or even to fix the export for this plot. But since we will likely be moving away from Highcharts (https://github.com/ewels/MultiQC/issues/1789), it's probably not worth refactoring it much for now.