### PR TITLE
Trigger changelog entry addition on PR creation, in addition to an explicit comment to multiqc-bot

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,12 +8,13 @@ on:
 jobs:
   update_changelog:
     runs-on: ubuntu-latest
-    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
-    if: >
-      github.repository_owner == 'ewels' &&
-      (github.event_name == 'pull_request_target' || 
-      github.event.issue.pull_request && 
-      startsWith(github.event.comment.body, '@multiqc-bot changelog'))
+    # Run if comment is on a PR with the main repo, and if it contains the magic keywords.
+    # Or run on PR creation, unless asked otherwise in the title.
+    if: |
+      github.repository_owner == 'ewels' && (
+        github.event_name == 'pull_request_target' ||
+        github.event.issue.pull_request && startsWith(github.event.comment.body, '@multiqc-bot changelog')
+      )
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,8 @@ name: Update CHANGELOG.md
 on:
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [opened]
 
 jobs:
   update_changelog:
@@ -9,8 +11,9 @@ jobs:
     # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
     if: >
       github.repository_owner == 'ewels' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '@multiqc-bot changelog')
+      (github.event_name == 'pull_request_target' || 
+      github.event.issue.pull_request && 
+      startsWith(github.event.comment.body, '@multiqc-bot changelog'))
 
     steps:
       - uses: actions/checkout@v3
@@ -22,17 +25,29 @@ jobs:
       - name: Checkout Pull Request
         env:
           GH_TOKEN: ${{ secrets.MQC_BOT_GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        run: |
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            PR_NUMBER="${{ github.event.issue.number }}"
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+          gh pr checkout $PR_NUMBER
 
       - uses: actions/setup-python@v3
 
       - name: Update CHANGELOG.md from the PR title
         env:
-          PR_TITLE: ${{ github.event.issue.title }}
-          PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT: ${{ github.event.comment.body }}
           GH_TOKEN: ${{ secrets.MQC_BOT_GITHUB_TOKEN }}
-        run: python ${GITHUB_WORKSPACE}/.github/workflows/changelog.py
+        run: |
+          if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
+            export PR_NUMBER="${{ github.event.issue.number }}"
+            export PR_TITLE="${{ github.event.issue.title }}"
+          elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            export PR_NUMBER="${{ github.event.pull_request.number }}"
+            export PR_TITLE="${{ github.event.pull_request.title }}"
+          fi
+          python ${GITHUB_WORKSPACE}/.github/workflows/changelog.py
 
       - name: Check if CHANGELOG.md actually changed
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
 - Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
 - Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
+- Trigger changelog entry addition on PR creation, in addition to an explicit comment to multiqc-bot ([#2102](https://github.com/ewels/MultiQC/pull/2102))
 
 ### New Modules
 

--- a/docs/core/development/contributing.md
+++ b/docs/core/development/contributing.md
@@ -20,24 +20,28 @@ The MultiQC changelog bot works by using the pull-request title.
 
 - `New module: XYZ` - adding a new module named `XYZ`
 - `XYZ: Change something in this existing module` - updating module `XYZ`
-- `Some other change` - anything else, eg. core MultiQC changes
+- `Some other change` - anything else, e.g. core MultiQC changes
+- `Typo in docs [skip changelog]` - a change so minor that we don't want to log it at all
 
 The MultiQC bot will automatically build a proper changelog entry based on this title
 and (for new modules / module changes) the meta-information in the `MultiqcModule` class.
 
-The MultiQC bot is triggered by adding the following comment on an open pull request:
+When a pull request is opened, a GitHub Action script is triggered, that inspects
+the PR, updates the changelog and commits the update back to your PR. If your
+pull request is not worth a change log entry (i.e. a minor documentation update),
+you can append `[skip changelog]` to the PR title.
+
+The action can also be triggered manually by adding the following comment on an open
+pull request:
 
 ```md
 @multiqc-bot changelog
 ```
 
-This triggers a GitHub Action script which inspects the PR, updates the changelog
-and commits the update back to your PR.
-
-:::tip
-Whilst you can trigger the bot yourself, it's expected that the core MultiQC
-maintainers will do this for you immediately prior to merging.
-:::
+It will replace the automatically added changelog entry if the pull request title
+was updated after the initial commit. And finally, if you forgot to initially append
+`[skip changelog]` and you did it after the initial commit, triggering the bot with a
+comment will assure that the changelog line is removed.
 
 ## Admonitions
 


### PR DESCRIPTION
Helpful for quick and simple pull requests. Additional "@multiqc-bot changelog" comments will replace an exiting comment anyway if needed.