### PR TITLE
Fix bug parsing TSV/CSV custom content

### DIFF
--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -131,11 +131,11 @@ def custom_module_classes():
                     parsed_data = {"id": f["s_name"], "plot_type": "html", "data": f["f"]}
                     parsed_data.update(_find_html_file_header(f))
 
-                if isinstance(parsed_data.get("data"), dict):
-                    # Run sample-name cleaning on the data keys
-                    parsed_data["data"] = {bm.clean_s_name(k, f): v for k, v in parsed_data["data"].items()}
-
                 if parsed_data is not None:
+                    if isinstance(parsed_data.get("data"), dict):
+                        # Run sample-name cleaning on the data keys
+                        parsed_data["data"] = {bm.clean_s_name(k, f): v for k, v in parsed_data["data"].items()}
+
                     c_id = parsed_data.get("id", k)
                     if len(parsed_data.get("data", {})) > 0:
                         if isinstance(parsed_data["data"], dict):


### PR DESCRIPTION
When running on a custom content in a TSV or CSV format, e.g.:

```sh
multiqc -f -v test_data/data/custom_content/issue_1883/FS56145117.variant_counts_mqc.tsv
```

The following unwanted exception is happening:

```
[2023-09-22 11:39:40] multiqc.modules.custom_content.custom_content      [ERROR  ]  Uncaught exception raised for file 'FS56145117.variant_counts_mqc.tsv'
[2023-09-22 11:39:40] multiqc.modules.custom_content.custom_content      [ERROR  ]  'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/Users/vlad/git/MultiQC/multiqc/modules/custom_content/custom_content.py", line 134, in custom_module_classes
    if isinstance(parsed_data.get("data"), dict):
AttributeError: 'NoneType' object has no attribute 'get'
```

Fixing this bug.