### PR TITLE
Pangolin: update for v4: add QC Note , update tool versions columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
 - **fastp**: correctly parse sample name from --in1/--in2 command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
-- **pangolin**: output tool versions and QC notes into table.
+- **Pangolin**: add tool versions and QC notes in the table ([#2157](https://github.com/ewels/MultiQC/pull/2157))
 
 ## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
 - **fastp**: correctly parse sample name from --in1/--in2 command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
+- **pangolin**: output tool versions and QC notes into table.
 
 ## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 
 ### Module updates
 
+- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/ewels/MultiQC/pull/2157))
 - **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
 - **fastp**: correctly parse sample name from --in1/--in2 command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
-- **Pangolin**: add tool versions and QC notes in the table ([#2157](https://github.com/ewels/MultiQC/pull/2157))
 
 ## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
 

--- a/multiqc/modules/pangolin/pangolin.py
+++ b/multiqc/modules/pangolin/pangolin.py
@@ -252,9 +252,7 @@ def _format_qc_notes(raw: str) -> str:
     # e.g. Ambiguous_content:0.03
     if raw.startswith("Ambiguous_content"):
         split = raw.split(":")
-        assert len(split) == 2, (
-            f"expected label of format 'Ambiguous_content:0.01', found {raw}"
-        )
+        assert len(split) == 2, f"expected label of format 'Ambiguous_content:0.01', found {raw}"
         proportion_n = float(split[1])
         percent_n = int(proportion_n * 100)
         return f"Ambiguous content: {percent_n}%"

--- a/multiqc/modules/pangolin/pangolin.py
+++ b/multiqc/modules/pangolin/pangolin.py
@@ -114,8 +114,8 @@ class MultiqcModule(BaseMultiqcModule):
 
                 # Version info
                 # Note: Excluded "version" field from software versions as this refers to
-                #       how the reference data was prepared. This info is still available
-                #       in the "Run table" table
+                # how the reference data was prepared. This info is still available
+                # in the "Run table" table
                 add_version_not_none(row.get("pangolin_version"), s_name, self.name)
                 add_version_not_none(row.get("pango_version"), s_name, "Pango")
                 add_version_not_none(row.get("pangoLEARN_version"), s_name, "PangoLEARN")
@@ -212,8 +212,8 @@ class MultiqcModule(BaseMultiqcModule):
         }
 
         headers["constellation_version"] = {
-            "title": "Constellation version",
-            "description": "The version of constellations that scorpio has used to curate the lineage assignment.",
+            "title": "Constellations version",
+            "description": "The version of Constellations that scorpio has used to curate the lineage assignment.",
             "scale": False,
             "hidden": True,
         }

--- a/multiqc/modules/pangolin/pangolin.py
+++ b/multiqc/modules/pangolin/pangolin.py
@@ -200,16 +200,16 @@ class MultiqcModule(BaseMultiqcModule):
             "hidden": True,
         }
 
-        headers["pangoLEARN_version"] = {
-            "title": "PangoLEARN version",
-            "description": "The dated version of the pangoLEARN model installed.",
+        headers["scorpio_version"] = {
+            "title": "Scorpio version",
+            "description": "The version of the scorpio software installed.",
             "scale": False,
             "hidden": True,
         }
 
-        headers["pango_version"] = {
-            "title": "Pango version",
-            "description": "The version of pango-designation lineages that this assignment is based on.",
+        headers["constellation_version"] = {
+            "title": "Constellation version",
+            "description": "The version of constellations that scorpio has used to curate the lineage assignment.",
             "scale": False,
             "hidden": True,
         }
@@ -219,6 +219,12 @@ class MultiqcModule(BaseMultiqcModule):
             "description": "Indicates whether the sequence passed the QC thresholds for minimum length and maximum N content.",
             "scale": False,
             "modify": lambda x: "Pass" if x == "passed_qc" else x.capitalize(),
+        }
+
+        headers["qc_notes"] = {
+            "title": "QC Note",
+            "description": "Notes specific to the QC checks run on the sequences.",
+            "scale": False,
         }
 
         headers["note"] = {

--- a/multiqc/modules/pangolin/pangolin.py
+++ b/multiqc/modules/pangolin/pangolin.py
@@ -225,6 +225,7 @@ class MultiqcModule(BaseMultiqcModule):
             "title": "QC Note",
             "description": "Notes specific to the QC checks run on the sequences.",
             "scale": False,
+            "modify": _format_qc_notes,
         }
 
         headers["note"] = {
@@ -241,3 +242,25 @@ class MultiqcModule(BaseMultiqcModule):
         }
 
         return table.plot(self.pangolin_data, headers, table_config)
+
+
+def _format_qc_notes(raw: str) -> str:
+    # parses qc notes, they appear to come from:
+    # https://github.com/cov-lineages/pangolin/blob/361f49cbffbf26eb28bed2f4a4c0e7f3d5a054cc/pangolin/utils/preprocessing.py#L91-L97
+    # https://github.com/cov-lineages/pangolin/blob/361f49cbffbf26eb28bed2f4a4c0e7f3d5a054cc/pangolin/utils/preprocessing.py#L179
+
+    # e.g. Ambiguous_content:0.03
+    if raw.startswith("Ambiguous_content"):
+        split = raw.split(":")
+        assert len(split) == 2, (
+            f"expected label of format 'Ambiguous_content:0.01', found {raw}"
+        )
+        proportion_n = float(split[1])
+        percent_n = int(proportion_n * 100)
+        return f"Ambiguous Content: {percent_n}% N"
+
+    if raw == "failed to map":
+        return "Failed to Map"
+
+    # unrecognized notes, just return them, capitalized
+    return raw.capitalize()

--- a/multiqc/modules/pangolin/pangolin.py
+++ b/multiqc/modules/pangolin/pangolin.py
@@ -257,10 +257,7 @@ def _format_qc_notes(raw: str) -> str:
         )
         proportion_n = float(split[1])
         percent_n = int(proportion_n * 100)
-        return f"Ambiguous Content: {percent_n}% N"
-
-    if raw == "failed to map":
-        return "Failed to Map"
+        return f"Ambiguous content: {percent_n}%"
 
     # unrecognized notes, just return them, capitalized
     return raw.capitalize()


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated


Hi @ewels and team! This PR:
* Adds an additional column "QC Note" present in the latest pangolin outputs: https://cov-lineages.org/resources/pangolin/output.html
* Report the versions of `constellations` and `scorpio` (used by Pangolin since v4) instead of `PangoLEARN` and `pango` (used by older versions).

I did run the MultiQC test data through and it all passed and looked good.
![image](https://github.com/ewels/MultiQC/assets/10245822/8459d887-8ac3-40d5-b665-aa112edcd9ab)

Thanks for your consideration!