### PR TITLE
Changelog bot: detect module updates when only `search_patterns.yaml` changed

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -282,7 +282,7 @@ else:
             f"- **{mod['name']}**: {descr} {pr_link}\n",
         ]
 if not new_lines:
-    if "[skip changelog]" not in pr_title:
+    if "skip changelog" not in pr_title and "no changelog" not in pr_title:
         new_lines = [
             f"- {pr_title} {pr_link}\n",
         ]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -36,6 +36,11 @@ jobs:
 
       - uses: actions/setup-python@v3
 
+      - name: Install packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install yaml
+
       - name: Update CHANGELOG.md from the PR title
         env:
           COMMENT: ${{ github.event.comment.body }}


### PR DESCRIPTION
E.g. will detect this https://github.com/ewels/MultiQC/pull/2129/files as a "HtSeq Count" module change, and put the entry correctly under the "Module Updates" section.