### PR TITLE
Fix table color scaling with negative numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/
 - [Fix](https://github.com/ewels/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/ewels/MultiQC/pull/2037)).
 - Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/ewels/MultiQC/pull/2055)
 - Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/ewels/MultiQC/pull/2058))
+- Fix table column color scaling then there are negative numbers ([1869](https://github.com/ewels/MultiQC/issues/1869))
 
 ### New Modules
 

--- a/multiqc/utils/mqc_colour.py
+++ b/multiqc/utils/mqc_colour.py
@@ -27,8 +27,8 @@ class mqc_colour_scale(object):
         self.colours = self.get_colours(name)
 
         # Sanity checks
-        minval = re.sub("[^0-9\.-e]", "", str(minval))
-        maxval = re.sub("[^0-9\.-e]", "", str(maxval))
+        minval = re.sub(r"[^0-9\.\-e]", "", str(minval))
+        maxval = re.sub(r"[^0-9\.\-e]", "", str(maxval))
         if minval == "":
             minval = 0
         if maxval == "":
@@ -70,7 +70,7 @@ class mqc_colour_scale(object):
 
             else:
                 # Sanity checks
-                val = re.sub("[^0-9\.-e]", "", str(val))
+                val = re.sub(r"[^0-9\.\-e]", "", str(val))
                 if val == "":
                     val = self.minval
                 val = float(val)


### PR DESCRIPTION
Escape the dash in the regular expressions to avoid trimming the leading minus in the negative numbers.

Fixes https://github.com/ewels/MultiQC/issues/1869