### PR TITLE
Use Ruff formatter instead of Black, pycln, isort

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install packages
         run: |
           python -m pip install --upgrade pip
-          pip install yaml
+          pip install pyyaml
 
       - name: Update CHANGELOG.md from the PR title
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,4 @@ repos:
     rev: v0.1.3
     hooks:
       - id: ruff
-#      - id: mypy
-#        name: mypy - Static type checking
-#        description: Mypy helps ensure that we use our functions and variables correctly by checking the types.
-#        entry: mypy
-#        language: python
-#        types: [python]
-#        exclude: ^examples/
-#        require_serial: true
-#        additional_dependencies:
-#          - mypy
+        args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-hooks-apply
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0" # Use the ref you want to point at
+    rev: "v4.5.0" # Use the ref you want to point at
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -26,7 +26,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: "v2.2.2" # Possible releases: https://github.com/hadialqattan/pycln/releases
+    rev: "v2.3.0" # Possible releases: https://github.com/hadialqattan/pycln/releases
     hooks:
       - id: pycln
         args: [--config=pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.3
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+#  - repo: https://github.com/astral-sh/ruff-pre-commit
+#    rev: v0.1.3
+#    hooks:
+#      - id: ruff
+#        args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,45 +25,10 @@ repos:
     hooks:
       - id: prettier
 
-  - repo: https://github.com/hadialqattan/pycln
-    rev: "v2.3.0" # Possible releases: https://github.com/hadialqattan/pycln/releases
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
-      - id: pycln
-        args: [--config=pyproject.toml]
-
-  - repo: local
-    hooks:
-      - id: isort
-        name: iSort - Sorts imports.
-        description: Sorts your import for you.
-        entry: isort
-        language: python
-        types: [python]
-        require_serial: true
-        additional_dependencies:
-          - isort
-
-      - id: black
-        name: Black - Auto-formatter.
-        description: Black is the uncompromising Python code formatter. Writing to files.
-        entry: black
-        language: python
-        types: [python]
-        require_serial: true
-        additional_dependencies:
-          - black
-#      - id: flake8
-#        name: Flake8 - Enforce code style and doc.
-#        description: A command-line utility for enforcing style consistency across Python projects.
-#        entry: flake8
-#        args: ["--config=.flake8"]
-#        language: python
-#        types: [python]
-#        exclude: ^examples/
-#        require_serial: true
-#        additional_dependencies:
-#          - flake8
-#          - flake8-docstrings
+      - id: ruff
 #      - id: mypy
 #        name: mypy - Static type checking
 #        description: Mypy helps ensure that we use our functions and variables correctly by checking the types.

--- a/docs/core/development/modules.md
+++ b/docs/core/development/modules.md
@@ -143,12 +143,12 @@ tool in the maintenance of high quality software.
 
 MultiQC uses a range of tools to check the code base. The main two code formatters are:
 
-- [Black](https://github.com/psf/black) - Python Code
+- [Ruff](https://docs.astral.sh/ruff/) - Python Code
 - [Prettier](https://prettier.io/) - Everything else (almost)
 
 The easiest way to work with these is to install editor plugins that run the tools every time you save a file.
 For example, [Visual Studio Code](https://code.visualstudio.com/) has
-[built-in support for Black](https://code.visualstudio.com/docs/python/editing#_formatting) and
+[built-in support for Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) and
 plugins for [Prettier](https://github.com/prettier/prettier-vscode).
 
 ### Pre-commit

--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -13,7 +13,6 @@ Makes the following available under the main multiqc namespace:
 
 import logging
 
-from .multiqc import run
 from .utils import config
 
 config.logger = logging.getLogger(__name__)

--- a/multiqc/modules/bbmap/plot_aqhist.py
+++ b/multiqc/modules/bbmap/plot_aqhist.py
@@ -29,9 +29,7 @@ def plot_aqhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_bhist.py
+++ b/multiqc/modules/bbmap/plot_bhist.py
@@ -29,9 +29,7 @@ def plot_bhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         nucleotide_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] * 100 if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_bqhist.py
+++ b/multiqc/modules/bbmap/plot_bqhist.py
@@ -45,9 +45,7 @@ def plot_bqhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_idhist.py
+++ b/multiqc/modules/bbmap/plot_idhist.py
@@ -27,9 +27,7 @@ def plot_idhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_indelhist.py
+++ b/multiqc/modules/bbmap/plot_indelhist.py
@@ -27,9 +27,7 @@ def plot_indelhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_mhist.py
+++ b/multiqc/modules/bbmap/plot_mhist.py
@@ -40,9 +40,7 @@ def plot_mhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_qahist.py
+++ b/multiqc/modules/bbmap/plot_qahist.py
@@ -45,9 +45,7 @@ def plot_qahist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/bbmap/plot_qhist.py
+++ b/multiqc/modules/bbmap/plot_qhist.py
@@ -35,9 +35,7 @@ def plot_qhist(samples, file_type, **plot_args):
     for column_type in columns_to_plot:
         plot_data.append(
             {
-                sample
-                + "."
-                + column_name: {
+                sample + "." + column_name: {
                     x: samples[sample]["data"][x][column] if x in samples[sample]["data"] else 0 for x in all_x
                 }
                 for sample in samples

--- a/multiqc/modules/clusterflow/clusterflow.py
+++ b/multiqc/modules/clusterflow/clusterflow.py
@@ -355,7 +355,5 @@ class MultiqcModule(BaseMultiqcModule):
                     <div class="panel-heading"><h3 class="panel-title">Pipeline Steps: {} (<code>{}</code>)</h3></div>
                     <pre class="panel-body" style="border:0; background-color:transparent; padding:0 15px; margin:0; color:#666; font-size:90%;">{}</pre>
                 </div>
-                """.format(
-                pid, d[0], d[1]
-            )
+                """.format(pid, d[0], d[1])
         return html

--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -105,9 +105,7 @@ class plotProfileMixin:
                     Accumulated view of the distribution of sequence reads related to the closest annotated gene.
                     All annotated genes have been normalized to the same size.
 
-                    {}""".format(
-                    plotBandHelp
-                ),
+                    {}""".format(plotBandHelp),
                 plot=linegraph.plot(self.deeptools_plotProfile, config),
             )
 

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -15,7 +15,7 @@ import re
 from collections import defaultdict
 
 from multiqc import config
-from multiqc.modules.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.modules.base_module import BaseMultiqcModule
 from multiqc.plots import table
 
 from .utils import check_duplicate_samples, clean_headers, make_log_report, order_headers
@@ -269,8 +269,7 @@ METRICS = {
         "scale": "RdGy",
         "colour": "255, 0, 0",
     },
-    "aligned reads in region"
-    + V2: {
+    "aligned reads in region" + V2: {
         "order_priority": 0.2,
         "max": 100,
         "suffix": " %",
@@ -294,8 +293,7 @@ METRICS = {
             "scale": "Oranges",
         },
     },
-    "aligned bases in region"
-    + V2: {
+    "aligned bases in region" + V2: {
         "order_priority": 0.5,
         "max": 100,
         "colour": "0, 0, 255",

--- a/multiqc/modules/dragen/fragment_length.py
+++ b/multiqc/modules/dragen/fragment_length.py
@@ -2,7 +2,7 @@
 import logging
 from collections import defaultdict
 
-from multiqc.modules.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.modules.base_module import BaseMultiqcModule
 from multiqc.plots import linegraph
 
 # Initialise the logger
@@ -60,9 +60,7 @@ class DragenFragmentLength(BaseMultiqcModule):
             Distribution of estimated fragment lengths of mapped reads per read group.
             Only points supported by at least {} reads are shown to prevent long flat tail.
             The plot is also smoothed down to showing 300 points on the X axis to reduce noise.
-            """.format(
-                MIN_CNT_TO_SHOW_ON_PLOT
-            ),
+            """.format(MIN_CNT_TO_SHOW_ON_PLOT),
             plot=linegraph.plot(
                 data_by_rg,
                 {

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from collections import defaultdict
 
-from multiqc.modules.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.modules.base_module import BaseMultiqcModule
 from multiqc.plots import bargraph, table
 
 from .utils import Metric, exist_and_number, make_headers
@@ -151,9 +151,7 @@ class DragenMappingMetics(BaseMultiqcModule):
                 data.get(rrna_filtered_reads_key, 0)
                 if rrna_filtered_reads_key is not None and rrna_filtered_reads_key == "rRNA filtered reads"
                 else 0
-            ) != data.get(
-                "Total reads in RG", 0
-            ):
+            ) != data.get("Total reads in RG", 0):
                 log.warning(
                     "sum of unpaired/discordant/proppaired/unmapped reads not matching total, "
                     "skipping mapping/paired percentages plot for: {}".format(sample_id)
@@ -168,9 +166,7 @@ class DragenMappingMetics(BaseMultiqcModule):
                 data.get(rrna_filtered_reads_key, 0)
                 if rrna_filtered_reads_key is not None and rrna_filtered_reads_key == "rRNA filtered reads"
                 else 0
-            ) != data.get(
-                "Total reads in RG", 0
-            ):
+            ) != data.get("Total reads in RG", 0):
                 log.warning(
                     "sum of unique/duplicate/unmapped reads not matching total, "
                     "skipping mapping/duplicates percentages plot for: {}".format(sample_id)

--- a/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
+++ b/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
@@ -112,9 +112,9 @@ class MultiqcModule(BaseMultiqcModule):
     def computeSnpHom(self):
         """Computes snp(hom) for data present by MultiVCFAnalyzer"""
         for sample in self.mvcf_data:
-            self.mvcf_data[sample]["SNP Calls (hom)"] = (self.mvcf_data[sample]["SNP Calls (all)"]) - self.mvcf_data[
-                sample
-            ]["SNP Calls (het)"]
+            self.mvcf_data[sample]["SNP Calls (hom)"] = (
+                (self.mvcf_data[sample]["SNP Calls (all)"]) - self.mvcf_data[sample]["SNP Calls (het)"]
+            )
 
     def addSummaryMetrics(self):
         """Take the parsed stats from MultiVCFAnalyzer and add it to the main plot"""

--- a/multiqc/modules/picard/RnaSeqMetrics.py
+++ b/multiqc/modules/picard/RnaSeqMetrics.py
@@ -142,9 +142,7 @@ def parse_reports(self):
               <span class="glyphicon glyphicon-warning-sign"></span>
               Picard was run without an rRNA annotation file {}, therefore the ribosomal assignment is not available. To correct, rerun with the <code>RIBOSOMAL_INTERVALS</code> parameter, as documented <a href="https://broadinstitute.github.io/picard/command-line-overview.html#CollectRnaSeqMetrics" target="_blank">here</a>.
             </div>
-            """.format(
-                missing_samples
-            )
+            """.format(missing_samples)
 
         pconfig = {
             "id": "picard_rnaseqmetrics_assignment_plot",

--- a/multiqc/modules/profile_runtime.py
+++ b/multiqc/modules/profile_runtime.py
@@ -6,7 +6,7 @@
 import logging
 from collections import OrderedDict
 
-from multiqc.modules.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.modules.base_module import BaseMultiqcModule
 from multiqc.plots import bargraph
 from multiqc.utils import report
 
@@ -63,9 +63,7 @@ class MultiqcModule(BaseMultiqcModule):
             description="""
                 Number of files searched by MultiQC, categorised by what happened to them.
                 **Total file searches: {}**.
-            """.format(
-                sum(report.file_search_stats.values())
-            ),
+            """.format(sum(report.file_search_stats.values())),
             helptext="""
                 Note that only files are considered in this plot - skipped directories are not shown.
 
@@ -102,9 +100,7 @@ class MultiqcModule(BaseMultiqcModule):
             description="""
                 Time spent running each search pattern to find files for MultiQC modules.
                 **Total file search time: {:.2f} seconds**.
-            """.format(
-                report.runtimes["total_sp"]
-            ),
+            """.format(report.runtimes["total_sp"]),
             helptext="""
                 **NOTE: Usually, MultiQC run time is fairly insignificant - in the order of seconds.
                 Unless you are running MultiQC on many thousands of analysis files, optimising this process

--- a/multiqc/modules/sentieon/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/sentieon/AlignmentSummaryMetrics.py
@@ -63,9 +63,7 @@ def parse_reports(self):
             if s_name in self.sentieon_alignment_metrics:
                 log.debug(
                     "Duplicate sample name found in {}!\
-                          Overwriting: {}".format(
-                        f["fn"], s_name
-                    )
+                          Overwriting: {}".format(f["fn"], s_name)
                 )
             self.add_data_source(f, s_name, section="AlignmentSummaryMetrics")
             self.sentieon_alignment_metrics[s_name] = parsed_data[s_name]

--- a/multiqc/modules/sentieon/GcBiasMetrics.py
+++ b/multiqc/modules/sentieon/GcBiasMetrics.py
@@ -61,9 +61,7 @@ def parse_reports(self):
                     if s_name in self.sentieon_GCbiasSummary_data:
                         log.debug(
                             "Duplicate sample name found in {}!\
-                             Overwriting: {}".format(
-                                f["fn"], s_name
-                            )
+                             Overwriting: {}".format(f["fn"], s_name)
                         )
                     self.add_data_source(f, s_name, section="GcBiasSummaryMetrics")
                     self.sentieon_GCbiasSummary_data[s_name] = dict()

--- a/multiqc/modules/sentieon/InsertSizeMetrics.py
+++ b/multiqc/modules/sentieon/InsertSizeMetrics.py
@@ -49,9 +49,7 @@ def parse_reports(self):
                     if s_name in self.sentieon_insertSize_data:
                         log.debug(
                             "Duplicate sample name found in {}!\
-                             Overwriting: {}".format(
-                                f["fn"], s_name
-                            )
+                             Overwriting: {}".format(f["fn"], s_name)
                         )
                     self.add_data_source(f, s_name, section="InsertSizeMetrics")
                     keys = f["f"].readline().strip("\n").split("\t")
@@ -71,9 +69,7 @@ def parse_reports(self):
                                     self.sentieon_insertSize_data[rowkey][k] = float(vals[i].replace(",", "."))
                                     log.debug(
                                         "Switching commas for points in '{}':\
-                                             {} - {}".format(
-                                            f["fn"], vals[i], vals[i].replace(",", ".")
-                                        )
+                                             {} - {}".format(f["fn"], vals[i], vals[i].replace(",", "."))
                                     )
                                 except ValueError:
                                     self.sentieon_insertSize_data[rowkey][k] = vals[i]
@@ -174,9 +170,7 @@ def parse_reports(self):
                 insertsize_smooth_points = int(config.sentieon_config["insertsize_smooth_points"])
                 log.debug(
                     "Custom Sentieon insert size smoothing:\
-                     {}".format(
-                        insertsize_smooth_points
-                    )
+                     {}".format(insertsize_smooth_points)
                 )
             except (AttributeError, KeyError, ValueError):
                 insertsize_smooth_points = 500

--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -452,18 +452,15 @@ class MultiqcModule(BaseMultiqcModule):
             colours_legend = ""
             for val in sorted(relatedness_colours.keys()):
                 name, col_rgb = relatedness_colours[val]
-                colours_legend += '<span style="color:{}">{}</span>, '.format(
-                    col_rgb.replace(str(alpha), "1.0"), name, val
-                )
+                col = col_rgb.replace(str(alpha), "1.0")
+                colours_legend += f'<span style="color:{col}">{name}</span>, '
 
             self.add_section(
                 name="Relatedness",
                 anchor="somalier-relatedness",
                 description="""
                 Shared allele rates between sample pairs.
-                Points are coloured by degree of expected-relatedness: {}""".format(
-                    colours_legend
-                ),
+                Points are coloured by degree of expected-relatedness: {}""".format(colours_legend),
                 plot=scatter.plot(data, pconfig),
             )
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1213,8 +1213,9 @@ def _required_logs_found(modules_with_logs):
         ]
         if required_modules_with_no_logs:
             logger.critical(
-                "The following modules were explicitly requested but no log files "
-                "were found: {}".format(", ".join(required_modules_with_no_logs))
+                "The following modules were explicitly requested but no log files were found: {}".format(
+                    ", ".join(required_modules_with_no_logs)
+                )
             )
             return False
     return True

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -369,9 +369,7 @@ def matplotlib_bargraph(plotdata, plotsamples, pconfig=None):
         html += '<div class="btn-group mpl_switch_group mqc_mplplot_bargraph_setcountspcnt"> \n\
             <button class="btn btn-default btn-sm {c_a} counts">{c_l}</button> \n\
             <button class="btn btn-default btn-sm {p_a} pcnt">{p_l}</button> \n\
-        </div> '.format(
-            c_a=c_active, p_a=p_active, c_l=c_label, p_l=p_label
-        )
+        </div> '.format(c_a=c_active, p_a=p_active, c_l=c_label, p_l=p_label)
         if len(plotdata) > 1:
             html += " &nbsp; &nbsp; "
 

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -98,9 +98,7 @@ def make_table(dt):
         empty_cells[rid] = '<td class="data-coloured {rid} {h}"></td>'.format(rid=rid, h=hide)
 
         # Build the modal table row
-        t_modal_headers[
-            rid
-        ] = """
+        t_modal_headers[rid] = """
         <tr class="{rid}{muted}" style="background-color: rgba({col}, 0.15);">
           <td class="sorthandle ui-sortable-handle">||</span></td>
           <td style="text-align:center;">
@@ -289,9 +287,7 @@ def make_table(dt):
         <button type="button" class="mqc_table_copy_btn btn btn-default btn-sm" data-clipboard-target="#{tid}">
             <span class="glyphicon glyphicon-copy"></span> Copy table
         </button>
-        """.format(
-            tid=table_id
-        )
+        """.format(tid=table_id)
 
         # Configure Columns Button
         if len(t_headers) > 1:
@@ -299,18 +295,14 @@ def make_table(dt):
             <button type="button" class="mqc_table_configModal_btn btn btn-default btn-sm" data-toggle="modal" data-target="#{tid}_configModal">
                 <span class="glyphicon glyphicon-th"></span> Configure Columns
             </button>
-            """.format(
-                tid=table_id
-            )
+            """.format(tid=table_id)
 
         # Sort By Highlight button
         html += """
         <button type="button" class="mqc_table_sortHighlight btn btn-default btn-sm" data-target="#{tid}" data-direction="desc" style="display:none;">
             <span class="glyphicon glyphicon-sort-by-attributes-alt"></span> Sort by highlight
         </button>
-        """.format(
-            tid=table_id
-        )
+        """.format(tid=table_id)
 
         # Scatter Plot Button
         if len(t_headers) > 1:
@@ -318,9 +310,7 @@ def make_table(dt):
             <button type="button" class="mqc_table_makeScatter btn btn-default btn-sm" data-toggle="modal" data-target="#tableScatterModal" data-table="#{tid}">
                 <span class="glyphicon glyphicon glyphicon-stats"></span> Plot
             </button>
-            """.format(
-                tid=table_id
-            )
+            """.format(tid=table_id)
 
         # "Showing x of y columns" text
         row_visibilities = [all(t_rows_empty[s_name].values()) for s_name in t_rows_empty]
@@ -344,9 +334,7 @@ def make_table(dt):
         # Build table header text
         html += """
         <small id="{tid}_numrows_text" class="mqc_table_numrows_text">{rows}{cols}.</small>
-        """.format(
-            tid=table_id, rows=t_showing_rows_txt, cols=t_showing_cols_txt
-        )
+        """.format(tid=table_id, rows=t_showing_rows_txt, cols=t_showing_cols_txt)
 
     # Build the table itself
     collapse_class = "mqc-table-collapse" if len(t_rows) > 10 and config.collapse_tables else ""
@@ -354,9 +342,7 @@ def make_table(dt):
         <div id="{tid}_container" class="mqc_table_container">
             <div class="table-responsive mqc-table-responsive {cc}">
                 <table id="{tid}" class="table table-condensed mqc_table" data-title="{title}">
-        """.format(
-        tid=table_id, title=table_title, cc=collapse_class
-    )
+        """.format(tid=table_id, title=table_title, cc=collapse_class)
 
     # Build the header row
     col1_header = dt.pconfig.get("col1_header", "Sample Name")
@@ -416,9 +402,7 @@ def make_table(dt):
             </table>
         </div>
         <div class="modal-footer"> <button type="button" class="btn btn-default" data-dismiss="modal">Close</button> </div>
-    </div> </div> </div>""".format(
-            tid=table_id, title=table_title, trows="".join(t_modal_headers.values())
-        )
+    </div> </div> </div>""".format(tid=table_id, title=table_title, trows="".join(t_modal_headers.values()))
 
     # Save the raw values to a file if requested
     if dt.pconfig.get("save_file") is True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,3 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
-target_version = ['py36', 'py37', 'py38', 'py39', 'py310']
-
-[tool.isort]
-profile = "black"
-known_first_party = ["multiqc"]
-line_length = 120
-
-# Unoffocial dev-only: use with `pip install Flake8-pyproject`
-[tool.flake8]
-max-line-length = 120
+target-version = "py312"


### PR DESCRIPTION
Fixes https://github.com/ewels/MultiQC/issues/2149

Ruff is a faster replacement for linters like flake8 and pylint, as well as the formatters like Black, isort, pycln, etc. All in one. Formatting is [very close](https://docs.astral.sh/ruff/formatter/black/) to that of Black, and all the divergencies make sense.

Only added Ruff formatter for now, as the fixer reports too many linting errors, which deserve a separate PR.