### PR TITLE
Add mosdepth XY coverage plot and contig filtering options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Module updates
 
+- **Mosdepth**
+  - Add X/Y relative coverage plot ([#1978](https://github.com/ewels/MultiQC/issues/1978)), analogous to the one in samtools-idxstats.
+  - Added the `perchrom_fraction_cutoff` option into the config to help avoid clutter in contig-level plots
+
 ## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
 
 #### Potential breaking change in some edge cases

--- a/docs/modules/mosdepth.md
+++ b/docs/modules/mosdepth.md
@@ -70,6 +70,15 @@ mosdepth_config:
 
 Note that exclusion superseeds inclusion for the contig filters.
 
+To additionally avoid cluttering the plot, mosdepth can exclude contigs with a low relative coverage.
+
+```yaml
+mosdepth_config:
+  # Should be a fraction, e.g. 0.001 (exclude contigs with 0.1% coverage of sum of
+  # coverages across all contigs)
+  perchrom_fraction_cutoff: 0.001
+```
+
 If you want to see what is being excluded, you can set `show_excluded_debug_logs` to `True`:
 
 ```yaml
@@ -83,3 +92,13 @@ This is disabled by default as there can be very many in some cases.
 Besides the `{prefix}.mosdepth.global.dist.txt` and `{prefix}.mosdepth.region.dist.txt`
 files, the `{prefix}.mosdepth.summary.txt` file is used to get the mean coverage for the
 General Stats table.
+
+The module also plots an X/Y relative chromosome coverage per sample. By default, it finds chromosome named X/Y or chrX/chrY, but that can be customised:
+
+```yaml
+mosdepth_config:
+  # Name of the X and Y chromosomes. If not specified, MultiQC will search for
+  # any chromosome names that look like x, y, chrx or chry (case-insensitive)
+  xchr: myXchr
+  ychr: myYchr
+```

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -46,12 +46,12 @@ def read_config():
         log.info('Using "{}" as Y chromosome name'.format(cfg["ychr"]))
 
     # The coverage cutoff to display chromosomes to avoid clutter
-    cutoff = cfg.get("perchrom_fraction_cutoff", 0.001)
+    cutoff = cfg.get("perchrom_fraction_cutoff", 0.0)
     try:
         cutoff = float(cutoff)
     except ValueError:
-        cutoff = 0.001
-    if cutoff != 0.001:
+        cutoff = 0.0
+    if cutoff != 0.0:
         log.info(f"Setting mosdepth per-chrom coverage cutoff to display contigs to: " f"{cutoff * 100.0}%")
     cfg["perchrom_fraction_cutoff"] = cutoff
 

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -37,22 +37,21 @@ def read_config():
         cfg["ychr"] = None
 
     if cfg["include_contigs"]:
-        log.info("Trying to include these contigs in mosdepth: {}".format(", ".join(cfg["include_contigs"])))
+        log.debug("Trying to include these contigs in mosdepth: {}".format(", ".join(cfg["include_contigs"])))
     if cfg["exclude_contigs"]:
-        log.info("Excluding these contigs from mosdepth: {}".format(", ".join(cfg["exclude_contigs"])))
+        log.debug("Excluding these contigs from mosdepth: {}".format(", ".join(cfg["exclude_contigs"])))
     if cfg["xchr"]:
-        log.info('Using "{}" as X chromosome name'.format(cfg["xchr"]))
+        log.debug('Using "{}" as X chromosome name'.format(cfg["xchr"]))
     if cfg["ychr"]:
-        log.info('Using "{}" as Y chromosome name'.format(cfg["ychr"]))
+        log.debug('Using "{}" as Y chromosome name'.format(cfg["ychr"]))
 
-    # The coverage cutoff to display chromosomes to avoid clutter
     cutoff = cfg.get("perchrom_fraction_cutoff", 0.0)
     try:
         cutoff = float(cutoff)
     except ValueError:
         cutoff = 0.0
     if cutoff != 0.0:
-        log.info(f"Setting mosdepth per-chrom coverage cutoff to display contigs to: " f"{cutoff * 100.0}%")
+        log.debug(f"Setting mosdepth coverage cutoff to display the contigs to " f"{cutoff * 100.0}%")
     cfg["perchrom_fraction_cutoff"] = cutoff
 
     return cfg
@@ -167,7 +166,7 @@ class MultiqcModule(BaseMultiqcModule):
             )
 
         if cov_dist_data:
-            # Write data to file, sort columns numberically and convert to strings
+            # Write data to file, sort columns numerically and convert to strings
             cov_dist_data_writeable = {
                 sample: {str(k): v for k, v in sorted(data.items())} for sample, data in cov_dist_data.items()
             }
@@ -273,11 +272,11 @@ class MultiqcModule(BaseMultiqcModule):
         self.general_stats_addcols(genstats, genstats_headers)
 
     def parse_cov_dist(self):
-        genstats = defaultdict(dict)  # mean coverage
-        cumcov_dist_data = defaultdict(dict)  # cumulative distribution
-        cov_dist_data = defaultdict(dict)  # absolute (non-cumulative) coverage
+        genstats = defaultdict(OrderedDict)  # mean coverage
+        cumcov_dist_data = defaultdict(OrderedDict)  # cumulative distribution
+        cov_dist_data = defaultdict(OrderedDict)  # absolute (non-cumulative) coverage
         xmax = 0
-        perchrom_avg_data = defaultdict(dict)  # per chromosome average coverage
+        perchrom_avg_data = defaultdict(OrderedDict)  # per chromosome average coverage
 
         # Parse mean coverage
         for f in self.find_log_files("mosdepth/summary"):
@@ -356,7 +355,7 @@ class MultiqcModule(BaseMultiqcModule):
                         passing_contigs.add(contig)
 
         rejected_contigs = set()
-        filtered_perchrom_avg_data = defaultdict(dict)
+        filtered_perchrom_avg_data = defaultdict(OrderedDict)
         for s_name, perchrom in perchrom_avg_data.items():
             for contig, cov in perchrom.items():
                 if contig not in passing_contigs:


### PR DESCRIPTION
1. Adds an X/Y coverage plot, similar to the one in `samtools-idxstats`:

<img width="1044" alt="Screenshot 2023-08-15 at 19 12 25" src="https://github.com/ewels/MultiQC/assets/1575412/12c8b294-803d-4f22-b0a4-854cf9d463fd">

2. Add chromosome filtering options similar to `samtools-idxstats` to avoid clutter. I didn't set a default threshold though to avoid breaking compatibility. Happy to discuss if we want to sync that between samtools or not.

Fixes #1978