### PR TITLE
Don't sys.exit from run() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/
 - Fixed parsing of `plot_type: "html"` `data` in json custom content
 - Replace deprecated `pkg_resources`
 - [Fix](https://github.com/ewels/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/ewels/MultiQC/pull/2037)).
+- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/ewels/MultiQC/pull/2055)
 
 ### New Modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -586,7 +586,7 @@ def run(
         run_modules = [m for m in run_modules if list(m.keys())[0] not in config.exclude_modules]
     if len(run_modules) == 0:
         logger.critical("No analysis modules specified!")
-        sys.exit(1)
+        return {"report": report, "config": config, "sys_exit_code": 1}
     run_module_names = [list(m.keys())[0] for m in run_modules]
     logger.debug("Analysing modules: {}".format(", ".join(run_module_names)))
 
@@ -981,7 +981,7 @@ def run(
                     logger.error("Output directory {} already exists.".format(config.plots_dir))
                     logger.info("Use -f or --force to overwrite existing reports")
                     shutil.rmtree(tmp_dir)
-                    sys.exit(1)
+                    return {"report": report, "config": config, "sys_exit_code": 1}
             logger.info(
                 "Plots       : {}{}".format(
                     os.path.relpath(config.plots_dir),

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -773,7 +773,7 @@ def run(
         shutil.rmtree(tmp_dir)
         logger.info("MultiQC complete")
         # Exit with an error code if a module broke
-        sys.exit(sys_exit_code)
+        return {"report": report, "config": config, "sys_exit_code": sys_exit_code}
 
     if config.make_report:
         # Sort the report module output if we have a config


### PR DESCRIPTION
Noticed that we have a stray `sys.exit()` call in the `run()` function. This should be removed for usage in interactive environments.

Not checked thoroughly yet, so needs sanity checking / testing before merge.