### PR TITLE
Fix dark-mode and light-mode logo appearing together in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![MultiQC](docs/images/MultiQC_logo.png#gh-light-mode-only) 
+![MultiQC](docs/images/MultiQC_logo.png#gh-light-mode-only)
 ![MultiQC](docs/images/MultiQC_logo_darkbg.png#gh-dark-mode-only)
 
 ### Aggregate bioinformatics results across many samples into a single report

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ![MultiQC](docs/images/MultiQC_logo.png#gh-light-mode-only) ![MultiQC](docs/images/MultiQC_logo_darkbg.png#gh-dark-mode-only)
+![MultiQC](docs/images/MultiQC_logo.png#gh-light-mode-only) 
+![MultiQC](docs/images/MultiQC_logo_darkbg.png#gh-dark-mode-only)
 
 ### Aggregate bioinformatics results across many samples into a single report
 


### PR DESCRIPTION
Before
<img width="907" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/1840cebd-e212-4758-be02-90f1ac2fc2bd">

After
<img width="907" alt="image" src="https://github.com/ewels/MultiQC/assets/27061883/12dcd483-427b-40b4-8674-969f71ba2fe9">
