### PR TITLE
Changelog bot: Update docs

### DIFF
--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -3,7 +3,36 @@ title: Contributing
 description: Guides for how to contribute to the MultiQC code base
 ---
 
-# Documentation
+## Changelog
+
+Almost all changes deserve an entry in the `CHANGELOG.md` file,
+so that people know that it's there.
+
+Whilst you can do this yourself, we prefer to automate this using our
+friendly MultiQC bot, just before merging. By doing the changelog entry
+at the last minute we reduce the risk of having to solve merge conflicts.
+
+The MultiQC changelog bot works by using the pull-request title.
+**Your job is to ensure that your pull-request follows one of the following 3 conventions:**
+
+- `New module: XYZ` - adding a new module named `XYZ`
+- `XYZ: Change something in this existing module` - updating module `XYZ`
+- `Some other change` - anything else, eg. core MultiQC changes
+
+The MultiQC bot will automatically build a proper changelog entry based on this title
+and (for new modules / module changes) the meta-information in the `MultiqcModule` class.
+
+The MultiQC bot is triggered by adding the following comment on an open pull request:
+
+```md
+@multiqc-bot changelog
+```
+
+This triggers a GitHub Action script which inspects the PR, updates the changelog
+and commits the update back to your PR.
+
+Whilst you can trigger this yourself, it's expected that the core MultiQC
+maintainers will do this for you immediately prior to merging.
 
 ## Admonitions
 

--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -3,6 +3,8 @@ title: Contributing
 description: Guides for how to contribute to the MultiQC code base
 ---
 
+# Contributing
+
 ## Changelog
 
 Almost all changes deserve an entry in the `CHANGELOG.md` file,

--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -7,12 +7,13 @@ description: Guides for how to contribute to the MultiQC code base
 
 ## Changelog
 
-Almost all changes deserve an entry in the `CHANGELOG.md` file,
-so that people know that it's there.
+Almost all changes deserve an entry in the `CHANGELOG.md` file, so that people
+know what updates are present between versions.
 
-Whilst you can do this yourself, we prefer to automate this using our
-friendly MultiQC bot, just before merging. By doing the changelog entry
-at the last minute we reduce the risk of having to solve merge conflicts.
+Whilst you can do this yourself by manually editing the file, we prefer to automate
+the process by using our friendly MultiQC bot, just before merging.
+By doing the changelog entry at the last minute we reduce the risk of having to
+solve changelog merge conflicts.
 
 The MultiQC changelog bot works by using the pull-request title.
 **Your job is to ensure that your pull-request follows one of the following 3 conventions:**
@@ -33,8 +34,10 @@ The MultiQC bot is triggered by adding the following comment on an open pull req
 This triggers a GitHub Action script which inspects the PR, updates the changelog
 and commits the update back to your PR.
 
-Whilst you can trigger this yourself, it's expected that the core MultiQC
+:::tip
+Whilst you can trigger the bot yourself, it's expected that the core MultiQC
 maintainers will do this for you immediately prior to merging.
+:::
 
 ## Admonitions
 

--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -332,20 +332,34 @@ Log messages can come in a range of formats:
 
 ### Changelog
 
-Last but not least, remember to add your new module to the `CHANGELOG.md`,
-so that people know that it's there. Note that you can do that by sending a comment
-to the pull request with the following text:
+Almost all changes deserve an entry in the `CHANGELOG.md` file,
+so that people know that it's there.
 
-> @multiqc-bot changelog
+Whilst you can do this yourself, we prefer to automate this using our
+friendly MultiQC bot, just before merging. By doing the changelog entry
+at the last minute we reduce the risk of having to solve merge conflicts.
 
-The bot will automatically build a proper entry based on the meta-information in
-the MultiqcModule class.
+The MultiQC changelog bot works by using the pull-request title.
+**Your job is to ensure that your pull-request follows one of the following 3 conventions:**
 
-You can also run this command if you only change an existing module, or
-do a non-module codebase change: the CI will populate the entry based on the
-pull request title. If your pull request starts with a module name followed
-by a colon (e.g. "Samtools: new feature"), it will be assumed that the PR changes
-a module; otherwise, a core change will be assumed.
+- `New module: XYZ` - adding a new module named `XYZ`
+- `XYZ: Change something in this existing module` - updating module `XYZ`
+- `Some other change` - anything else, eg. core MultiQC changes
+
+The MultiQC bot will automatically build a proper changelog entry based on this title
+and (for new modules / module changes) the meta-information in the `MultiqcModule` class.
+
+The MultiQC bot is triggered by adding the following comment on an open pull request:
+
+```md
+@multiqc-bot changelog
+```
+
+This triggers a GitHub Action script which inspects the PR, updates the changelog
+and commits the update back to your PR.
+
+Whilst you can trigger this yourself, it's expected that the core MultiQC
+maintainers will do this for you immediately prior to merging.
 
 ## Step 1 - Find log files
 

--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -332,34 +332,18 @@ Log messages can come in a range of formats:
 
 ### Changelog
 
-Almost all changes deserve an entry in the `CHANGELOG.md` file,
-so that people know that it's there.
+When opening a pull-request, please ensure that the PR title is
+formatted as `New module: XYZ`, where `XYZ` is the name of your module.
 
-Whilst you can do this yourself, we prefer to automate this using our
-friendly MultiQC bot, just before merging. By doing the changelog entry
-at the last minute we reduce the risk of having to solve merge conflicts.
+The changelog entry will be automatically generated for you, based on
+the meta-information that you add to the module `MultiqcModule` class.
 
-The MultiQC changelog bot works by using the pull-request title.
-**Your job is to ensure that your pull-request follows one of the following 3 conventions:**
+:::tip
+Please do not add anything to the `CHANGELOG.md` file!
+This is now handled by our friendly MultiQC bot 🤖
 
-- `New module: XYZ` - adding a new module named `XYZ`
-- `XYZ: Change something in this existing module` - updating module `XYZ`
-- `Some other change` - anything else, eg. core MultiQC changes
-
-The MultiQC bot will automatically build a proper changelog entry based on this title
-and (for new modules / module changes) the meta-information in the `MultiqcModule` class.
-
-The MultiQC bot is triggered by adding the following comment on an open pull request:
-
-```md
-@multiqc-bot changelog
-```
-
-This triggers a GitHub Action script which inspects the PR, updates the changelog
-and commits the update back to your PR.
-
-Whilst you can trigger this yourself, it's expected that the core MultiQC
-maintainers will do this for you immediately prior to merging.
+For more information about how it works, see the [contributing docs](contributing.md#changelog).
+:::
 
 ## Step 1 - Find log files
 


### PR DESCRIPTION
Tweaked the docs for the new changelog bot.

I wonder if we should also / instead have something about this under the "contributing" section of the docs. As anyone updating a module or doing some core MultiQC change will not be reading this part of the docs... 🤔 