### PR TITLE
Log the absolute path to report in verbose mode

### DIFF
--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -953,6 +953,8 @@ def run(
             copy_tree(config.data_tmp_dir, config.data_dir, preserve_times=0, preserve_mode=0)
             shutil.rmtree(config.data_tmp_dir)
 
+        logger.debug("Full report path: {}".format(os.path.realpath(config.output_fn)))
+
         # Copy across the static plot images if requested
         if config.export_plots:
             config.plots_dir = os.path.join(config.output_dir, config.plots_dir_name)


### PR DESCRIPTION
When debugging MultiQC in PyCharm, run configurations are often used, and their working directory might be different from the working directory of the terminal. So it's helpful to log the absolute path in the end in order to quickly copy and open a report in the browser.

Since I'm not sure if there are other use cases for this, not insisting on it - feel free to just close.