### PR TITLE
Remove redundant namespace in `general_stats_addcols` usages

### DIFF
--- a/multiqc/modules/anglerfish/anglerfish.py
+++ b/multiqc/modules/anglerfish/anglerfish.py
@@ -162,7 +162,7 @@ class MultiqcModule(BaseMultiqcModule):
             "suffix": " bp",
         }
 
-        self.general_stats_addcols(data, headers, "anglerfish")
+        self.general_stats_addcols(data, headers)
 
     def anglerfish_sample_stats(self):
         """Generate plot for read length from sample stats.

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -200,7 +200,7 @@ class StatsReportMixin:
             # Stats Table
             stats_headers = self.bcftools_stats_genstats_headers()
             if getattr(config, "bcftools", {}).get("write_general_stats", True):
-                self.general_stats_addcols(self.bcftools_stats, stats_headers, "Bcftools Stats")
+                self.general_stats_addcols(self.bcftools_stats, stats_headers)
             if getattr(config, "bcftools", {}).get("write_separate_table", False):
                 self.add_section(
                     name="Bcftools Stats",

--- a/multiqc/modules/hicup/hicup.py
+++ b/multiqc/modules/hicup/hicup.py
@@ -151,7 +151,7 @@ class MultiqcModule(BaseMultiqcModule):
             "suffix": "%",
             "scale": "YlGn",
         }
-        self.general_stats_addcols(self.hicup_data, headers, "HiCUP")
+        self.general_stats_addcols(self.hicup_data, headers)
 
     def hicup_truncating_chart(self):
         """Generate the HiCUP Truncated reads plot"""


### PR DESCRIPTION
Remove the namespace parameter for `general_stats_addcols` in a few cases where it's redundant (as it matches the default value equivalent to the module name). Fixes https://github.com/ewels/MultiQC/issues/2032

A more robust solution to namespaces might take a bit longer to discuss and implement, so leaving https://github.com/ewels/MultiQC/pull/2037 for that.

Not adding a changelog entry as I expect the more robust solution to be a part of the next release as well.