### PR TITLE
Kaiju: Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,13 +31,17 @@
 - **RSeQC**
   - Fix "max() arg is an empty sequence" error ([#1985](https://github.com/ewels/MultiQC/issues/1985))
 - **NanoStat**
-  - Support new format ([#1995](https://github.com/ewels/MultiQC/issues/1995)).
+  - Support new format ([#1997](https://github.com/ewels/MultiQC/pull/1997)).
 - **DRAGEN**
-  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1865])
+  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/ewels/MultiQC/pull/1994))
 - **WhatsHap**
-  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/ewels/MultiQC/pull/1981)]
+  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/ewels/MultiQC/pull/1981))
 - **Samtools**
-  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1971](https://github.com/ewels/MultiQC/issues/1971))
+  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/ewels/MultiQC/pull/1972))
+- **FastQC**:
+  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/ewels/MultiQC/issues/2024))
+- **Kaiju**:
+  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/ewels/MultiQC/pull/2023))
 
 ## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
 

--- a/multiqc/modules/kaiju/kaiju.py
+++ b/multiqc/modules/kaiju/kaiju.py
@@ -75,6 +75,7 @@ class MultiqcModule(BaseMultiqcModule):
     def parse_kaiju2table_report(self, f):
         """Search a kaiju with a set of regexes"""
         parsed_data = {}
+        taxo_rank = None
 
         for l in f["f"]:
             if l.startswith("file\t"):


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/1947