### PR TITLE
Lint modules for missing `self.add_software_version`

### DIFF
--- a/.github/workflows/code_checks.py
+++ b/.github/workflows/code_checks.py
@@ -15,6 +15,7 @@ checks = {
     "self.add_data_source": "self.find_log_files",
     "self.write_data_file": "self.find_log_files",
     "doi=": "super(MultiqcModule, self).__init__(",
+    "self.add_software_version": "self.find_log_files",
 }
 
 # Check that add_data_source() is called for each module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### MultiQC updates
 
 - Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025))
+- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
 
 ### New Modules
 

--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -702,6 +702,22 @@ for line in f.splitlines():
     # ..rest of file parsing
 ```
 
+Even if the logs does not contain any version information, you should still
+add a superfluous `self.add_software_version()` call to the module. This
+will help maintainers to check if new modules or submodules parse any version
+information that might exist. The call should also include a note that it is
+a dummy call. Example:
+
+```python
+for f in self.find_log_files("mymodule/submodule"):
+    sample = f["s_name"]
+    data[sample] = parse_file(f)
+
+    # Superfluous function call to confirm that it is used in this module
+    # Replace None with actual version if it is available
+    self.add_software_version(None, sample)
+```
+
 ## Step 3 - Adding to the general statistics table
 
 Now that you have your parsed data, you can start inserting it into the

--- a/multiqc/modules/afterqc/afterqc.py
+++ b/multiqc/modules/afterqc/afterqc.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("afterqc", filehandles=True):
             self.parse_afterqc_log(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.afterqc_data = self.ignore_samples(self.afterqc_data)
 

--- a/multiqc/modules/bamtools/stats.py
+++ b/multiqc/modules/bamtools/stats.py
@@ -54,6 +54,10 @@ def parse_reports(self):
             self.add_data_source(f, section="stats")
             self.bamtools_stats_data[f["s_name"]] = d
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.bamtools_stats_data = self.ignore_samples(self.bamtools_stats_data)
 

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -489,8 +489,14 @@ class BaseMultiqcModule(object):
         except AttributeError:
             logger.warning("Tried to add data source for {}, but was missing fields data".format(self.name))
 
-    def add_software_version(self, version: str, sample: str = None, software_name: str = None):
+    def add_software_version(self, version: str = None, sample: str = None, software_name: str = None):
         """Save software versions for module."""
+        # Don't add if version is None. This allows every module to call this function
+        # even those without a version to add. This is useful to check that all modules
+        # are calling this function.
+        if version is None:
+            return
+
         # Don't add if version detection is disabled
         if config.disable_version_detection:
             return

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -41,6 +41,10 @@ class MultiqcModule(BaseMultiqcModule):
                     self.add_data_source(f)
                     data_found = True
 
+                    # Superfluous function call to confirm that it is used in this module
+                    # Replace None with actual version if it is available
+                    self.add_software_version(None, f["s_name"])
+
         if not data_found:
             raise UserWarning
         else:

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -146,6 +146,10 @@ class MultiqcModule(BaseMultiqcModule):
         # Clean / prepend directories to sample names
         runId = self.clean_s_name(content["RunId"], f)
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, runId)
+
         if runId not in self.bcl2fastq_data:
             self.bcl2fastq_data[runId] = dict()
         run_data = self.bcl2fastq_data[runId]

--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -99,6 +99,10 @@ class MultiqcModule(BaseMultiqcModule):
                 section="bclconvert-bysample",
             )
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s)
+
         self.write_data_file(
             {str(k): self.bclconvert_bylane[k] for k in self.bclconvert_bylane.keys()}, "multiqc_bclconvert_bylane"
         )

--- a/multiqc/modules/biobloomtools/biobloomtools.py
+++ b/multiqc/modules/biobloomtools/biobloomtools.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.add_data_source(f)
                 self.bbt_data[f["s_name"]] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.bbt_data = self.ignore_samples(self.bbt_data)
 

--- a/multiqc/modules/biscuit/biscuit.py
+++ b/multiqc/modules/biscuit/biscuit.py
@@ -114,6 +114,10 @@ class MultiqcModule(BaseMultiqcModule):
 
                 self.mdata[k][s_name] = getattr(self, "parse_logs_{}".format(k))(f["f"], f["fn"])
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         for k in self.mdata:
             self.mdata[k] = self.ignore_samples(self.mdata[k])
 

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -62,6 +62,11 @@ class MultiqcModule(BaseMultiqcModule):
             "multimapped": r"# reads with alignments suppressed due to -m:\s+(\d+)",
             "multimapped_percentage": r"# reads with alignments suppressed due to -m:\s+\d+\s+\(([\d\.]+)%\)",
         }
+
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         for l in f["f"].splitlines():
             # Attempt in vain to find original bowtie1 command, logged by another program
             if "bowtie" in l and "q.gz" in l:

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -37,6 +37,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("bowtie2", filehandles=True):
             self.parse_bowtie2_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.bowtie2_data = self.ignore_samples(self.bowtie2_data)
 

--- a/multiqc/modules/bustools/bustools.py
+++ b/multiqc/modules/bustools/bustools.py
@@ -44,6 +44,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.bustools_data[s_name] = content
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names
         self.bustools_data = self.ignore_samples(self.bustools_data)
 

--- a/multiqc/modules/ccs/ccs.py
+++ b/multiqc/modules/ccs/ccs.py
@@ -46,6 +46,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.ccs_data[filename] = v5_data
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, filename)
+
     def parse_v5_log_files(self):
         for f in self.find_log_files("ccs/v5", filehandles=True):
             v5_data = json.load(f["f"])

--- a/multiqc/modules/checkqc/checkqc.py
+++ b/multiqc/modules/checkqc/checkqc.py
@@ -43,6 +43,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_checkqc_json(raw_content, f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         if not self.checkqc_data:
             raise UserWarning
         log.info(f"Found {len(self.log_files)} run and {len(self.checkqc_data)} samples")

--- a/multiqc/modules/clusterflow/clusterflow.py
+++ b/multiqc/modules/clusterflow/clusterflow.py
@@ -37,6 +37,11 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("clusterflow/logs", filehandles=True):
             self.parse_clusterflow_logs(f)
             self.add_data_source(f, "log")
+
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         for f in self.find_log_files("clusterflow/runfiles", filehandles=True):
             parsed_data = self.parse_clusterflow_runfiles(f)
             if parsed_data is not None:

--- a/multiqc/modules/conpair/conpair.py
+++ b/multiqc/modules/conpair/conpair.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("conpair/concordance"):
             self.parse_conpair_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         for f in self.find_log_files("conpair/contamination"):
             self.parse_conpair_logs(f)
 

--- a/multiqc/modules/deeptools/bamPEFragmentSizeDistribution.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSizeDistribution.py
@@ -21,6 +21,10 @@ class bamPEFragmentSizeDistributionMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="bamPEFragmentSizeDistribution")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_bamPEFragmentSizeDistribution = self.ignore_samples(self.deeptools_bamPEFragmentSizeDistribution)
 
         if len(self.deeptools_bamPEFragmentSizeDistribution) > 0:

--- a/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
@@ -23,6 +23,10 @@ class bamPEFragmentSizeTableMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="bamPEFragmentSize")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_bamPEFragmentSize = self.ignore_samples(self.deeptools_bamPEFragmentSize)
 
         if len(self.deeptools_bamPEFragmentSize) > 0:

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -23,6 +23,10 @@ class estimateReadFilteringMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="estimateReadFiltering")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_estimateReadFiltering = self.ignore_samples(self.deeptools_estimateReadFiltering)
 
         if len(self.deeptools_estimateReadFiltering) > 0:

--- a/multiqc/modules/deeptools/plotCorrelation.py
+++ b/multiqc/modules/deeptools/plotCorrelation.py
@@ -21,6 +21,10 @@ class plotCorrelationMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotCorrelation")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotCorrelationData = self.ignore_samples(self.deeptools_plotCorrelationData)
 
         if len(self.deeptools_plotCorrelationData) > 0:

--- a/multiqc/modules/deeptools/plotCoverage.py
+++ b/multiqc/modules/deeptools/plotCoverage.py
@@ -23,6 +23,10 @@ class plotCoverageMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotCoverage")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotCoverageOutRawCounts = dict()
         for f in self.find_log_files("deeptools/plotCoverageOutRawCounts"):
             parsed_data = self.parsePlotCoverageOutRawCounts(f)

--- a/multiqc/modules/deeptools/plotEnrichment.py
+++ b/multiqc/modules/deeptools/plotEnrichment.py
@@ -23,6 +23,10 @@ class plotEnrichmentMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotEnrichment")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotEnrichment = self.ignore_samples(self.deeptools_plotEnrichment)
 
         if len(self.deeptools_plotEnrichment) > 0:

--- a/multiqc/modules/deeptools/plotFingerprint.py
+++ b/multiqc/modules/deeptools/plotFingerprint.py
@@ -26,6 +26,10 @@ class plotFingerprintMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotFingerprint")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotFingerprintOutRawCounts = dict()
         for f in self.find_log_files("deeptools/plotFingerprintOutRawCounts"):
             parsed_data = self.parsePlotFingerprintOutRawCounts(f)

--- a/multiqc/modules/deeptools/plotPCA.py
+++ b/multiqc/modules/deeptools/plotPCA.py
@@ -21,6 +21,10 @@ class plotPCAMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotPCA")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotPCAData = self.ignore_samples(self.deeptools_plotPCAData)
 
         if len(self.deeptools_plotPCAData) > 0:

--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -21,6 +21,10 @@ class plotProfileMixin:
             if len(parsed_data) > 0:
                 self.add_data_source(f, section="plotProfile")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.deeptools_plotProfile = self.ignore_samples(self.deeptools_plotProfile)
 
         if len(self.deeptools_plotProfile) > 0:

--- a/multiqc/modules/disambiguate/disambiguate.py
+++ b/multiqc/modules/disambiguate/disambiguate.py
@@ -37,6 +37,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.data[sample] = counts
                 self.add_data_source(f, s_name=sample)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, sample)
+
         self.data = self.ignore_samples(self.data)
 
         if len(self.data) == 0:

--- a/multiqc/modules/dragen/coverage_hist.py
+++ b/multiqc/modules/dragen/coverage_hist.py
@@ -21,6 +21,10 @@ class DragenCoverageHist(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_phenotype_by_sample[s_name].update(data_by_phenotype)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_phenotype_by_sample = self.ignore_samples(data_by_phenotype_by_sample)
 

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -555,6 +555,10 @@ class DragenCoverageMetrics(BaseMultiqcModule):
                 match_overall_mean_cov[cleaned_sample][phenotype] = (original_sample, file["root"])
                 all_metrics.update(out["metric_IDs_with_original_names"])
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, cleaned_sample)
+
         cov_data = self.ignore_samples(cov_data)
         if not cov_data:
             return set()

--- a/multiqc/modules/dragen/coverage_per_contig.py
+++ b/multiqc/modules/dragen/coverage_per_contig.py
@@ -21,6 +21,10 @@ class DragenCoveragePerContig(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             perchrom_data_by_phenotype_by_sample[s_name].update(perchrom_data_by_phenotype)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         perchrom_data_by_phenotype_by_sample = self.ignore_samples(perchrom_data_by_phenotype_by_sample)
 

--- a/multiqc/modules/dragen/dragen_gc_metrics.py
+++ b/multiqc/modules/dragen/dragen_gc_metrics.py
@@ -23,6 +23,10 @@ class DragenGcMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/fragment_length.py
+++ b/multiqc/modules/dragen/fragment_length.py
@@ -28,6 +28,10 @@ class DragenFragmentLength(BaseMultiqcModule):
                     log.debug(f"Duplicate read group name {rg} found for {s_name}! Overwriting")
             data_by_rg_by_sample[s_name].update(data_by_rg)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_rg_by_sample = self.ignore_samples(data_by_rg_by_sample)
         if not data_by_rg_by_sample:

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -36,6 +36,10 @@ class DragenMappingMetics(BaseMultiqcModule):
                         log.debug(f"Duplicate read group name {rg} found for output prefix {s_name}! Overwriting")
             data_by_rg_by_sample[s_name].update(data_by_readgroup)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # filter to strip out ignored sample names:
         data_by_rg_by_sample = self.ignore_samples(data_by_rg_by_sample)
         data_by_phenotype_by_sample = self.ignore_samples(data_by_phenotype_by_sample)

--- a/multiqc/modules/dragen/overall_mean_cov.py
+++ b/multiqc/modules/dragen/overall_mean_cov.py
@@ -51,6 +51,10 @@ class DragenOverallMeanCovMetrics(BaseMultiqcModule):
                 else:
                     pass
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, file["s_name"])
+
         # Report found info/warnings/errors, which were collected while
         # calling the coverage_parser and constructing cov_headers.
         # You can disable it anytime, if it is not wanted.

--- a/multiqc/modules/dragen/ploidy_estimation_metrics.py
+++ b/multiqc/modules/dragen/ploidy_estimation_metrics.py
@@ -22,6 +22,10 @@ class DragenPloidyEstimationMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
         if not data_by_sample:

--- a/multiqc/modules/dragen/rna_quant_metrics.py
+++ b/multiqc/modules/dragen/rna_quant_metrics.py
@@ -18,6 +18,10 @@ class DragenRnaQuantMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/rna_transcript_cov.py
+++ b/multiqc/modules/dragen/rna_transcript_cov.py
@@ -20,6 +20,10 @@ class DragenRnaTranscriptCoverage(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/sc_atac_metrics.py
+++ b/multiqc/modules/dragen/sc_atac_metrics.py
@@ -39,6 +39,10 @@ class DragenScAtacMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/sc_rna_metrics.py
+++ b/multiqc/modules/dragen/sc_rna_metrics.py
@@ -40,6 +40,10 @@ class DragenScRnaMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/time_metrics.py
+++ b/multiqc/modules/dragen/time_metrics.py
@@ -19,6 +19,10 @@ class DragenTimeMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/trimmer_metrics.py
+++ b/multiqc/modules/dragen/trimmer_metrics.py
@@ -19,6 +19,10 @@ class DragenTrimmerMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/dragen/vc_metrics.py
+++ b/multiqc/modules/dragen/vc_metrics.py
@@ -24,6 +24,10 @@ class DragenVCMetrics(BaseMultiqcModule):
             self.add_data_source(f, section="stats")
             data_by_sample[s_name] = data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         data_by_sample = self.ignore_samples(data_by_sample)
         if not data_by_sample:

--- a/multiqc/modules/dragen_fastqc/dragen_fastqc.py
+++ b/multiqc/modules/dragen_fastqc/dragen_fastqc.py
@@ -68,6 +68,10 @@ class MultiqcModule(DragenBaseMetrics, DragenReadMetrics, DragenFastqcGcMetrics,
             self.add_data_source(f, section="stats")
             data_by_sample.update(data_by_mate)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names:
         self.dragen_fastqc_data = self.ignore_samples(data_by_sample)
 

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -44,6 +44,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("fastp", filehandles=True):
             self.parse_fastp_log(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.fastp_data = self.ignore_samples(self.fastp_data)
 

--- a/multiqc/modules/featureCounts/feature_counts.py
+++ b/multiqc/modules/featureCounts/feature_counts.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("featurecounts"):
             self.parse_featurecounts_report(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.featurecounts_data = self.ignore_samples(self.featurecounts_data)
 

--- a/multiqc/modules/fgbio/ErrorRateByReadPosition.py
+++ b/multiqc/modules/fgbio/ErrorRateByReadPosition.py
@@ -83,6 +83,10 @@ def parse_reports(self):
             error_rate = 0.0 if bases_total == 0 else errors / float(bases_total)
             error_rates[s_name] = {"error_rate": error_rate}
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # ignore samples
     all_data = self.ignore_samples(all_data)
 

--- a/multiqc/modules/fgbio/groupreadsbyumi.py
+++ b/multiqc/modules/fgbio/groupreadsbyumi.py
@@ -37,6 +37,10 @@ class GroupReadsByUmiMixin:
             umi_data[f["s_name"]] = {int(s): int(d[1]) for s, d in enumerate(family_size, 1)}
             umi_data_normed[f["s_name"]] = {int(s): float(d[2]) * 100.0 for s, d in enumerate(family_size, 1)}
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter samples
         self.fgbio_umi_data = self.ignore_samples(umi_data)
         self.fgbio_umi_data_normed = self.ignore_samples(umi_data_normed)

--- a/multiqc/modules/filtlong/filtlong.py
+++ b/multiqc/modules/filtlong/filtlong.py
@@ -25,6 +25,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("filtlong", filehandles=True):
             self.parse_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.filtlong_data = self.ignore_samples(self.filtlong_data)
 
         if len(self.filtlong_data) == 0:

--- a/multiqc/modules/freyja/freyja.py
+++ b/multiqc/modules/freyja/freyja.py
@@ -91,6 +91,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.freyja_data[s_name] = d
             self.add_data_source(f, s_name)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
     def general_stats_cols(self, top_lineages_dict, all_lineages):
         """Add a single column displaying the most abundant lineage to the General Statistics table"""
         headers = OrderedDict()

--- a/multiqc/modules/gatk/analyze_saturation_mutagenesis.py
+++ b/multiqc/modules/gatk/analyze_saturation_mutagenesis.py
@@ -28,6 +28,10 @@ class AnalyzeSaturationMutagenesisMixin:
                 self.add_data_source(file_handle, section="analyze_saturation_mutagenesis")
                 self.gatk_analyze_saturation_mutagenesis[file_handle["s_name"]] = parsed_data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, file_handle["s_name"])
+
         # Filter to strip out ignored sample names
         self.gatk_analyze_saturation_mutagenesis = self.ignore_samples(self.gatk_analyze_saturation_mutagenesis)
 

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -37,6 +37,10 @@ class BaseRecalibratorMixin:
             if self.is_ignore_sample(f["s_name"]):
                 continue
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
             parsed_data = self.parse_report(f["f"].readlines(), report_table_headers)
             rt_type = determine_recal_table_type(parsed_data)
             if len(parsed_data) > 0:

--- a/multiqc/modules/gatk/varianteval.py
+++ b/multiqc/modules/gatk/varianteval.py
@@ -24,6 +24,10 @@ class VariantEvalMixin:
                 self.add_data_source(f, section="varianteval")
                 self.gatk_varianteval[f["s_name"]] = parsed_data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.gatk_varianteval = self.ignore_samples(self.gatk_varianteval)
 

--- a/multiqc/modules/goleft_indexcov/goleft_indexcov.py
+++ b/multiqc/modules/goleft_indexcov/goleft_indexcov.py
@@ -46,6 +46,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_bin_plot_data(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.bin_plot_data = self.ignore_samples(self.bin_plot_data)
 

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -43,6 +43,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_file(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         if len(self.happy_raw_sample_names) == 0:
             raise UserWarning
 

--- a/multiqc/modules/hicexplorer/hicexplorer.py
+++ b/multiqc/modules/hicexplorer/hicexplorer.py
@@ -36,6 +36,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.hicexplorer_data[s_name] = parsed_data
                 self.add_data_source(f, s_name=s_name)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         self.hicexplorer_data = self.ignore_samples(self.hicexplorer_data)
 
         if len(self.hicexplorer_data) == 0:

--- a/multiqc/modules/hicpro/hicpro.py
+++ b/multiqc/modules/hicpro/hicpro.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
             for f in self.find_log_files("hicpro/{}".format(k)):
                 self.parse_hicpro_stats(f, k)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Update current statistics
         for s_name in self.hicpro_data:
             data = self.hicpro_data[s_name]

--- a/multiqc/modules/hicup/hicup.py
+++ b/multiqc/modules/hicup/hicup.py
@@ -30,6 +30,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("hicup"):
             self.parse_hicup_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.hicup_data = self.ignore_samples(self.hicup_data)
 

--- a/multiqc/modules/hisat2/hisat2.py
+++ b/multiqc/modules/hisat2/hisat2.py
@@ -32,6 +32,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("hisat2", filehandles=True):
             self.parse_hisat2_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.hisat2_data = self.ignore_samples(self.hisat2_data)
 

--- a/multiqc/modules/homer/findpeaks.py
+++ b/multiqc/modules/homer/findpeaks.py
@@ -16,6 +16,10 @@ class FindPeaksReportMixin:
         for f in self.find_log_files("homer/findpeaks", filehandles=True):
             self.parse_findPeaks(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.homer_findpeaks = self.ignore_samples(self.homer_findpeaks)
 

--- a/multiqc/modules/homer/tagdirectory.py
+++ b/multiqc/modules/homer/tagdirectory.py
@@ -42,6 +42,10 @@ class TagDirReportMixin:
                 self.add_data_source(f, s_name, section="GCcontent")
                 self.tagdir_data["GCcontent"][s_name] = parsed_data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         ## get esimated genome content distribution:
         for f in self.find_log_files("homer/genomeGCcontent", filehandles=True):
             parsed_data = self.parse_twoCol_file(f)

--- a/multiqc/modules/hops/hops.py
+++ b/multiqc/modules/hops/hops.py
@@ -31,6 +31,10 @@ class MultiqcModule(BaseMultiqcModule):
             except KeyError:
                 logging.warning("Error loading file {}".format(f["fn"]))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.hops_data = self.ignore_samples(self.hops_data)
 
         if len(self.hops_data) == 0:

--- a/multiqc/modules/htseq/htseq.py
+++ b/multiqc/modules/htseq/htseq.py
@@ -34,6 +34,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.htseq_data[f["s_name"]] = parsed_data
                 self.add_data_source(f)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.htseq_data = self.ignore_samples(self.htseq_data)
 

--- a/multiqc/modules/humid/humid.py
+++ b/multiqc/modules/humid/humid.py
@@ -47,6 +47,10 @@ class MultiqcModule(BaseMultiqcModule):
             # file as sample name (since the filename is always stats.dat
             s_name = self.clean_s_name(f["root"], f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
             # Read the statistics from file
             d = {}
             for line in f["f"]:

--- a/multiqc/modules/ivar/ivar.py
+++ b/multiqc/modules/ivar/ivar.py
@@ -32,6 +32,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("ivar/trim", filehandles=True):
             self.parse_ivar(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.ivar_data = self.ignore_samples(self.ivar_data)
         self.ivar_primers = self.ignore_samples(self.ivar_primers)

--- a/multiqc/modules/jcvi/jcvi.py
+++ b/multiqc/modules/jcvi/jcvi.py
@@ -28,6 +28,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("jcvi", filehandles=True):
             self.parse_jcvi(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.jcvi = self.ignore_samples(self.jcvi)
 

--- a/multiqc/modules/jellyfish/jellyfish.py
+++ b/multiqc/modules/jellyfish/jellyfish.py
@@ -26,6 +26,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("jellyfish", filehandles=True):
             self.parse_jellyfish_data(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         if self.jellyfish_max_x < 100:
             # the maximum is below 100, we display anyway up to 200
             self.jellyfish_max_x = 200

--- a/multiqc/modules/kaiju/kaiju.py
+++ b/multiqc/modules/kaiju/kaiju.py
@@ -39,6 +39,11 @@ class MultiqcModule(BaseMultiqcModule):
                                 taxo_rank, s_name
                             )
                         )
+
+                    # Superfluous function call to confirm that it is used in this module
+                    # Replace None with actual version if it is available
+                    self.add_software_version(None, s_name)
+
                 self.add_data_source(f)
                 if taxo_rank in self.kaiju_data.keys():
                     self.kaiju_data[taxo_rank].update(parsed_data)

--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -32,6 +32,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("kallisto", filehandles=True):
             self.parse_kallisto_log(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.kallisto_data = self.ignore_samples(self.kallisto_data)
 

--- a/multiqc/modules/kat/kat.py
+++ b/multiqc/modules/kat/kat.py
@@ -29,6 +29,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.kat_data[s_name] = self.parse_kat_report(content)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names
         self.kat_data = self.ignore_samples(self.kat_data)
 

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -58,6 +58,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.parse_logs_minimizer(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.kraken_raw_data = self.ignore_samples(self.kraken_raw_data)
 
         if len(self.kraken_raw_data) == 0:

--- a/multiqc/modules/leehom/leehom.py
+++ b/multiqc/modules/leehom/leehom.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.leehom_data[f["s_name"]] = parsed_data
                 self.add_data_source(f, f["s_name"])
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.leehom_data = self.ignore_samples(self.leehom_data)
 

--- a/multiqc/modules/librarian/librarian.py
+++ b/multiqc/modules/librarian/librarian.py
@@ -63,6 +63,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.librarian_data[s_name] = data_float
                 self.add_data_source(f, s_name=s_name)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
     def plot_librarian_heatmap(self):
         """Make the heatmap plot"""
         # Get all library types

--- a/multiqc/modules/lima/lima.py
+++ b/multiqc/modules/lima/lima.py
@@ -90,6 +90,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.lima_summary[f["s_name"]] = data
                 self.add_data_source(f)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
     def parse_counts_files(self):
         for f in self.find_log_files("lima/counts", filehandles=True):
             data = self.parse_lima_counts(f["f"], f)

--- a/multiqc/modules/mapdamage/mapdamage.py
+++ b/multiqc/modules/mapdamage/mapdamage.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("mapdamage", filehandles=True):
             self.parse_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.threepGtoAfreq_data = self.ignore_samples(self.threepGtoAfreq_data)
         self.fivepCtoTfreq_data = self.ignore_samples(self.fivepCtoTfreq_data)

--- a/multiqc/modules/methylQA/methylQA.py
+++ b/multiqc/modules/methylQA/methylQA.py
@@ -32,6 +32,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("methylQA"):
             self.parse_methylqa_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.methylqa_data = self.ignore_samples(self.methylqa_data)
 

--- a/multiqc/modules/minionqc/minionqc.py
+++ b/multiqc/modules/minionqc/minionqc.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
             # get sample name
             s_name = self.clean_s_name(os.path.basename(f["root"]), f, root=os.path.dirname(f["root"]))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
             # parses minionqc summary data
             parsed_dict = self.parse_minionqc_report(s_name, f["f"])
 

--- a/multiqc/modules/mirtrace/mirtrace.py
+++ b/multiqc/modules/mirtrace/mirtrace.py
@@ -30,6 +30,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("mirtrace/summary"):
             self.parse_summary(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Find and load miRTrace read length table
         self.length_data = dict()
         for f in self.find_log_files("mirtrace/length"):

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -132,6 +132,11 @@ class MultiqcModule(BaseMultiqcModule):
                     contig, length, bases, mean, min_cov, max_cov = line.split("\t")
                     genstats[s_name]["mean_coverage"] = mean
                     self.add_data_source(f, s_name=s_name, section="summary")
+
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Filter out any samples from --ignore-samples
         genstats = defaultdict(OrderedDict, self.ignore_samples(genstats))
         samples_found = set(genstats.keys())

--- a/multiqc/modules/motus/motus.py
+++ b/multiqc/modules/motus/motus.py
@@ -29,6 +29,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("motus", filehandles=True):
             self.parse_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.motus_data = self.ignore_samples(self.motus_data)
 
         if len(self.motus_data) == 0:

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -60,6 +60,11 @@ class MultiqcModule(BaseMultiqcModule):
         self.has_fasta = False
         for f in self.find_log_files("nanostat", filehandles=True):
             self.parse_nanostat_log(f)
+
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         for f in self.find_log_files("nanostat/legacy", filehandles=True):
             self.parse_legacy_nanostat_log(f)
 

--- a/multiqc/modules/nextclade/nextclade.py
+++ b/multiqc/modules/nextclade/nextclade.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_nextclade_log(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Remove ignored samples
         self.nextclade_data = self.ignore_samples(self.nextclade_data)
 

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -49,6 +49,10 @@ class MultiqcModule(BaseMultiqcModule):
                 expected_header_count_strandedness,
             )
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         for f in self.find_log_files("ngsderive/instrument"):
             self.parse(
                 self.instrument,

--- a/multiqc/modules/odgi/odgi.py
+++ b/multiqc/modules/odgi/odgi.py
@@ -34,6 +34,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("odgi", filehandles=True):
             self.parse_odgi_stats_report(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.odgi_stats_map = self.ignore_samples(self.odgi_stats_map)
 
         # No samples found

--- a/multiqc/modules/optitype/optitype.py
+++ b/multiqc/modules/optitype/optitype.py
@@ -42,6 +42,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.optitype_data[f["s_name"]][header] = col
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.optitype_data = self.ignore_samples(self.optitype_data)
 

--- a/multiqc/modules/pbmarkdup/pbmarkdup.py
+++ b/multiqc/modules/pbmarkdup/pbmarkdup.py
@@ -39,6 +39,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.pbmarkdup[s_name] = data
                 self.add_data_source(logfile)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names
         self.pbmarkdup = self.ignore_samples(self.pbmarkdup)
 

--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -45,6 +45,10 @@ class MultiqcModule(BaseMultiqcModule):
                         self.peddy_data[cleaned_s_name] = parsed_data[s_name]
                 self.add_data_source(f)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, cleaned_s_name)
+
         # parse peddy CSV files
         for pattern in ["het_check", "ped_check", "sex_check"]:
             sp_key = "peddy/{}".format(pattern)

--- a/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
+++ b/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
@@ -28,6 +28,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("phantompeakqualtools/out", filehandles=False):
             self.parse_phantompeakqualtools(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.phantompeakqualtools_data = self.ignore_samples(self.phantompeakqualtools_data)
 

--- a/multiqc/modules/picard/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/picard/AlignmentSummaryMetrics.py
@@ -51,6 +51,10 @@ def parse_reports(self):
                         s_name = None
                         keys = None
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         # Remove empty dictionaries
         for s_name in list(parsed_data.keys()):
             if len(parsed_data[s_name]) == 0:

--- a/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
+++ b/multiqc/modules/picard/BaseDistributionByCycleMetrics.py
@@ -97,6 +97,10 @@ def parse_reports(self):
             for name in s_names.values():
                 self.add_data_source(f, name, section="BaseDistributionByCycle")
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
             for read_end in s_names:
                 data_by_cycle = data[read_end]
                 s_name = s_names[read_end]

--- a/multiqc/modules/picard/CollectIlluminaBasecallingMetrics.py
+++ b/multiqc/modules/picard/CollectIlluminaBasecallingMetrics.py
@@ -32,6 +32,10 @@ def parse_reports(self):
                         data.pop("MOLECULAR_BARCODE_NAME")
                         self.picard_basecalling_metrics[data["LANE"]] = data
 
+                        # Superfluous function call to confirm that it is used in this module
+                        # Replace None with actual version if it is available
+                        self.add_software_version(None, data["LANE"])
+
     # Filter to strip out ignored sample names
     self.picard_basecalling_metrics = self.ignore_samples(self.picard_basecalling_metrics)
 

--- a/multiqc/modules/picard/CollectIlluminaLaneMetrics.py
+++ b/multiqc/modules/picard/CollectIlluminaLaneMetrics.py
@@ -83,6 +83,10 @@ def parse_reports(self):
                         self.picard_lane_metrics[run_name][lane] = {}
                     self.picard_lane_metrics[run_name][lane].update(d)
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, run_name)
+
     # Filter to strip out ignored sample names
     self.picard_lane_metrics = self.ignore_samples(self.picard_lane_metrics)
 

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -67,6 +67,10 @@ def parse_reports(self):
             row["TUMOR_AWARENESS"] = tumor_awareness
             self.picard_CrosscheckFingerprints_data[i] = row
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, i)
+
     # Only add sections if we found data
     if len(self.picard_CrosscheckFingerprints_data) > 0:
         # Write data to file

--- a/multiqc/modules/picard/ExtractIlluminaBarcodes.py
+++ b/multiqc/modules/picard/ExtractIlluminaBarcodes.py
@@ -43,6 +43,10 @@ def parse_reports(self):
         for bc_data in raw_data:
             self.picard_barcode_metrics[bc_data["LANE"]][bc_data["BARCODE"]] = bc_data
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, bc_data["LANE"])
+
     # Filter to strip out ignored sample names
     self.picard_barcode_metrics = self.ignore_samples(self.picard_barcode_metrics)
 

--- a/multiqc/modules/picard/GcBiasMetrics.py
+++ b/multiqc/modules/picard/GcBiasMetrics.py
@@ -74,6 +74,10 @@ def parse_reports(self):
                 self.picard_GCbias_data.pop(s_name, None)
                 log.debug("Removing {} as no data parsed".format(s_name))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         for s_name in list(self.picard_GCbiasSummary_data.keys()):
             if len(self.picard_GCbiasSummary_data[s_name]) == 0:
                 self.picard_GCbiasSummary_data.pop(s_name, None)

--- a/multiqc/modules/picard/HsMetrics.py
+++ b/multiqc/modules/picard/HsMetrics.py
@@ -133,6 +133,10 @@ def parse_reports(self):
             if len(parsed_data[s_name]) == 0:
                 parsed_data.pop(s_name, None)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Manipulate sample names if multiple baits found
         for s_name in parsed_data.keys():
             for j in parsed_data[s_name].keys():

--- a/multiqc/modules/picard/InsertSizeMetrics.py
+++ b/multiqc/modules/picard/InsertSizeMetrics.py
@@ -99,6 +99,10 @@ def parse_reports(self):
                 self.picard_insertSize_histogram.pop(s_name, None)
                 log.debug("Ignoring '{}' histogram as no data parsed".format(s_name))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
     # Calculate summed mean values for all read orientations
     for s_name, v in self.picard_insertSize_samplestats.items():
         self.picard_insertSize_samplestats[s_name]["summed_mean"] = v["meansum"] / v["total_pairs"]

--- a/multiqc/modules/picard/MarkDuplicates.py
+++ b/multiqc/modules/picard/MarkDuplicates.py
@@ -143,6 +143,10 @@ def parse_reports(
                             except ValueError:
                                 parsed_data[k] = vals[i]
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         # Files with no extra lines after last library
         if in_stats_block:
             save_table_results(s_name, base_s_name, keys, parsed_data, recompute_merged_metrics)

--- a/multiqc/modules/picard/MarkIlluminaAdapters.py
+++ b/multiqc/modules/picard/MarkIlluminaAdapters.py
@@ -42,6 +42,10 @@ def parse_reports(self):
     for s_name in all_data:
         lg[s_name] = {clipped_bases: data["read_count"] for clipped_bases, data in all_data[s_name].items()}
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
     self.add_section(
         name="Mark Illumina Adapters",
         description="""

--- a/multiqc/modules/picard/OxoGMetrics.py
+++ b/multiqc/modules/picard/OxoGMetrics.py
@@ -66,6 +66,10 @@ def parse_reports(self):
                 self.add_data_source(s_files[idx], s_name, section="OxoGMetrics")
                 self.picard_OxoGMetrics_data[s_name] = parsed_data[idx]
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.picard_OxoGMetrics_data = self.ignore_samples(self.picard_OxoGMetrics_data)
 

--- a/multiqc/modules/picard/QualityByCycleMetrics.py
+++ b/multiqc/modules/picard/QualityByCycleMetrics.py
@@ -20,6 +20,11 @@ def parse_reports(self):
     if not all_data:
         return 0
 
+    # Superfluous function call to confirm that it is used in this module
+    # Replace None with actual version if it is available
+    for s_name in all_data:
+        self.add_software_version(None, s_name)
+
     # Write parsed data to a file
     self.write_data_file(all_data, "multiqc_picard_quality_by_cycle")
 

--- a/multiqc/modules/picard/QualityScoreDistributionMetrics.py
+++ b/multiqc/modules/picard/QualityScoreDistributionMetrics.py
@@ -21,6 +21,11 @@ def parse_reports(self):
     if not all_data:
         return 0
 
+    # Superfluous function call to confirm that it is used in this module
+    # Replace None with actual version if it is available
+    for s_name in all_data:
+        self.add_software_version(None, s_name)
+
     # Write parsed data to a file
     self.write_data_file(all_data, "multiqc_picard_quality_score_distribution")
 

--- a/multiqc/modules/picard/QualityYieldMetrics.py
+++ b/multiqc/modules/picard/QualityYieldMetrics.py
@@ -52,6 +52,10 @@ def parse_reports(self):
         if s_name is None:
             continue
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         sample_data = dict()
         try:
             # skip to the histogram

--- a/multiqc/modules/picard/RnaSeqMetrics.py
+++ b/multiqc/modules/picard/RnaSeqMetrics.py
@@ -86,6 +86,10 @@ def parse_reports(self):
                 self.picard_RnaSeqMetrics_histogram.pop(s_name, None)
                 log.debug("Ignoring '{}' histogram as no data parsed".format(s_name))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.picard_RnaSeqMetrics_data = self.ignore_samples(self.picard_RnaSeqMetrics_data)
 

--- a/multiqc/modules/picard/RrbsSummaryMetrics.py
+++ b/multiqc/modules/picard/RrbsSummaryMetrics.py
@@ -61,6 +61,10 @@ def parse_reports(self):
             self.add_data_source(f, s_name, section="RrbsSummaryMetrics")
             self.picard_rrbs_metrics[s_name] = parsed_data[s_name]
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.picard_rrbs_metrics = self.ignore_samples(self.picard_rrbs_metrics)
 

--- a/multiqc/modules/picard/TargetedPcrMetrics.py
+++ b/multiqc/modules/picard/TargetedPcrMetrics.py
@@ -49,6 +49,10 @@ def parse_reports(self):
                             except ValueError:
                                 self.picard_pcrmetrics_data[s_name][k] = vals[i]
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.picard_pcrmetrics_data = self.ignore_samples(self.picard_pcrmetrics_data)
 

--- a/multiqc/modules/picard/ValidateSamFile.py
+++ b/multiqc/modules/picard/ValidateSamFile.py
@@ -133,6 +133,10 @@ def _parse_reports_by_type(self):
 
         data[sample] = sample_data
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, sample)
+
     return data
 
 

--- a/multiqc/modules/picard/WgsMetrics.py
+++ b/multiqc/modules/picard/WgsMetrics.py
@@ -80,6 +80,10 @@ def parse_reports(self):
                 self.picard_wgsmetrics_histogram.pop(s_name, None)
                 log.debug("Ignoring '{}' histogram as no data parsed".format(s_name))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.picard_wgsmetrics_data = self.ignore_samples(self.picard_wgsmetrics_data)
 

--- a/multiqc/modules/picard/util.py
+++ b/multiqc/modules/picard/util.py
@@ -55,6 +55,10 @@ def read_histogram(self, program_key, program_name, headers, formats):
         if s_name is None:
             continue
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         sample_data = OrderedDict()
 
         try:

--- a/multiqc/modules/porechop/porechop.py
+++ b/multiqc/modules/porechop/porechop.py
@@ -65,6 +65,11 @@ class MultiqcModule(BaseMultiqcModule):
                 if s_name in self.porechop_data:
                     log.debug(f"Duplicate sample name found! Overwriting: {s_name}")
                 self.porechop_data[s_name] = {}
+
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
             ## Find each valid metric, clean up for plain integer
             # 10,000 reads loaded
             if "reads loaded" in l:

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -48,6 +48,10 @@ class MultiqcModule(BaseMultiqcModule):
             data[f["s_name"]] = sample_data_raw
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         data = self.ignore_samples(data)
         if len(data) == 0:

--- a/multiqc/modules/prinseqplusplus/prinseqplusplus.py
+++ b/multiqc/modules/prinseqplusplus/prinseqplusplus.py
@@ -26,6 +26,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("prinseqplusplus", filehandles=True):
             self.parse_logs(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.prinseqplusplus_data = self.ignore_samples(self.prinseqplusplus_data)
 
         if len(self.prinseqplusplus_data) == 0:

--- a/multiqc/modules/prokka/prokka.py
+++ b/multiqc/modules/prokka/prokka.py
@@ -28,6 +28,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("prokka", filehandles=True):
             self.parse_prokka(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.prokka = self.ignore_samples(self.prokka)
 

--- a/multiqc/modules/pychopper/pychopper.py
+++ b/multiqc/modules/pychopper/pychopper.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.pychopper_data[sample][category][name] = float(value)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, sample)
+
         # Filter to strip out ignored sample names
         self.pychopper_data = self.ignore_samples(self.pychopper_data)
 

--- a/multiqc/modules/qorts/qorts.py
+++ b/multiqc/modules/qorts/qorts.py
@@ -30,6 +30,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_qorts(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Remove empty samples
         self.qorts_data = {s: v for s, v in self.qorts_data.items() if len(v) > 0}
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -20,6 +20,11 @@ def parse_reports(self):
     self.qualimap_bamqc_genome_results = dict()
     for f in self.find_log_files("qualimap/bamqc/genome_results"):
         parse_genome_results(self, f)
+
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     self.qualimap_bamqc_genome_results = self.ignore_samples(self.qualimap_bamqc_genome_results)
     if len(self.qualimap_bamqc_genome_results) > 0:
         self.write_data_file(self.qualimap_bamqc_genome_results, "multiqc_qualimap_bamqc_genome_results")

--- a/multiqc/modules/qualimap/QM_RNASeq.py
+++ b/multiqc/modules/qualimap/QM_RNASeq.py
@@ -41,6 +41,10 @@ def parse_reports(self):
             log.warning("Couldn't find an input filename in genome_results file {}/{}".format(f["root"], f["fn"]))
             return None
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         # Check for and 'fix' European style decimal places / thousand separators
         comma_regex = re.search(r"exonic\s*=\s*[\d\.]+ \(\d{1,3},\d+%\)", f["f"], re.MULTILINE)
         if comma_regex:

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -41,6 +41,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("quast"):
             self.parse_quast_log(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.quast_data = self.ignore_samples(self.quast_data)
 

--- a/multiqc/modules/rna_seqc/rna_seqc.py
+++ b/multiqc/modules/rna_seqc/rna_seqc.py
@@ -29,6 +29,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_metrics_rnaseqc_v1(f)
             self.add_data_source(f, section="v1")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Parse metrics from RNA-SeQC v2
         for f in self.find_log_files("rna_seqc/metrics_v2", filehandles=True):
             self.parse_metrics_rnaseqc_v2(f)

--- a/multiqc/modules/rockhopper/rockhopper.py
+++ b/multiqc/modules/rockhopper/rockhopper.py
@@ -38,6 +38,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("rockhopper"):
             self.parse_rockhopper_summary(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.rh_data = self.ignore_samples(self.rh_data)
 

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -35,6 +35,10 @@ class MultiqcModule(BaseMultiqcModule):
         for f in self.find_log_files("rsem"):
             self.parse_rsem_report(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.rsem_mapped_data = self.ignore_samples(self.rsem_mapped_data)
 

--- a/multiqc/modules/rseqc/bam_stat.py
+++ b/multiqc/modules/rseqc/bam_stat.py
@@ -66,6 +66,10 @@ def parse_reports(self):
                 is_paired_end = True
             self.bam_stat_data[f["s_name"]] = d
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.bam_stat_data = self.ignore_samples(self.bam_stat_data)
 

--- a/multiqc/modules/rseqc/gene_body_coverage.py
+++ b/multiqc/modules/rseqc/gene_body_coverage.py
@@ -73,6 +73,10 @@ def parse_reports(self):
                 del self.gene_body_cov_hist_counts[f["s_name"]]
                 log.warning("Empty geneBodyCoverage file found: {}".format(f["fn"]))
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.gene_body_cov_hist_counts = self.ignore_samples(self.gene_body_cov_hist_counts)
 

--- a/multiqc/modules/rseqc/infer_experiment.py
+++ b/multiqc/modules/rseqc/infer_experiment.py
@@ -38,6 +38,10 @@ def parse_reports(self):
             self.add_data_source(f, section="infer_experiment")
             self.infer_exp[f["s_name"]] = d
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.infer_exp = self.ignore_samples(self.infer_exp)
 

--- a/multiqc/modules/rseqc/inner_distance.py
+++ b/multiqc/modules/rseqc/inner_distance.py
@@ -37,6 +37,10 @@ def parse_reports(self):
         if len(parsed_data) > 0:
             self.inner_distance[f["s_name"]] = parsed_data
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.inner_distance = self.ignore_samples(self.inner_distance)
 

--- a/multiqc/modules/rseqc/junction_annotation.py
+++ b/multiqc/modules/rseqc/junction_annotation.py
@@ -59,6 +59,10 @@ def parse_reports(self):
             self.add_data_source(f, section="junction_annotation")
             self.junction_annotation_data[f["s_name"]] = d
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.junction_annotation_data = self.ignore_samples(self.junction_annotation_data)
 

--- a/multiqc/modules/rseqc/junction_saturation.py
+++ b/multiqc/modules/rseqc/junction_saturation.py
@@ -41,6 +41,10 @@ def parse_reports(self):
                     self.junction_saturation_known[f["s_name"]][v] = parsed["y"][k]
                     self.junction_saturation_novel[f["s_name"]][v] = parsed["w"][k]
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.junction_saturation_all = self.ignore_samples(self.junction_saturation_all)
     self.junction_saturation_known = self.ignore_samples(self.junction_saturation_known)

--- a/multiqc/modules/rseqc/read_distribution.py
+++ b/multiqc/modules/rseqc/read_distribution.py
@@ -69,6 +69,10 @@ def parse_reports(self):
             self.add_data_source(f, section="read_distribution")
             self.read_dist[f["s_name"]] = d
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.read_dist = self.ignore_samples(self.read_dist)
 

--- a/multiqc/modules/rseqc/read_duplication.py
+++ b/multiqc/modules/rseqc/read_duplication.py
@@ -31,6 +31,10 @@ def parse_reports(self):
                 except:
                     pass
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.read_dups = self.ignore_samples(self.read_dups)
 

--- a/multiqc/modules/rseqc/read_gc.py
+++ b/multiqc/modules/rseqc/read_gc.py
@@ -41,6 +41,10 @@ def parse_reports(self):
                     self.read_gc[f["s_name"]][gc[i]] = counts[i]
                     self.read_gc_pct[f["s_name"]][gc[i]] = (counts[i] / total) * 100
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, f["s_name"])
+
     # Filter to strip out ignored sample names
     self.read_gc = self.ignore_samples(self.read_gc)
 

--- a/multiqc/modules/rseqc/tin.py
+++ b/multiqc/modules/rseqc/tin.py
@@ -31,6 +31,10 @@ def parse_reports(self):
         # Add file to multiqc_sources.txt
         self.add_data_source(f)
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
     # Filter to strip out ignored sample names
     self.tin_data = self.ignore_samples(self.tin_data)
 

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -25,6 +25,10 @@ class FlagstatReportMixin:
                 self.add_data_source(f, section="flagstat")
                 self.samtools_flagstat[f["s_name"]] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.samtools_flagstat = self.ignore_samples(self.samtools_flagstat)
 

--- a/multiqc/modules/samtools/idxstats.py
+++ b/multiqc/modules/samtools/idxstats.py
@@ -25,6 +25,10 @@ class IdxstatsReportMixin:
                 self.add_data_source(f, section="idxstats")
                 self.samtools_idxstats[f["s_name"]] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.samtools_idxstats = self.ignore_samples(self.samtools_idxstats)
 

--- a/multiqc/modules/samtools/rmdup.py
+++ b/multiqc/modules/samtools/rmdup.py
@@ -35,6 +35,10 @@ class RmdupReportMixin:
                     self.samtools_rmdup[s_name]["n_unique"] = int(match.group(2)) - int(match.group(1))
                     self.samtools_rmdup[s_name]["pct_dups"] = float(match.group(3)) * 100
 
+                    # Superfluous function call to confirm that it is used in this module
+                    # Replace None with actual version if it is available
+                    self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names
         self.samtools_rmdup = self.ignore_samples(self.samtools_rmdup)
 

--- a/multiqc/modules/sargasso/sargasso.py
+++ b/multiqc/modules/sargasso/sargasso.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.sargasso_files.append(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # log.info('Removing ignored samples...')
         self.sargasso_data = self.ignore_samples(self.sargasso_data)
 

--- a/multiqc/modules/sentieon/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/sentieon/AlignmentSummaryMetrics.py
@@ -49,6 +49,10 @@ def parse_reports(self):
                         s_name = None
                         keys = None
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         # Remove empty dictionaries
         for s_name in list(parsed_data.keys()):
             if len(parsed_data[s_name]) == 0:

--- a/multiqc/modules/sentieon/GcBiasMetrics.py
+++ b/multiqc/modules/sentieon/GcBiasMetrics.py
@@ -76,6 +76,10 @@ def parse_reports(self):
                         except ValueError:
                             self.sentieon_GCbiasSummary_data[s_name][k] = vals[i]
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         for s_name in list(self.sentieon_GCbias_data.keys()):
             if len(self.sentieon_GCbias_data[s_name]) == 0:
                 self.sentieon_GCbias_data.pop(s_name, None)

--- a/multiqc/modules/sentieon/InsertSizeMetrics.py
+++ b/multiqc/modules/sentieon/InsertSizeMetrics.py
@@ -94,6 +94,10 @@ def parse_reports(self):
                     self.sentieon_insertSize_histogram[s_name] = OrderedDict()
                     in_hist = True
 
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None, s_name)
+
         for key in list(self.sentieon_insertSize_data.keys()):
             if len(self.sentieon_insertSize_data[key]) == 0:
                 self.sentieon_insertSize_data.pop(key, None)

--- a/multiqc/modules/seqyclean/seqyclean.py
+++ b/multiqc/modules/seqyclean/seqyclean.py
@@ -29,6 +29,10 @@ class MultiqcModule(BaseMultiqcModule):
 
             self.seqyclean_data[f["s_name"]] = dict()
             for header, col in zip(headers, cols):
+                # Add verions info
+                if header == "Version":
+                    self.add_software_version(col, f["s_name"])
+
                 # Attempt to convert into a float if we can
                 try:
                     col = float(col)

--- a/multiqc/modules/sexdeterrmine/sexdeterrmine.py
+++ b/multiqc/modules/sexdeterrmine/sexdeterrmine.py
@@ -59,6 +59,9 @@ class MultiqcModule(BaseMultiqcModule):
             log.warning("Could not parse SexDeterrmine JSON: '{}'".format(f["fn"]))
             return
 
+        # Get the version
+        version = str(data["Metadata"]["version"])
+
         # Parse JSON data to a dict
         for s_name in data:
             if s_name == "Metadata":
@@ -69,6 +72,7 @@ class MultiqcModule(BaseMultiqcModule):
                 log.debug("Duplicate sample name found! Overwriting: {}".format(s_clean))
 
             self.add_data_source(f, s_clean)
+            self.add_software_version(version, s_clean)
             self.sexdet_data[s_clean] = dict()
 
             for k, v in data[s_name].items():

--- a/multiqc/modules/sickle/sickle.py
+++ b/multiqc/modules/sickle/sickle.py
@@ -31,6 +31,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.sickle_data[f["s_name"]] = parsed_data
                 self.add_data_source(f)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         self.sickle_data = self.ignore_samples(self.sickle_data)
 
         # no file found

--- a/multiqc/modules/skewer/skewer.py
+++ b/multiqc/modules/skewer/skewer.py
@@ -11,6 +11,8 @@ from multiqc.plots import linegraph
 # Initialise the logger
 log = logging.getLogger(__name__)
 
+VERSION_REGEX = r"skewer v([\d\.]+) \[.+\]"
+
 
 class MultiqcModule(BaseMultiqcModule):
     """Skewer"""
@@ -110,6 +112,11 @@ class MultiqcModule(BaseMultiqcModule):
         readlen_dist = OrderedDict()
 
         for l in fh:
+            if l.startswith("skewer"):
+                match = re.search(VERSION_REGEX, l)
+                if match:
+                    data["version"] = match.group(1)
+
             for k, r in regexes.items():
                 match = re.search(r, l)
                 if match:
@@ -128,6 +135,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.add_data_source(f, s_name)
             self.add_skewer_data(s_name, data, f)
             self.skewer_readlen_dist[s_name] = readlen_dist
+            self.add_software_version(data.get("version"), s_name)
 
         if data["fq2"] is not None:
             s_name = self.clean_s_name(data["fq1"], f)
@@ -136,6 +144,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.add_data_source(f, s_name)
             self.add_skewer_data(s_name, data, f)
             self.skewer_readlen_dist[s_name] = readlen_dist
+            self.add_software_version(data.get("version"), s_name)
 
     def add_skewer_data(self, s_name, data, f):
         stats = ["r_processed", "r_short_filtered", "r_empty_filtered", "r_avail", "r_trimmed", "r_untrimmed"]

--- a/multiqc/modules/slamdunk/slamdunk.py
+++ b/multiqc/modules/slamdunk/slamdunk.py
@@ -12,6 +12,8 @@ from multiqc.plots import bargraph, linegraph, scatter, table
 # Initialise the logger
 log = logging.getLogger(__name__)
 
+VERSION_REGEX = r"# slamdunk summary v([\d\.]+)"
+
 
 class MultiqcModule(BaseMultiqcModule):
     """
@@ -293,8 +295,12 @@ class MultiqcModule(BaseMultiqcModule):
             pos += 1
 
     def parseSummary(self, f):
-        # Skip comment line #
-        next(f["f"])
+        # Parse version form first line
+        first = next(f["f"])
+        version = None
+        match = re.search(VERSION_REGEX, first)
+        if match:
+            version = match.group(1)
 
         # Skip header line "FileName..."
         columnCount = next(f["f"]).count("\t") + 1
@@ -317,6 +323,7 @@ class MultiqcModule(BaseMultiqcModule):
                 self.slamdunk_data[s_name]["counted"] = int(fields[12])
 
         self.add_data_source(f)
+        self.add_software_version(version, s_name)
 
     def slamdunkGeneralStatsTable(self):
         """Take the parsed summary stats from Slamdunk and add it to the

--- a/multiqc/modules/snippy/snippy.py
+++ b/multiqc/modules/snippy/snippy.py
@@ -55,6 +55,7 @@ class MultiqcModule(BaseMultiqcModule):
             data = self.parse_snippy_txt(f["f"])
             if data:
                 self.snippy_data[f["s_name"]] = data
+                self.add_software_version(data["version"], f["s_name"])
 
             self.add_data_source(f, section="snippy")
 
@@ -99,6 +100,10 @@ class MultiqcModule(BaseMultiqcModule):
             split_line = line.strip().split("\t")
             if split_line[0] in self.snippy_col:
                 data[split_line[0]] = int(split_line[1])
+
+            if split_line[0] == "Software":
+                data["version"] = split_line[1].split(" ")[1]
+
         if len(data) == 0:
             return False
         for col in self.snippy_col:

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -2,6 +2,7 @@
 
 
 import logging
+import re
 from collections import OrderedDict
 
 from multiqc.modules.base_module import BaseMultiqcModule
@@ -9,6 +10,8 @@ from multiqc.plots import bargraph, linegraph
 
 # Initialise the logger
 log = logging.getLogger(__name__)
+
+VERSION_REGEX = r"SnpEff_version , SnpEff ([\d\.a-z]+)"
 
 
 class MultiqcModule(BaseMultiqcModule):
@@ -164,8 +167,15 @@ class MultiqcModule(BaseMultiqcModule):
         }
         parsed_data = {}
         section = None
+        version = None
         for l in f["f"]:
             l = l.strip()
+
+            # Parse version
+            match = re.search(VERSION_REGEX, l)
+            if match:
+                version = match.group(1)
+
             if l[:1] == "#":
                 section = l
                 self.snpeff_section_totals[section] = dict()
@@ -211,6 +221,7 @@ class MultiqcModule(BaseMultiqcModule):
                 log.debug("Duplicate sample name found! Overwriting: {}".format(f["s_name"]))
             self.add_data_source(f)
             self.snpeff_data[f["s_name"]] = parsed_data
+            self.add_software_version(version, f["s_name"])
 
     def general_stats(self):
         """Add key SnpEff stats to the general stats table"""

--- a/multiqc/modules/snpsplit/snpsplit.py
+++ b/multiqc/modules/snpsplit/snpsplit.py
@@ -55,6 +55,7 @@ class MultiqcModule(BaseMultiqcModule):
             log.debug("Replacing duplicate sample {}".format(s_name))
         self.snpsplit_data[s_name] = parsed[1]
         self.add_data_source(f, s_name=s_name)
+        self.add_software_version(parsed[1].get("version"), s_name)
 
     def parse_new_snpsplit_log(self, f):
         data = next(yaml.load_all(f["f"], Loader=yaml.SafeLoader))
@@ -68,6 +69,7 @@ class MultiqcModule(BaseMultiqcModule):
                 flat_key = "{}_{}".format(k.lower(), key)
                 flat_data[flat_key] = data[k][sk]
         input_fn = data["Meta"]["infile"]
+        flat_data["version"] = data["Meta"]["version"]
         return [input_fn, flat_data]
 
     def parse_old_snpsplit_log(self, f):

--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -51,6 +51,10 @@ class MultiqcModule(BaseMultiqcModule):
                     self.add_data_source(f, s_name)
                     self.somalier_data[s_name] = parsed_data[s_name_raw]
 
+                    # Superfluous function call to confirm that it is used in this module
+                    # Replace None with actual version if it is available
+                    self.add_software_version(None, s_name)
+
         # parse somalier CSV files
         for f in self.find_log_files("somalier/pairs"):
             parsed_data = self.parse_somalier_pairs_tsv(f)

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -31,6 +31,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_sortmerna(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.sortmerna = self.ignore_samples(self.sortmerna)
 

--- a/multiqc/modules/sourmash/compare.py
+++ b/multiqc/modules/sourmash/compare.py
@@ -39,6 +39,10 @@ class CompareMixin:
                 matrices[f["s_name"]] = (labels, matrix.tolist())
                 self.add_data_source(f, section="compare")
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         matrices = self.ignore_samples(matrices)
         if len(matrices) == 0:
             return 0

--- a/multiqc/modules/sourmash/gather.py
+++ b/multiqc/modules/sourmash/gather.py
@@ -38,6 +38,10 @@ class GatherMixin:
                 self.gather_raw_data[f["s_name"]] = data
             self.add_data_source(f, section="gather")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         self.gather_raw_data = self.ignore_samples(self.gather_raw_data)
 
         if len(self.gather_raw_data) == 0:

--- a/multiqc/modules/stacks/stacks.py
+++ b/multiqc/modules/stacks/stacks.py
@@ -132,6 +132,10 @@ class MultiqcModule(BaseMultiqcModule):
             except:
                 log.error("Could not parse gstacks.distribs file in {}".format(f["s_name"]))
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # Parse populations data
         self.distribs_loci = OrderedDict()
         self.distribs_snps = OrderedDict()

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -38,6 +38,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.add_data_source(f, section="SummaryLog")
                 self.star_data[s_name] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         # Find and load any STAR gene count tables
         self.star_genecounts_unstranded = dict()
         self.star_genecounts_first_strand = dict()

--- a/multiqc/modules/supernova/supernova.py
+++ b/multiqc/modules/supernova/supernova.py
@@ -204,6 +204,10 @@ class MultiqcModule(BaseMultiqcModule):
             reports[s_name] = data
             self.add_data_source(f, s_name=s_name, section="supernova-table")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, s_name)
+
         # summary.json files
         for f in self.find_log_files("supernova/summary"):
             log.debug("Found summary.json in: {}".format(f["root"]))

--- a/multiqc/modules/theta2/theta2.py
+++ b/multiqc/modules/theta2/theta2.py
@@ -33,6 +33,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.add_data_source(f)
                 self.theta2_data[f["s_name"]] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.theta2_data = self.ignore_samples(self.theta2_data)
 

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -41,6 +41,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.add_data_source(f, s_name)
                 self.tophat_data[s_name] = parsed_data
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names
         self.tophat_data = self.ignore_samples(self.tophat_data)
 

--- a/multiqc/modules/trimmomatic/trimmomatic.py
+++ b/multiqc/modules/trimmomatic/trimmomatic.py
@@ -30,6 +30,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_trimmomatic(f)
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter to strip out ignored sample names
         self.trimmomatic = self.ignore_samples(self.trimmomatic)
 

--- a/multiqc/modules/umitools/umitools.py
+++ b/multiqc/modules/umitools/umitools.py
@@ -43,6 +43,8 @@ class MultiqcModule(BaseMultiqcModule):
                 self.umitools_data[f["s_name"]] = data
                 # Add the log file information to the multiqc_sources.txt
                 self.add_data_source(f)
+                # Add version info
+                self.add_software_version(data["version"], f["s_name"])
 
         # Check the log files against the user supplied list of samples to ignore
         self.umitools_data = self.ignore_samples(self.umitools_data)
@@ -109,11 +111,15 @@ class MultiqcModule(BaseMultiqcModule):
             "positions_deduplicated": r"INFO Total number of positions deduplicated: (\d+)",
             "mean_umi_per_pos": r"INFO Mean number of unique UMIs per position: ([\d\.]+)",
             "max_umi_per_pos": r"INFO Max. number of unique UMIs per position: (\d+)",
+            "version": r"# UMI-tools version: ([\d\.]+)",
         }
         for key, regex in regexes.items():
             re_matches = re.search(regex, f["f"])
             if re_matches:
-                data[key] = float(re_matches.group(1))
+                if key == "version":
+                    data[key] = re_matches.group(1)
+                else:
+                    data[key] = float(re_matches.group(1))
 
         # calculate a few simple supplementary stats
         try:

--- a/multiqc/modules/varscan2/varscan2.py
+++ b/multiqc/modules/varscan2/varscan2.py
@@ -37,6 +37,10 @@ class MultiqcModule(BaseMultiqcModule):
                 self.varscan2_data[s_name] = parsed_data
                 self.add_data_source(f, s_name, section="mpileup2snp")
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         for f in self.find_log_files("varscan2/mpileup2indel", filehandles=True):
             parsed_data = self.parse_varscan(f)
             s_name = self.clean_s_name(parsed_data["sample_name"], f)

--- a/multiqc/modules/vcftools/relatedness2.py
+++ b/multiqc/modules/vcftools/relatedness2.py
@@ -19,6 +19,10 @@ class Relatedness2Mixin:
                 matrices[f["s_name"]] = m
             self.add_data_source(f, section="Relatedness")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         matrices = self.ignore_samples(matrices)
 
         if len(matrices) == 0:

--- a/multiqc/modules/vcftools/tstv_by_count.py
+++ b/multiqc/modules/vcftools/tstv_by_count.py
@@ -22,6 +22,10 @@ class TsTvByCountMixin:
             self.vcftools_tstv_by_count[f["s_name"]] = d
             self.add_data_source(f, "TsTv by counts")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter out ignored sample names
         self.vcftools_tstv_by_count = self.ignore_samples(self.vcftools_tstv_by_count)
 

--- a/multiqc/modules/vcftools/tstv_by_qual.py
+++ b/multiqc/modules/vcftools/tstv_by_qual.py
@@ -24,6 +24,10 @@ class TsTvByQualMixin:
             self.vcftools_tstv_by_qual[f["s_name"]] = d
             self.add_data_source(f, "TsTv by quality")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter out ignored sample names
         self.vcftools_tstv_by_qual = self.ignore_samples(self.vcftools_tstv_by_qual)
 

--- a/multiqc/modules/vcftools/tstv_summary.py
+++ b/multiqc/modules/vcftools/tstv_summary.py
@@ -23,6 +23,10 @@ class TsTvSummaryMixin:
             self.vcftools_tstv_summary[f["s_name"]] = d
             self.add_data_source(f, "Summary")
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, f["s_name"])
+
         # Filter out ignored sample names
         self.vcftools_tstv_summary = self.ignore_samples(self.vcftools_tstv_summary)
 

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -40,6 +40,20 @@ class MultiqcModule(BaseMultiqcModule):
             self.parse_vep_txt(f)
             self.add_data_source(f)
 
+        # Add version information
+        for sample, data in self.vep_data.items():
+            if "VEP run statistics" not in data:
+                print(data.keys())
+                continue
+
+            print(data["VEP run statistics"]["VEP version (API)"])
+            vep_version, api_version = data["VEP run statistics"]["VEP version (API)"].strip().split(" ")
+            api_version = api_version.replace("(", "").replace(")", "")
+            self.add_software_version(vep_version, sample)
+            # Only add API version if it's different to VEP version
+            if vep_version != api_version:
+                self.add_software_version(api_version, sample, "VEP API")
+            print()
         # Filter to strip out ignored sample names
         self.vep_data = self.ignore_samples(self.vep_data)
 

--- a/multiqc/modules/verifybamid/verifybamid.py
+++ b/multiqc/modules/verifybamid/verifybamid.py
@@ -60,6 +60,10 @@ class MultiqcModule(BaseMultiqcModule):
                 # add data source to multiqc_sources.txt
                 self.add_data_source(f, s_name)
 
+                # Superfluous function call to confirm that it is used in this module
+                # Replace None with actual version if it is available
+                self.add_software_version(None, s_name)
+
         # Filter to strip out ignored sample names as per config.yaml
         self.verifybamid_data = self.ignore_samples(self.verifybamid_data)
 

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -38,6 +38,10 @@ class MultiqcModule(BaseMultiqcModule):
             self.whatshap_stats[sample] = data
             self.add_data_source(f)
 
+            # Superfluous function call to confirm that it is used in this module
+            # Replace None with actual version if it is available
+            self.add_software_version(None, sample)
+
         # Filter to strip out ignored sample names
         self.whatshap_stats = self.ignore_samples(self.whatshap_stats)
 


### PR DESCRIPTION
Related to https://github.com/ewels/MultiQC/issues/2042

- Adds new code check for making sure each module/submodule calls `self.add_software_version`.
- Updated docs so that developers of new modules/submodules are aware that they need to include a `self.add_software_version` call
- For modules missing software version a superfluous `self.add_software_version` calls are added.
- Adds version parsing for remaining modules (see https://github.com/ewels/MultiQC/pull/2051):
  - seqyclean
  - sexdetermine
  - skewer
  - slamdunk
  - snippy
  - snpeff
  - snpsplit
  - umitools
  - vep

For some modules I could find version information in the logs but in files that are currently unparsed e.g. `dragen`, or is missing from the current testdata e.g. `fastp` .  I will raise separate issues for these. 

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` has been updated
