### PR TITLE
Fix sample names convert to float in custom content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Module updates
 
+- **Custom content**
+  - Don't convert sample IDs to floats ([#1883](https://github.com/ewels/MultiQC/issues/1883))
 - **Kraken**
   - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/ewels/MultiQC/issues/1766)).
 - **Mosdepth**

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -558,8 +558,8 @@ def _parse_txt(f, conf):
 
     all_numeric = all([type(l) == float for l in d[i][1:] for i in range(1, len(d))])
 
-    # General stat info files - expected to be have at least 2 rows (first row always being the header)
-    # and have atleast 2 columns (first column always being sample name)
+    # General stat info files - expected to have at least 2 rows (first row always being the header)
+    # and have at least 2 columns (first column always being sample name)
     if conf.get("plot_type") == "generalstats" and len(d) >= 2 and ncols >= 2:
         data = defaultdict(dict)
         for i, l in enumerate(d[1:], 1):


### PR DESCRIPTION
Fix https://github.com/ewels/MultiQC/issues/1883 by keeping sample names as strings in TSV custom content parsing.

Long term, refactoring to use a more type-safe approach would help to avoid such problems.