### PR TITLE
refactor(freyja): remove warning about percentages summing up to <1

### DIFF
--- a/multiqc/modules/freyja/freyja.py
+++ b/multiqc/modules/freyja/freyja.py
@@ -84,10 +84,6 @@ class MultiqcModule(BaseMultiqcModule):
                 except ValueError:
                     pass
 
-            # Percentages don't always add up to 1, show a warning if this is the case
-            if sum(d.values()) != 1:
-                log.warning(f"Freyja {s_name}: percentages don't sum to 1: {sum(d.values())}")
-
             # There is no sample name in the log, so we use the root of the
             # file as sample name (since the filename is always stats.dat
             if s_name in self.freyja_data:


### PR DESCRIPTION
Remove warnings about percentages summing up to <1, as it is almost always going to be the case), see [discussion](https://github.com/ewels/MultiQC/pull/1903\#discussion_r1312990819).
