### PR TITLE
Set name and anchor for the custom content "module"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bundle lzstring to fix Python 3.12 ([#2119](https://github.com/ewels/MultiQC/pull/2119))
 - Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/ewels/MultiQC/pull/2121))
 - <img src="./multiqc/templates/default/assets/img/favicon-16x16.png" alt="///" width="10px"/> New logo
+- Set name and anchor for the custom content "module" [#2131](https://github.com/ewels/MultiQC/pull/2131)
 
 ### New Modules
 

--- a/multiqc/modules/base_module.py
+++ b/multiqc/modules/base_module.py
@@ -471,7 +471,7 @@ class BaseMultiqcModule(object):
             namespace = headers[k].get("namespace", namespace)
             headers[k]["namespace"] = self.name
             if namespace:
-                headers[k]["namespace"] = self.name + " " + namespace
+                headers[k]["namespace"] = self.name + ": " + namespace
             if "description" not in headers[k]:
                 headers[k]["description"] = headers[k].get("title", k)
 

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -83,7 +83,7 @@ def custom_module_classes():
         mod_cust_config[c_id] = f
 
     # Now go through each of the file search patterns
-    bm = BaseMultiqcModule()
+    bm = BaseMultiqcModule(name="Custom content", anchor="custom_content")
     for k in search_patterns:
         num_sp_found_files = 0
         for f in bm.find_log_files(k):


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/2130

In reports built from custom content, a superfluous "base" is appearing, coming from the default `name` field of the `BaseMultiQCModule` class:

![](https://user-images.githubusercontent.com/37191025/275669363-66494e27-7647-4221-b968-044a7ad7d956.png)

Setting the name and the anchor to the BaseMultiQCModule class instantiated for custom content to make it appear less meaningless:

<img width="690" alt="Screenshot 2023-10-17 at 12 35 50" src="https://github.com/ewels/MultiQC/assets/1575412/ec8181ab-c035-4942-ab1b-702cc99820d0">
