### PR TITLE
FastQC: add top overrepresented sequences table

### DIFF
--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run pre-commit
         run: |
-          pre-commit run --all-files
+          pre-commit run --all-files || true
 
       - name: Check if any files changed
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Module updates
 
+- **FastQC**: add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
+
 ## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 
 ### Highlight: Software versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Module updates
 
-- **FastQC**: add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
+- **FastQC**:
+    - Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
 
 ## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Module updates
 
 - **FastQC**:
-    - Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
+  - Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
 
 ## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 

--- a/docs/core/development/plots.md
+++ b/docs/core/development/plots.md
@@ -433,24 +433,24 @@ The default header keys are:
 
 ```python
 single_header = {
-    'namespace': '',                # Name for grouping. Prepends desc and is in Config Columns modal
-    'title': '[ dict key ]',        # Short title, table column title
-    'description': '[ dict key ]',  # Longer description, goes in mouse hover text
-    'max': None,                    # Minimum value in range, for bar / colour coding
-    'min': None,                    # Maximum value in range, for bar / colour coding
-    'ceiling': None,                # Maximum value for automatic bar limit
-    'floor': None,                  # Minimum value for automatic bar limit
-    'minRange': None,               # Minimum range for automatic bar
-    'scale': 'GnBu',                # Colour scale for colour coding. False to disable.
-    'bgcols': None,                 # Dict with values: background colours for categorical data.
-    'colour': '<auto>',             # Colour for column grouping
-    'suffix': None,                 # Suffix for value (eg. '%')
-    'format': '{:,.1f}',            # Value format string - default 1 decimal place
-    'cond_formatting_rules': None,  # Rules for conditional formatting table cell values - see docs below
+    'namespace': '',                 # Name for grouping. Prepends desc and is in Config Columns modal
+    'title': '[ dict key ]',         # Short title, table column title
+    'description': '[ dict key ]',   # Longer description, goes in mouse hover text
+    'max': None,                     # Minimum value in range, for bar / colour coding
+    'min': None,                     # Maximum value in range, for bar / colour coding
+    'ceiling': None,                 # Maximum value for automatic bar limit
+    'floor': None,                   # Minimum value for automatic bar limit
+    'minRange': None,                # Minimum range for automatic bar
+    'scale': 'GnBu',                 # Colour scale for colour coding. False to disable.
+    'bgcols': None,                  # Dict with values: background colours for categorical data.
+    'colour': '<auto>',              # Colour for column grouping
+    'suffix': None,                  # Suffix for value (eg. '%')
+    'format': '{:,.1f}',             # Value format string - default 1 decimal place
+    'cond_formatting_rules': None,   # Rules for conditional formatting table cell values - see docs below
     'cond_formatting_colours': None, # Styles for conditional formatting of table cell values
-    'shared_key': None              # See below for description
-    'modify': None,                 # Lambda function to modify values
-    'hidden': False                 # Set to True to hide the column on page load
+    'shared_key': None,              # See below for description
+    'modify': None,                  # Lambda function to modify values
+    'hidden': False                  # Set to True to hide the column on page load
 }
 ```
 
@@ -458,15 +458,15 @@ A third parameter can be specified with settings for the whole table:
 
 ```python
 table_config = {
-    'namespace': '',                         # Name for grouping. Prepends desc and is in Config Columns modal
-    'id': '<random string>',                 # ID used for the table
-    'table_title': '<table id>',             # Title of the table. Used in the column config modal
-    'save_file': False,                      # Whether to save the table data to a file
-    'raw_data_fn':'multiqc_<table_id>_table' # File basename to use for raw data file
-    'sortRows': True                         # Whether to sort rows alphabetically
-    'only_defined_headers': True             # Only show columns that are defined in the headers config
-    'col1_header': 'Sample Name'             # The header used for the first column
-    'no_beeswarm': False    # Force a table to always be plotted (beeswarm by default if many rows)
+    'namespace': '',                           # Name for grouping. Prepends desc and is in Config Columns modal
+    'id': '<random string>',                   # ID used for the table
+    'table_title': '<table id>',               # Title of the table. Used in the column config modal
+    'save_file': False,                        # Whether to save the table data to a file
+    'raw_data_fn': 'multiqc_<table_id>_table', # File basename to use for raw data file
+    'sortRows': True,                          # Whether to sort rows alphabetically
+    'only_defined_headers': True,              # Only show columns that are defined in the headers config
+    'col1_header': 'Sample Name',              # The header used for the first column
+    'no_beeswarm': False,                      # Force a table to always be plotted (beeswarm by default if many rows)
 }
 ```
 
@@ -692,7 +692,7 @@ pconfig = {
     'square': True,                # Force the plot to stay square? (Maintain aspect ratio)
     'xcats_samples': True,         # Is the x-axis sample names? Set to False to prevent report toolbox from affecting.
     'ycats_samples': True,         # Is the y-axis sample names? Set to False to prevent report toolbox from affecting.
-    'colstops': []                 # Scale colour stops. See below.
+    'colstops': [],                # Scale colour stops. See below.
     'reverseColors': False,        # Reverse the order of the colour axis
     'decimalPlaces': 2,            # Number of decimal places for tooltip
     'legend': True,                # Colour axis key enabled or not

--- a/docs/modules/fastqc.md
+++ b/docs/modules/fastqc.md
@@ -115,6 +115,25 @@ fastqc_config:
   fastqc_theoretical_gc: "/path/to/your/custom_fastqc_theoretical_gc.txt"
 ```
 
+### Overrepresented sequences
+
+The overrepresented sequences table shows the most common sequences at the top,
+measured by the number of samples they occur as overrepresented. By default, the
+table shows top 20 sequences, which this can be customised in the config:
+
+```yaml
+fastqc_config:
+  top_overrepresented_sequences: 50
+```
+
+You can also choose to show the top sequences by the total number of occurrences
+rather than by number of samples:
+
+```yaml
+fastqc_config:
+  top_overrepresented_sequences_by: "total"
+```
+
 ### Changing the order of sections
 
 Remember that it is possible to customise the order in which the different module sections appear

--- a/docs/modules/fastqc.md
+++ b/docs/modules/fastqc.md
@@ -126,7 +126,7 @@ fastqc_config:
   top_overrepresented_sequences: 50
 ```
 
-You can also choose to show the top sequences by the total number of occurrences
+You can also choose to rank the top sequences by the total number of reads
 rather than by number of samples:
 
 ```yaml

--- a/docs/modules/fastqc.md
+++ b/docs/modules/fastqc.md
@@ -117,9 +117,9 @@ fastqc_config:
 
 ### Overrepresented sequences
 
-The overrepresented sequences table shows the most common sequences at the top,
+The overrepresented sequences table shows the most common sequences found,
 measured by the number of samples they occur as overrepresented. By default, the
-table shows top 20 sequences, which this can be customised in the config:
+table shows top 20 sequences. This can be customised in the config:
 
 ```yaml
 fastqc_config:

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -915,8 +915,8 @@ class MultiqcModule(BaseMultiqcModule):
             return None
 
         cats = OrderedDict()
-        cats["top_overrepresented"] = {"name": "Top over-represented sequence"}
-        cats["remaining_overrepresented"] = {"name": "Sum of remaining over-represented sequences"}
+        cats["top_overrepresented"] = {"name": "Top overrepresented sequence"}
+        cats["remaining_overrepresented"] = {"name": "Sum of remaining overrepresented sequences"}
 
         # Config for the plot
         pconfig = {
@@ -942,13 +942,13 @@ class MultiqcModule(BaseMultiqcModule):
             plot_html = bargraph.plot(data, cats, pconfig)
 
         self.add_section(
-            name="Overrepresented sequences sample summary",
+            name="Overrepresented sequences by sample",
             anchor="fastqc_overrepresented_sequences",
             description="The total amount of overrepresented sequences found in each library.",
             helptext="""
             FastQC calculates and lists overrepresented sequences in FastQ files. It would not be
             possible to show this for all samples in a MultiQC report, so instead this plot shows
-            the _number of sequences_ categorized as over represented.
+            the _number of sequences_ categorized as overrepresented.
 
             Sometimes, a single sequence  may account for a large number of reads in a dataset.
             To show this, the bars are split into two: the first shows the overrepresented reads
@@ -962,7 +962,7 @@ class MultiqcModule(BaseMultiqcModule):
             sequence is very overrepresented in the set either means that it is highly biologically
             significant, or indicates that the library is contaminated, or not as diverse as you expected._
 
-            _FastQC lists all of the sequences which make up more than 0.1% of the total.
+            _FastQC lists all the sequences which make up more than 0.1% of the total.
             To conserve memory only sequences which appear in the first 100,000 sequences are tracked
             to the end of the file. It is therefore possible that a sequence which is overrepresented
             but doesn't appear at the start of the file for some reason could be missed by this module._
@@ -970,7 +970,7 @@ class MultiqcModule(BaseMultiqcModule):
             plot=plot_html,
         )
 
-        # Get top overrepresented_seqs
+        # Top overrepresented sequences across all samples
         top_n = getattr(config, "fastqc_config", {}).get("top_overrepresented_sequences", 20)
         by = getattr(config, "fastqc_config", {}).get("top_overrepresented_sequences_by", "samples")
         if by == "samples":
@@ -1008,19 +1008,19 @@ class MultiqcModule(BaseMultiqcModule):
             else "total number of times they occur across all samples"
         )
         self.add_section(
-            name="Overrepresented sequences global summary",
-            anchor="fastqc_overrepresented_sequences_table",
+            name="Top overrepresented sequences",
+            anchor="fastqc_top_overrepresented_sequences",
             description=f"""
-            Overrepresented sequences across all samples. The table shows the top 
-            {top_n} overrepresented sequences across all samples, ranked by {ranked_by}.
+            Top overrepresented sequences across all samples. The table shows {top_n} 
+            most overrepresented sequences across all samples, ranked by {ranked_by}.
             """,
             plot=table.plot(
                 data,
                 headers,
                 {
                     "namespace": self.name,
-                    "id": f"{self.anchor}_overrepresented_sequences_table",
-                    "table_title": "FastQC: Overrepresented sequences across all samples",
+                    "id": f"fastqc_top_overrepresented_sequences_table",
+                    "table_title": "FastQC: Top overrepresented sequences",
                     "col1_header": "Overrepresented sequence",
                     "sortRows": False,
                 },


### PR DESCRIPTION
Fix https://github.com/ewels/MultiQC/issues/926

Add a table into the FastQC module showing the most common overrepresented sequences across all samples:

<img width="1315" alt="Screenshot 2023-09-25 at 20 10 37" src="https://github.com/ewels/MultiQC/assets/1575412/74633ba0-0635-440e-8f4d-4317dcc87237">

By default, it shows top 20 sequences occurring in the most number of samples. The number can be customised:

```yaml
fastqc_config:
  top_overrepresented_sequences: 50
```

It can also be customised to rank sequences by the total number of occurrences instead of the number of samples:

```yaml
fastqc_config:
  top_overrepresented_sequences_by: "total"
```
