### PR TITLE
Fix adding changelog entries with backticks from PR titles

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,11 +42,11 @@ jobs:
           GH_TOKEN: ${{ secrets.MQC_BOT_GITHUB_TOKEN }}
         run: |
           if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
-            export PR_NUMBER="${{ github.event.issue.number }}"
-            export PR_TITLE="${{ github.event.issue.title }}"
+            export PR_NUMBER='${{ github.event.issue.number }}'
+            export PR_TITLE='${{ github.event.issue.title }}'
           elif [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-            export PR_NUMBER="${{ github.event.pull_request.number }}"
-            export PR_TITLE="${{ github.event.pull_request.title }}"
+            export PR_NUMBER='${{ github.event.pull_request.number }}'
+            export PR_TITLE='${{ github.event.pull_request.title }}'
           fi
           python ${GITHUB_WORKSPACE}/.github/workflows/changelog.py
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
 - Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/ewels/MultiQC/pull/2101))
 - Trigger changelog entry addition on PR creation, in addition to an explicit comment to multiqc-bot ([#2102](https://github.com/ewels/MultiQC/pull/2102))
+- Fix adding changelog entries with backticks from PR titles ([#2115](https://github.com/ewels/MultiQC/pull/2115))
 
 ### New Modules
 


### PR DESCRIPTION
Single quotes make sure that the backticks are not interpreted by the shell as special characters.