### PR TITLE
Bcftools: fix parsing of multi-sample stats outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/
   - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/ewels/MultiQC/pull/2023))
 - **Qualimap**
   - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/ewels/MultiQC/issues/2019))
+- **BcfTools**
+  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/ewels/MultiQC/issues/2052))
 
 ## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
 

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -74,10 +74,10 @@ class StatsReportMixin:
                 if s[0] == "TSTV" and len(s_names) > 0:
                     s_name = s_names[int(s[1])]
                     fields = ["ts", "tv", "tstv", "ts_1st_ALT", "tv_1st_ALT", "tstv_1st_ALT"]
-                    for i, f in enumerate(fields):
+                    for i, field in enumerate(fields):
                         value = float(s[i + 2].strip())
 
-                        self.bcftools_stats[s_name][f] = value
+                        self.bcftools_stats[s_name][field] = value
 
                 # Parse substitution types
                 if s[0] == "ST" and len(s_names) > 0:
@@ -105,8 +105,8 @@ class StatsReportMixin:
                 if s[0] == "PSC" and len(s_names) > 0:
                     s_name = s_names[int(s[1])]
                     fields = ["variations_hom", "variations_het"]
-                    for i, f in enumerate(fields):
-                        self.bcftools_stats[s_name][f] = int(s[i + 4].strip())
+                    for i, field in enumerate(fields):
+                        self.bcftools_stats[s_name][field] = int(s[i + 4].strip())
 
                 # Per-sample variant stats
                 if s[0] == "PSC" and len(s_names) > 0:


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/2052

That's why linters tend to flag single-letter variables 😅 