### PR TITLE
Whatshap: process truncated input with no ALL chromosome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,9 @@
 
 ### Module updates
 
-  - Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
-  - Fix parsing mixed strings/numbers, account for trailing tab ([#2083](https://github.com/ewels/MultiQC/pull/2083))
-- **FastQC**:
-- **Picard**:
-- **WhatsHap**: process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
+- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
+- **Picard**: Fix parsing mixed strings/numbers, account for trailing tab ([#2083](https://github.com/ewels/MultiQC/pull/2083))
+- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
 
 ## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@
 
 ### Module updates
 
-- **FastQC**:
   - Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
-- **Picard**:
   - Fix parsing mixed strings/numbers, account for trailing tab ([#2083](https://github.com/ewels/MultiQC/pull/2083))
+- **FastQC**:
+- **Picard**:
+- **WhatsHap**: process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
 
 ## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -127,7 +127,7 @@ class MultiqcModule(BaseMultiqcModule):
         # as a fictional 'ALL' chromosome.
         if ALL_CHROM not in results and len(results) > 1:
             log.warning(
-                f"Could not find the 'ALL' chromosome for {sample}. Make sure that the input is not truncated. Will summarize information for all available chromosomes instead."
+                f"Could not find the 'ALL' chromosome for {sample}. Make sure that the input is not truncated. MultiQC will summarize information for all available chromosomes instead."
             )
             sum_fields = {
                 "variants",

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -10,6 +10,9 @@ from multiqc.plots import bargraph, table
 log = logging.getLogger(__name__)
 
 
+ALL_CHROM = "ALL"
+
+
 class MultiqcModule(BaseMultiqcModule):
     """
     WhatsHap module class, parses WhatsHap output.
@@ -64,12 +67,12 @@ class MultiqcModule(BaseMultiqcModule):
     def parse_whatshap_stats(self, logfile):
         """Parse WhatsHap stats file"""
 
-        def process_data(data):
+        def parse_numeric_values(data):
             """
             Process the data to convert it to the proper format
 
             In practice, this only involves the following changes:
-                - Convert all numeric values to integers
+                - Convert all numeric values to integers or floats
                 - Replace 'nan' values with zero
             """
             for key, value in data.items():
@@ -77,7 +80,10 @@ class MultiqcModule(BaseMultiqcModule):
                 try:
                     data[key] = int(data[key])
                 except ValueError:
-                    pass
+                    try:
+                        data[key] = float(data[key])
+                    except ValueError:
+                        pass
 
                 # Replace 'nan' with zero
                 if value == "nan":
@@ -91,6 +97,9 @@ class MultiqcModule(BaseMultiqcModule):
         header = next(file_content).strip().split("\t")
         header[0] = header[0].lstrip("#")
 
+        if sample == "GM24385_0_1x_full_opt":
+            pass
+
         # The results from this log file, a dictionary for every chromosome
         results = defaultdict(dict)
         # Parse the lines that have the data
@@ -103,25 +112,63 @@ class MultiqcModule(BaseMultiqcModule):
             chromosome = data.pop("chromosome")
 
             # Process the remaining data fields
-            process_data(data)
-
-            # Calculate the fraction of heterozygous variants that were phased
-            try:
-                frac_het_phased = data["phased"] / data["heterozygous_variants"]
-            except ZeroDivisionError:
-                frac_het_phased = 0
-            data["frac_het_phased"] = frac_het_phased
+            parse_numeric_values(data)
 
             # Insert the current line under chromosome
             results[chromosome] = data
 
         # If we were parsing an empty file, we return dummy data (basically all
         # zero) so the sample statistics are consistent, which eases parsing
-        # later on. WhatsHap uses the fictional 'ALL' chromsome to store the
+        # later on. WhatsHap uses the fictional 'ALL' chromosome to store the
         # summary for all results, so we re-use that to store all zero's
         if not results:
             results = dict()
-            results["ALL"] = defaultdict(int)
+            results[ALL_CHROM] = defaultdict(int)
+
+        # If ALL chromosome is not present, and there are multiple contigs available,
+        # e.g. in case of a truncated input file, we summarize available contigs
+        # as a fictional 'ALL' chromosome.
+        if ALL_CHROM not in results and len(results) > 1:
+            log.warning(
+                f"Could not find the 'ALL' chromosome for {sample}. Make sure that the input is not truncated. Will summarize information for all available chromosomes instead."
+            )
+            sum_fields = {
+                "variants",
+                "phased",
+                "unphased",
+                "singletons",
+                "blocks",
+                "bp_per_block_sum",
+                "heterozygous_variants",
+                "heterozygous_snvs",
+                "phased_snvs",
+            }
+            avg_fields = {
+                "bp_per_block_avg",
+                "variant_per_block_avg",
+                "bp_per_block_avg",
+            }
+            results[ALL_CHROM] = defaultdict(int)
+            for chrom in results:
+                if chrom == ALL_CHROM:
+                    continue
+                for field in results[chrom]:
+                    val = results[chrom][field]
+                    if val:
+                        if field in sum_fields:
+                            results[ALL_CHROM][field] += int(results[chrom][field])
+                        elif field in avg_fields:
+                            results[ALL_CHROM][field] += float(results[chrom][field]) * results[chrom]["blocks"]
+            for field in avg_fields:
+                results[ALL_CHROM][field] /= results[ALL_CHROM]["blocks"]
+
+        # Calculate the fraction of heterozygous variants that were phased
+        for chrom, data in results.items():
+            try:
+                frac_het_phased = data["phased"] / data["heterozygous_variants"]
+            except ZeroDivisionError:
+                frac_het_phased = 0
+            results[chrom]["frac_het_phased"] = frac_het_phased
 
         # Clean the sample name
         sample = self.clean_s_name(sample, logfile["root"])
@@ -129,7 +176,7 @@ class MultiqcModule(BaseMultiqcModule):
         return sample, results
 
     @staticmethod
-    def get_summary_field(sample_stats):
+    def get_summary_field(sample_stats, sample):
         """
         Return the summary field for sample_stats
 
@@ -143,7 +190,12 @@ class MultiqcModule(BaseMultiqcModule):
         if len(sample_stats) == 1:
             summary_field = list(sample_stats)[0]
         else:
-            summary_field = "ALL"
+            summary_field = ALL_CHROM
+            if summary_field not in sample_stats:
+                log.warning(
+                    f"Could not find the {summary_field} chromosome for {sample}. Make sure that the input is not truncated. Will summarize information for all available chromosomes instead."
+                )
+                return None
         return summary_field
 
     def whatshap_add_general_stats(self):
@@ -202,7 +254,9 @@ class MultiqcModule(BaseMultiqcModule):
         general = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats)
+            summary_field = self.get_summary_field(sample_stats, sample)
+            if not summary_field:
+                continue
 
             # The summary data we are adding to the general statistics
             summary_data = sample_stats[summary_field]
@@ -218,8 +272,9 @@ class MultiqcModule(BaseMultiqcModule):
         pdata = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats)
-            pdata[sample] = {"Phased Base Pairs": sample_stats[summary_field]["bp_per_block_sum"]}
+            summary_field = self.get_summary_field(sample_stats, sample)
+            if summary_field:
+                pdata[sample] = {"Phased Base Pairs": sample_stats[summary_field]["bp_per_block_sum"]}
 
         configuration = {
             "id": "multiqc_whatshap_phased_bp_plot",
@@ -430,7 +485,9 @@ class MultiqcModule(BaseMultiqcModule):
         general = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats)
+            summary_field = self.get_summary_field(sample_stats, sample)
+            if not summary_field:
+                continue
 
             # The summary data we are adding to the general statistics
             summary_data = sample_stats[summary_field]

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -173,7 +173,7 @@ class MultiqcModule(BaseMultiqcModule):
         return sample, results
 
     @staticmethod
-    def get_summary_field(sample_stats, sample):
+    def get_summary_field(sample_stats):
         """
         Return the summary field for sample_stats
 
@@ -188,11 +188,6 @@ class MultiqcModule(BaseMultiqcModule):
             summary_field = list(sample_stats)[0]
         else:
             summary_field = ALL_CHROM
-            if summary_field not in sample_stats:
-                log.warning(
-                    f"Could not find the {summary_field} chromosome for {sample}. Make sure that the input is not truncated. Will summarize information for all available chromosomes instead."
-                )
-                return None
         return summary_field
 
     def whatshap_add_general_stats(self):
@@ -251,9 +246,7 @@ class MultiqcModule(BaseMultiqcModule):
         general = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats, sample)
-            if not summary_field:
-                continue
+            summary_field = self.get_summary_field(sample_stats)
 
             # The summary data we are adding to the general statistics
             summary_data = sample_stats[summary_field]
@@ -269,9 +262,8 @@ class MultiqcModule(BaseMultiqcModule):
         pdata = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats, sample)
-            if summary_field:
-                pdata[sample] = {"Phased Base Pairs": sample_stats[summary_field]["bp_per_block_sum"]}
+            summary_field = self.get_summary_field(sample_stats)
+            pdata[sample] = {"Phased Base Pairs": sample_stats[summary_field]["bp_per_block_sum"]}
 
         configuration = {
             "id": "multiqc_whatshap_phased_bp_plot",
@@ -482,9 +474,7 @@ class MultiqcModule(BaseMultiqcModule):
         general = dict()
         for sample, sample_stats in self.whatshap_stats.items():
             # Get the summary field
-            summary_field = self.get_summary_field(sample_stats, sample)
-            if not summary_field:
-                continue
+            summary_field = self.get_summary_field(sample_stats)
 
             # The summary data we are adding to the general statistics
             summary_data = sample_stats[summary_field]

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -97,9 +97,6 @@ class MultiqcModule(BaseMultiqcModule):
         header = next(file_content).strip().split("\t")
         header[0] = header[0].lstrip("#")
 
-        if sample == "GM24385_0_1x_full_opt":
-            pass
-
         # The results from this log file, a dictionary for every chromosome
         results = defaultdict(dict)
         # Parse the lines that have the data


### PR DESCRIPTION
MultiQC can pretty much summarise the ALL "chromosome" given available information: all reported fields are either sums, or averages across blocks, so it's a relatively easy addition. Fixes https://github.com/ewels/MultiQC/issues/2093