### PR TITLE
Fix casing in software versions table

### DIFF
--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -503,8 +503,6 @@ class BaseMultiqcModule(object):
         if software_name is None:
             software_name = self.name
 
-        software_name = software_name.lower()
-
         # Check if version string is PEP 440 compliant to enable version normalization and proper ordering.
         # Otherwise use raw string is used for version.
         # - https://peps.python.org/pep-0440/
@@ -519,7 +517,7 @@ class BaseMultiqcModule(object):
         self.versions[software_name] = software_versions.sort_versions(self.versions[software_name])
 
         # Update version list for report section.
-        group_name = self.name.lower()
+        group_name = self.name
         report.software_versions[group_name][software_name] = self.versions[software_name]
 
     def write_data_file(self, data, fn, sort_cols=False, data_format=None):

--- a/multiqc/modules/software_versions.py
+++ b/multiqc/modules/software_versions.py
@@ -67,11 +67,11 @@ class MultiqcModule(BaseMultiqcModule):
             html.append("<tbody>")
             for i, (tool, versions) in enumerate(sorted(tmp_versions.items())):
                 rows = [
-                    f"<td><samp>{tool}</samp></td>",
+                    f"<td>{tool}</td>",
                     f"<td><samp>{', '.join(list(map(str, versions)))}</samp></td>",
                 ]
                 if not ignore_groups:
-                    rows.insert(0, f"<td><samp>{group if (i == 0) else ''}</samp></td>")
+                    rows.insert(0, f"<td>{group if (i == 0) else ''}</td>")
                 html.append(f"<tr>{''.join(rows)}</tr>")
             html.append("</tbody>")
         html.append("</table>")

--- a/multiqc/templates/default/content.html
+++ b/multiqc/templates/default/content.html
@@ -18,7 +18,7 @@ the output from each module and print it in sections.
           {% if m.versions %}
             <div class="text-muted">
               {% for tool, versions in m.versions.items() %}
-                {% if tool == m.name.lower() %}
+                {% if tool == m.name %}
                   <em>Version{% if versions|length > 1 %}s{% endif %}:</em> <code>{{versions|join("</code>, <code>")}}</code>
                 {% else %}
                   <em>{{ tool }}:</em> <code>{{ versions|join("</code>, <code>") }}</code>


### PR DESCRIPTION
See discussion in https://github.com/ewels/MultiQC/pull/2051 

- Software/group names now match the casing/format used by the module. 
- Maintain casing for software versions as specified in the config or in a separate YAML

**Example**

*YAML file: test_mqc_versions.yaml*

```yaml
PROCESS_1:
  QUAST:
    - "5.1.5"
    - "4.5.1"
samtools:
  SAMtools:
    - "1.1"
  Htslib:
    - "1.1"
```

*Command*
```
multiqc testdata/data/modules/samtools/ testdata/data/modules/samblaster/ test_mqc_versions.yaml 
```

*Resulting table*

<img width="928" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/a9c46127-a991-47cf-b06d-944bdb2d35a2">



- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated
