### PR TITLE
File search: fix off-by-1 error in num_lines

### DIFF
--- a/multiqc/utils/report.py
+++ b/multiqc/utils/report.py
@@ -387,6 +387,10 @@ def search_file(pattern, f, module_key):
 
         # Go through the parsed file contents
         for i, line in enumerate(f["contents_lines"]):
+            # Break if we've searched enough lines for this pattern
+            if pattern.get("num_lines") and i >= pattern.get("num_lines"):
+                break
+
             # Search by file contents (string)
             if pattern.get("contents") is not None:
                 if pattern["contents"] in line:
@@ -401,9 +405,6 @@ def search_file(pattern, f, module_key):
                     if pattern.get("fn") is None and pattern.get("fn_re") is None:
                         return True
                     break
-            # Break if we've searched enough lines for this pattern
-            if pattern.get("num_lines") and i >= pattern.get("num_lines"):
-                break
 
     return fn_matched and contents_matched
 


### PR DESCRIPTION
When a search pattern has `num_lines: 1`, it actually makes it check 2 lines

Normally it's alright as the `num_lines` option was originally thought to optimise the file search.

However, to tell Kraken output from Bracken, we actually have to rely on this.

Tested on all existing modules, doesn't break anything.
