### PR TITLE
Minor: Add pyproject.toml flake8 config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.black]
 line-length = 120
-target_version = ['py36','py37','py38','py39','py310']
+target_version = ['py36', 'py37', 'py38', 'py39', 'py310']
 
 [tool.isort]
 profile = "black"
 known_first_party = ["multiqc"]
 line_length = 120
+
+# Unoffocial dev-only: use with `pip install Flake8-pyproject`
+[tool.flake8]
+max-line-length = 120


### PR DESCRIPTION
### ⚠️  Temporary: Hoping to move to ruff / similar soon.

Just because VSCode is annoying me by constantly highlighting lines that it thinks are too long. And I really dislike polluting the project root with config dotfiles. Uses https://pypi.org/project/Flake8-pyproject/ to avoid yet another dotfile.

Usage:

```bash
pip install Flake8-pyproject
```

Then make sure that VSCode is set to use the local flake8 binary instead of its built-in version:

![CleanShot 2023-08-28 at 14 19 54@2x](https://github.com/ewels/MultiQC/assets/465550/621a94ff-b18a-422a-acb8-9e04997d037a)
