### PR TITLE
Changelog action: remove `.capitalize()`, add changelog entry

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -180,9 +180,9 @@ section, mod = _determine_change_type(pr_title, pr_number)
 
 # Prepare the change log entry.
 pr_link = f"([#{pr_number}]({REPO_URL}/pull/{pr_number}))"
-if comment := comment.removeprefix("@multiqc-bot changelog").strip().capitalize():
+if comment := comment.removeprefix("@multiqc-bot changelog").strip():
     new_lines = [
-        f"- {comment.capitalize()} {pr_link}\n",
+        f"- {comment} {pr_link}\n",
     ]
 elif section == "### New modules":
     new_lines = [
@@ -191,13 +191,13 @@ elif section == "### New modules":
     ]
 elif section == "### Module updates":
     assert mod is not None
-    descr = pr_title.split(":", maxsplit=1)[1].strip().capitalize()
+    descr = pr_title.split(":", maxsplit=1)[1].strip()
     new_lines = [
         f"- **{mod['name']}**: {descr} {pr_link}\n",
     ]
 else:
     new_lines = [
-        f"- {pr_title.capitalize()} {pr_link}\n",
+        f"- {pr_title} {pr_link}\n",
     ]
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025))
+
 ### New Modules
 
 - [**Bracken**](https://ccb.jhu.edu/software/bracken/)


### PR DESCRIPTION
A follow up on https://github.com/ewels/MultiQC/pull/2025:
* Do not run `capitalize()` on the entry as turns out it forces lowercase on all non-initial letters.
* Add a missing changelog entry on the original PR :)