### PR TITLE
Just run CI on the oldest + newest supported Python versions

### DIFF
--- a/.github/workflows/multiqc.yml
+++ b/.github/workflows/multiqc.yml
@@ -55,7 +55,8 @@ jobs:
     needs: changes
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        # Just test the oldest and newest supported Python versions
+        python-version: ["3.6", "3.11"]
     timeout-minutes: 10
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Just run ci on the oldest + newest supported python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
+
 ### New Modules
 
 - [**Bracken**](https://ccb.jhu.edu/software/bracken/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### MultiQC updates
 
-- Just run ci on the oldest + newest supported python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
 - Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025))
 - Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/ewels/MultiQC/pull/2049))
 - Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
 - Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
+- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
 
 ### New Modules
 


### PR DESCRIPTION
Small measure to reduce the amount of CI jobs that we run.

I think it's vanishingly rare that anything fails only in a _middle_ version of Python - it's basically always one end of the range. So maybe it makes sense to only run tests on the extremes.