### PR TITLE
Fix Python and MultiQC version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Fix Python and MultiQC version checks ([#2148](https://github.com/ewels/MultiQC/pull/2148))
+
 ### New Modules
 
 ### Module updates


### PR DESCRIPTION
Few more bits for https://github.com/ewels/MultiQC/pull/2147

* Put the oldest supported version into a variable
* Return when version doesn't match
* Make the check as early as possible
* Also, fix MultiQC remote version check: replace `version.StrictVersion` with `version.parse`