### PR TITLE
Update installation.md

### DIFF
--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -254,7 +254,7 @@ For more help, look into [the Docker documentation](https://docs.docker.com/engi
 The above base command is a little verbose, so if you are using this a lot it may be worth adding the following bash alias to your `~/.bashrc` file:
 
 ```bash
-alias multiqc="docker run -tv `pwd`:`pwd` -w `pwd` ewels/multiqc"
+alias multiqc="docker run -tv `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc"
 ```
 
 Once applied (first log out and in again) you can then just use the `multiqc` command instead:


### PR DESCRIPTION
Add `multiqc` function call at the end of the bash alias definition. Without it, to run multiqc one would have to call `multiqc multiqc .` instead of `multiqc .`

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated
