### PR TITLE
Add GitHub Actions bot workflow to fix code linting from a PR comment

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,13 +3,6 @@ on:
   issue_comment:
     types: [created]
 
-  # For manually triggering this workflow
-  workflow_dispatch:
-    inputs:
-      number:
-        description: PR number
-        required: true
-
 jobs:
   update_changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Check if CHANGELOG.md actually changed
         run: |
           git diff --exit-code ${GITHUB_WORKSPACE}/CHANGELOG.md || echo "changed=YES" >> $GITHUB_ENV
-          echo "file changed: ${{ env.changed }}"
+          echo "File changed: ${{ env.changed }}"
 
-      - name: Push changes
+      - name: Commit and push changes
+        if: env.changed == 'YES'
         run: |
           git config user.name 'MultiQC Bot'
           git config user.email 'multiqc-bot@seqera.io'

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -1,0 +1,53 @@
+name: Fix linting
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fix_linting:
+    runs-on: ubuntu-latest
+    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+    if: >
+      github.repository_owner == 'ewels' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@multiqc-bot fix linting')
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MQC_BOT_GITHUB_TOKEN }}
+
+      # Action runs on the issue comment, so we don't get the PR by default.
+      # Use the GitHub CLI to check out the PR:
+      - name: Checkout Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.MQC_BOT_GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - uses: actions/setup-python@v3
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files
+
+      - name: Check if any files changed
+        run: |
+          git diff --exit-code || echo "changed=YES" >> $GITHUB_ENV
+          echo "Files changed: ${{ env.changed }}"
+
+      - name: Commit and push changes
+        if: env.changed == 'YES'
+        run: |
+          git config user.name 'MultiQC Bot'
+          git config user.email 'multiqc-bot@seqera.io'
+          git config push.default upstream
+          git add .
+          git status
+          git commit -m "[automated] Fix code linting"
+          git push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,25 +7,26 @@ repos:
     hooks:
       - id: identity
       - id: check-hooks-apply
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0 # Use the ref you want to point at
+    rev: "v4.4.0" # Use the ref you want to point at
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: debug-statements
-      # - id: name-tests-test
+
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.3.1
+    rev: "v1.5.4"
     hooks:
       - id: remove-crlf
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.1"
+    rev: "v3.0.3"
     hooks:
       - id: prettier
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.2 # Possible releases: https://github.com/hadialqattan/pycln/releases
+    rev: "v2.2.2" # Possible releases: https://github.com/hadialqattan/pycln/releases
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025))
 - Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/ewels/MultiQC/pull/2049))
 - Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
+- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
 
 ### New Modules
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -3,6 +3,14 @@
 
 script-src 'self'
 
+    # 1.17
+    'sha256-krKzkLmKjisEgw0YGKglUFqLmEh6sK08Qw6xPmmo/10=' # ////////////////////////////////////////////////// Base JS for MultiQC Reports//
+    'sha256-8k3VwupzY7v2YyNWjgl7LjJRpDHztn+213IxxMtlhGU=' # ////////////////////////////////////////////////// HighCharts Plotting Code/////
+    'sha256-F/Ns5XO/YJO5xM4MiEoOb0Oo02hP7aTlfRywlFde9G4=' # ////////////////////////////////////////////////// MultiQC Report Toolbox Code//
+    'sha256-lD87d8oI1kNPJlsmI02I4WwpZwxfpFZnvq5MdsR3yaE=' # // Return JS code required for plotting a single sample// RSeQC plot. Attempt to
+    'sha256-Nbg17DNbGUiybFNgr6wbIU1w5j833X0XIK/iycwTXDQ=' # // Javascript for the FastQC MultiQC Mod///////////////// Per Base Sequence Cont
+    'sha256-Y19Ab/rDOuOgOuoftOFGSCo6C6kLjM/LSa2eQgrOCUM=' # // Javascript for the FastQC MultiQC Mod///////////////// Per Base Sequence Cont
+
     # 1.16
     'sha256-wlLs2UDz7n3cvWqY0PTazlKGYhGTOPH77vsElgE7pFw=' # multiqc_fastqc.js
     'sha256-GueuiCxuV8FbnCv7Txho8dTrz3HODU6GH40tvy5kMks=' # multiqc_dragen_fastqc.js

--- a/flake.lock
+++ b/flake.lock
@@ -19,9 +19,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "pypi-deps-db": [
-          "pypi"
-        ]
+        "pypi-deps-db": ["pypi"]
       },
       "locked": {
         "lastModified": 1657089034,

--- a/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
+++ b/multiqc/modules/dragen_fastqc/assets/js/multiqc_dragen_fastqc.js
@@ -115,17 +115,15 @@ function fastqc_module(module_element, module_key) {
         .prepend('<p class="fastqc-heatmap-no-samples text-muted">No samples found.</p>');
     }
     if (hidden_samples > 0) {
-      module_element
-        .find("#fastqc_seq_heatmap_div")
-        .prepend(
-          '<div class="samples-hidden-warning alert alert-warning"> \
+      module_element.find("#fastqc_seq_heatmap_div").prepend(
+        '<div class="samples-hidden-warning alert alert-warning"> \
                 <span class="glyphicon glyphicon-info-sign"></span> \
                 <strong>Warning:</strong> ' +
-            hidden_samples +
-            ' samples hidden in toolbox. \
+          hidden_samples +
+          ' samples hidden in toolbox. \
                 <a href="#mqc_hidesamples" class="alert-link" onclick="mqc_toolbox_openclose(\'#mqc_hidesamples\', true); return false;">See toolbox.</a>\
-            </div>'
-        );
+            </div>',
+      );
     }
     if (num_samples == 0) {
       return;
@@ -355,7 +353,7 @@ function fastqc_module(module_element, module_key) {
           f_col +
           ';"><span class="hc_handle"><span></span><span></span></span><input class="f_text" value="' +
           f_text +
-          '"/><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '"/><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
     }
     // Apply highlights and open toolbox
@@ -393,7 +391,7 @@ function fastqc_module(module_element, module_key) {
       $("#mqc_hidesamples_filters").append(
         '<li><input class="f_text" value="' +
           f_text +
-          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
     }
     // Apply highlights and open toolbox
@@ -421,7 +419,7 @@ function fastqc_module(module_element, module_key) {
   // Export plot
   module_element.find(".dragen_fastqc_per_base_sequence_content_plot").on("mqc_plotexport_image", function (e, cfg) {
     alert(
-      "Apologies, it's not yet possible to export the DRAGEN-FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data."
+      "Apologies, it's not yet possible to export the DRAGEN-FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data.",
     );
   });
   module_element.find(".dragen_fastqc_per_base_sequence_content_plot").on("mqc_plotexport_data", function (e, cfg) {
@@ -470,7 +468,7 @@ function fastqc_module(module_element, module_key) {
           s_status_class +
           '">' +
           s_status +
-          "</span>"
+          "</span>",
       );
 
     // Update the key with the raw data for this position
@@ -662,7 +660,7 @@ function fastqc_module(module_element, module_key) {
                 '; padding-left:5px; margin-bottom: 2px;"></div>' +
                 this.y.toFixed(1) +
                 this.series.name +
-                "</span>"
+                "</span>",
             );
             bars.push(
               '<div class="progress-bar" style="width:' +
@@ -671,7 +669,7 @@ function fastqc_module(module_element, module_key) {
                 this.color +
                 ';">' +
                 this.series.name.replace("%", "").trim() +
-                "</div>"
+                "</div>",
             );
             if (this.point.name) {
               xlabel = this.point.name;

--- a/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
+++ b/multiqc/modules/fastqc/assets/js/multiqc_fastqc.js
@@ -116,17 +116,15 @@ function fastqc_module(module_element, module_key) {
         .prepend('<p class="fastqc-heatmap-no-samples text-muted">No samples found.</p>');
     }
     if (hidden_samples > 0) {
-      module_element
-        .find("#fastqc_seq_heatmap_div")
-        .prepend(
-          '<div class="samples-hidden-warning alert alert-warning"> \
+      module_element.find("#fastqc_seq_heatmap_div").prepend(
+        '<div class="samples-hidden-warning alert alert-warning"> \
                 <span class="glyphicon glyphicon-info-sign"></span> \
                 <strong>Warning:</strong> ' +
-            hidden_samples +
-            ' samples hidden in toolbox. \
+          hidden_samples +
+          ' samples hidden in toolbox. \
                 <a href="#mqc_hidesamples" class="alert-link" onclick="mqc_toolbox_openclose(\'#mqc_hidesamples\', true); return false;">See toolbox.</a>\
-            </div>'
-        );
+            </div>',
+      );
     }
     if (num_samples == 0) {
       return;
@@ -356,7 +354,7 @@ function fastqc_module(module_element, module_key) {
           f_col +
           ';"><span class="hc_handle"><span></span><span></span></span><input class="f_text" value="' +
           f_text +
-          '"/><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '"/><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
     }
     // Apply highlights and open toolbox
@@ -394,7 +392,7 @@ function fastqc_module(module_element, module_key) {
       $("#mqc_hidesamples_filters").append(
         '<li><input class="f_text" value="' +
           f_text +
-          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
     }
     // Apply highlights and open toolbox
@@ -422,7 +420,7 @@ function fastqc_module(module_element, module_key) {
   // Export plot
   module_element.find(".fastqc_per_base_sequence_content_plot").on("mqc_plotexport_image", function (e, cfg) {
     alert(
-      "Apologies, it's not yet possible to export the FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data."
+      "Apologies, it's not yet possible to export the FastQC per-base sequence content plot.\nPlease take a screengrab or export the JSON data.",
     );
   });
   module_element.find(".fastqc_per_base_sequence_content_plot").on("mqc_plotexport_data", function (e, cfg) {
@@ -471,7 +469,7 @@ function fastqc_module(module_element, module_key) {
           s_status_class +
           '">' +
           s_status +
-          "</span>"
+          "</span>",
       );
 
     // Update the key with the raw data for this position
@@ -663,7 +661,7 @@ function fastqc_module(module_element, module_key) {
                 '; padding-left:5px; margin-bottom: 2px;"></div>' +
                 this.y.toFixed(1) +
                 this.series.name +
-                "</span>"
+                "</span>",
             );
             bars.push(
               '<div class="progress-bar" style="width:' +
@@ -672,7 +670,7 @@ function fastqc_module(module_element, module_key) {
                 this.color +
                 ';">' +
                 this.series.name.replace("%", "").trim() +
-                "</div>"
+                "</div>",
             );
             if (this.point.name) {
               xlabel = this.point.name;

--- a/multiqc/modules/rseqc/assets/js/multiqc_rseqc.js
+++ b/multiqc/modules/rseqc/assets/js/multiqc_rseqc.js
@@ -124,7 +124,7 @@ function single_sample_plot(e) {
             <small>loading..</small> \
           </div> \
         </div> \
-      </div>'
+      </div>',
   );
   var pwrapper = rseqc_junction_saturation_plot.parent().parent();
   newplot.insertAfter(pwrapper).hide().slideDown();

--- a/multiqc/templates/default/assets/js/multiqc.js
+++ b/multiqc/templates/default/assets/js/multiqc.js
@@ -45,7 +45,7 @@ $(function () {
     console.log(
       "Could not access localStorage: " +
         e +
-        "\nPlease disable 'Block third-party cookies and site data' or browser equivalent."
+        "\nPlease disable 'Block third-party cookies and site data' or browser equivalent.",
     );
   }
   $("#mqc_hide_welcome_btn, #mqc_welcome .close").click(function (e) {

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -487,7 +487,7 @@ function plot_xy_line_graph(target, ds) {
         config["ymin"] +
         '" data-target="#' +
         target +
-        '">Y-Limits: <span class="mqc_switch on">on</span></span>'
+        '">Y-Limits: <span class="mqc_switch on">on</span></span>',
     );
     wrapper.after('<div class="clearfix" />');
   }
@@ -1068,7 +1068,7 @@ function plot_scatter_plot(target, ds) {
           resizeCh(this_chart);
         });
       }
-    }
+    },
   );
 }
 
@@ -1192,7 +1192,7 @@ function plot_beeswarm_graph(target, ds) {
 
   // Clear the loading text and add hover text placeholder
   $("#" + target).html(
-    '<div class="beeswarm-hovertext"><em class="placeholder">Hover over a data point for more information</em></div><div class="beeswarm-plots"></div>'
+    '<div class="beeswarm-hovertext"><em class="placeholder">Hover over a data point for more information</em></div><div class="beeswarm-plots"></div>',
   );
   // Resize the parent draggable div
   $("#" + target)
@@ -1398,7 +1398,7 @@ function plot_beeswarm_graph(target, ds) {
                     }
                   });
                   $("#" + target + " .beeswarm-hovertext").html(
-                    '<em class="placeholder">Hover over a data point for more information</em>'
+                    '<em class="placeholder">Hover over a data point for more information</em>',
                   );
                 },
               },
@@ -1925,7 +1925,7 @@ function plot_heatmap(target, ds) {
           }
         });
       }
-    }
+    },
   );
 
   // Listeners for range slider
@@ -1940,7 +1940,7 @@ function plot_heatmap(target, ds) {
       chart.colorAxis[0].update({ max: $(this).val() });
     }
     $("#" + target + "_range_slider_" + minmax + ", #" + target + "_range_slider_" + minmax + "_txt").val(
-      $(this).val()
+      $(this).val(),
     );
   });
 }

--- a/multiqc/templates/default/assets/js/multiqc_toolbox.js
+++ b/multiqc/templates/default/assets/js/multiqc_toolbox.js
@@ -36,7 +36,7 @@ $(function () {
             tt +
             '" /> \
           <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button> \
-        </li>'
+        </li>',
         );
       }
       apply_mqc_renamesamples();
@@ -82,7 +82,7 @@ $(function () {
       $("#mqc_hidesamples_filters").append(
         '<li><input class="f_text" value="' +
           val +
-          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
     });
     apply_mqc_hidesamples(show_hide_mode);
@@ -137,7 +137,7 @@ $(function () {
         ajax_promises.push(
           $.get("https://api.crossref.org/works/" + doi + "/transform/application/x-bibtex", function (data) {
             bibtex_string += data + "\n";
-          })
+          }),
         );
       }
       // Wait until all API calls are done
@@ -171,7 +171,7 @@ $(function () {
         f_text +
         '" tabindex="' +
         mqc_colours_idx +
-        '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+        '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
     );
     $("#mqc_cols_apply").attr("disabled", false).removeClass("btn-default").addClass("btn-primary");
     $("#mqc_colour_filter").val("");
@@ -275,7 +275,7 @@ $(function () {
         f_text +
         '" tabindex="' +
         mqc_hidesamples_idx +
-        '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+        '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
     );
     $("#mqc_hide_apply").attr("disabled", false).removeClass("btn-default").addClass("btn-primary");
     $("#mqc_hidesamples_filter").val("");
@@ -304,7 +304,11 @@ $(function () {
     $(".hc-plot").each(function () {
       var fname = $(this).attr("id");
       $("#mqc_export_selectplots").append(
-        '<div class="checkbox"><label><input type="checkbox" value="' + fname + '" checked> ' + fname + "</label></div>"
+        '<div class="checkbox"><label><input type="checkbox" value="' +
+          fname +
+          '" checked> ' +
+          fname +
+          "</label></div>",
       );
     });
     // Select all / none for checkboxes
@@ -379,7 +383,7 @@ $(function () {
           alert(
             "Warning: " +
               skipped_plots +
-              " plots skipped.\n\nNote that it is not currently possible to export dot plot images from reports. Data exports do work."
+              " plots skipped.\n\nNote that it is not currently possible to export dot plot images from reports. Data exports do work.",
           );
         }
         // Save the zip and trigger a download
@@ -1057,7 +1061,7 @@ function populate_mqc_saveselect() {
         'you have the <em>"Block third-party cookies and site data"</em> setting ticked (Chrome) ' +
         "or equivalent in other browsers.</p><p>Please " +
         '<a href="https://www.google.se/search?q=Block+third-party+cookies+and+site+data" target="_blank">change this browser setting</a>' +
-        " to save MultiQC report configs.</p>"
+        " to save MultiQC report configs.</p>",
     );
   }
 }
@@ -1139,7 +1143,7 @@ function load_mqc_config(name) {
           hashCode(f_text + f_col) +
           '"><span class="hc_handle"><span></span><span></span></span><input class="f_text" value="' +
           f_text +
-          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
       window.mqc_highlight_f_texts.push(f_text);
       window.mqc_highlight_f_cols.push(f_col);
@@ -1176,7 +1180,7 @@ function load_mqc_config(name) {
       $("#mqc_hidesamples_filters").append(
         '<li><input class="f_text" value="' +
           f_text +
-          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>'
+          '" /><button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button></li>',
       );
       window.mqc_hide_f_texts.push(f_text);
     });


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/1988

A bot command triggered on a comment "@multiqc-bot fix linting". Inspired by [nf-core/tools](https://github.com/nf-core/tools/blob/master/.github/workflows/fix-linting.yml), though installs and runs pre-commit hooks on all files instead of running separate actions, so we control all linting through the single file `.pre-commit-config.yaml`.

I also updated the linters' versions.