### PR TITLE
Do not remove invalid software versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/ewels/MultiQC/pull/2143))
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
+- Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
 
 ### New Modules
 

--- a/multiqc/utils/software_versions.py
+++ b/multiqc/utils/software_versions.py
@@ -143,17 +143,10 @@ def validate_software_versions(input):
     def _list_of_versions_is_good(lst: List[str]) -> bool:
         good = True
         for item in lst:
-            try:
-                if not isinstance(item, str):
-                    log.error(
-                        f"Version must be a string, got '{type(item).__name__}': '{item}'. Consider wrapping the value in quotes: '\"{item}\"'"
-                    )
-                    good = False
-                elif not packaging.version.parse(item):
-                    log.error(f"Invalid version: '{item}'")
-                    good = False
-            except packaging.version.InvalidVersion:
-                log.error(f"Invalid version: '{item}'")
+            if not isinstance(item, str):
+                log.error(
+                    f"Version must be a string, got '{type(item).__name__}': '{item}'. Consider wrapping the value in quotes: '\"{item}\"'"
+                )
                 good = False
         return good
 
@@ -171,10 +164,6 @@ def validate_software_versions(input):
                 software = level2_key
                 if not isinstance(versions, list):
                     versions = [versions]
-
-                # Remove anything in parentheses after the version,
-                # eg. 0.9.0 (build 0cea70d) -> 0.9.0
-                versions = [re.sub(r"([\d\.]+) \(.+\)", r"\g<1>", v) for v in versions]
                 if not _list_of_versions_is_good(versions):
                     return output, False
                 output[group][software] = versions

--- a/multiqc/utils/software_versions.py
+++ b/multiqc/utils/software_versions.py
@@ -179,25 +179,6 @@ def validate_software_versions(versions_config: Dict) -> Dict[str, Dict]:
     return output
 
 
-def merge(a: dict, b: dict, path=None):
-    """Merge two dict of dicts recursively"""
-    # source: https://stackoverflow.com/a/7205107
-    if path is None:
-        path = []
-
-    for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                merge(a[key], b[key], path + [str(key)])
-            elif isinstance(a[key], list) and isinstance(b[key], list):
-                a[key].extend(b[key])
-            else:
-                raise Exception("Conflict at " + ".".join(path + [str(key)]))
-        else:
-            a[key] = b[key]
-    return a
-
-
 def sort_versions(versions):
     """
     Sort list of versions in descending order. Accepts list with both strings and packaging.version.Version

--- a/multiqc/utils/software_versions.py
+++ b/multiqc/utils/software_versions.py
@@ -205,7 +205,7 @@ def sort_versions(versions):
     """
     version_objs = [v for v in versions if isinstance(v, packaging.version.Version)]
     version_strs = [v for v in versions if not isinstance(v, packaging.version.Version)]
-    versions = sorted(version_objs) + sorted(sorted(version_strs))
+    versions = sorted(version_objs) + sorted(version_strs)
     return versions
 
 

--- a/multiqc/utils/software_versions.py
+++ b/multiqc/utils/software_versions.py
@@ -7,7 +7,7 @@ import logging
 import os
 import re
 from collections import defaultdict
-from typing import List
+from typing import List, Dict, Union
 
 import packaging.version
 import yaml
@@ -59,20 +59,21 @@ def update_versions_from_config(config, report):
 def load_versions_from_config(config):
     """Try to load software versions from config"""
     log.debug("Reading software versions from config.software_versions")
-    software_versions_config = getattr(config, "software_versions", defaultdict(lambda: defaultdict(list)))
-    software_versions_config, is_valid = validate_software_versions(software_versions_config)
+    versions_config = getattr(config, "software_versions", defaultdict(lambda: defaultdict(list)))
+    if not isinstance(versions_config, dict):
+        log.error(f"Expected the `software_versions` config section to be a dictionary")
+        versions_config = {}
+    else:
+        versions_config = validate_software_versions(versions_config)
 
-    if not is_valid:
-        log.error("Software versions loaded config.software_versions is not in a valid format, ignoring the section.")
-
-    software_versions_file = defaultdict(lambda: defaultdict(list))
+    versions_from_files = defaultdict(lambda: defaultdict(list))
     for f in mqc_report.files.get("software_versions", []):
         file_name = os.path.join(f["root"], f["fn"])
-        with open(file_name) as f:
+        with open(file_name) as fh:
+            log.debug(f"Reading software versions settings from: {file_name}")
             try:
-                log.debug(f"Reading software versions settings from: {file_name}")
-                software_versions_file_tmp = yaml.load(
-                    f,
+                versions_from_one_file = yaml.load(
+                    fh,
                     # We need to be cautious when loading unquoted version strings from a YAML file.
                     # For instance, the version `1.10` will be parsed as a float by default, this converted
                     # into `1.1`. Passing yaml.BaseLoader explicitly makes YAML treat all scalar values
@@ -85,33 +86,31 @@ def load_versions_from_config(config):
             except yaml.scanner.ScannerError as e:
                 log.error(f"Error parsing versions YAML: {e}")
 
-        software_versions_file_tmp, is_valid = validate_software_versions(software_versions_file_tmp)
-
-        if not is_valid:
-            log.error(f"Software versions loaded from {file_name} is not in a valid format, ignoring the file.")
+        if not isinstance(versions_from_one_file, dict):
+            log.error(
+                f"Expected the software versions file {file_name} to contain a dictionary structure, "
+                f"ignoring the file."
+            )
             continue
-
-        software_versions_file = merge(software_versions_file, software_versions_file_tmp)
+        versions_from_one_file = validate_software_versions(versions_from_one_file)
+        config.update_dict(versions_from_files, versions_from_one_file)
 
     # Aggregate versions listed in config and file
-    software_versions = merge(software_versions_config, software_versions_file)
+    config.update_dict(versions_config, versions_from_files)
 
     # Parse the aggregated versions
-    for group in list(software_versions):
-        softwares = software_versions[group]
-        for tool in list(softwares):
-            versions = softwares[tool]
-
+    for group in versions_config:
+        softwares = versions_config[group]
+        for tool in softwares:
             # Try and convert version to packaging.versions.Version object and remove duplicates
-            versions = list(set([parse_version(version) for version in versions]))
+            versions = list(set([parse_version(version) for version in softwares[tool]]))
             versions = sort_versions(versions)
-
             softwares[tool] = versions
 
-    return software_versions
+    return versions_config
 
 
-def validate_software_versions(input):
+def validate_software_versions(versions_config: Dict) -> Dict[str, Dict]:
     """
     Validate software versions input from config file
 
@@ -137,24 +136,24 @@ def validate_software_versions(input):
 
     It is also possible to mix the two formats, but this is not recommended.
 
-    Returns a dict of dicts of list in the format (1) and a boolean indicating if the input is valid.
+    Returns a dict of dicts of list in the format (1).
     """
 
-    def _list_of_versions_is_good(lst: List[str]) -> bool:
-        good = True
+    def _filter_list(lst: List[str]) -> List[str]:
+        """Remove all non-string version tags"""
+        fixed_lst = []
         for item in lst:
             if not isinstance(item, str):
                 log.error(
                     f"Version must be a string, got '{type(item).__name__}': '{item}'. Consider wrapping the value in quotes: '\"{item}\"'"
                 )
-                good = False
-        return good
+            else:
+                fixed_lst.append(item)
+        return fixed_lst
 
     output = defaultdict(lambda: defaultdict(list))
-    if not isinstance(input, dict):
-        return output, False
 
-    for level1_key, level1_values in input.items():
+    for level1_key, level1_values in versions_config.items():
         group = level1_key
         software = level1_key
 
@@ -164,20 +163,20 @@ def validate_software_versions(input):
                 software = level2_key
                 if not isinstance(versions, list):
                     versions = [versions]
-                if not _list_of_versions_is_good(versions):
-                    return output, False
-                output[group][software] = versions
+                versions = _filter_list(versions)
+                if versions:
+                    output[group][software] = versions
 
         # Check if the input is in format (2)
         else:
             versions = level1_values
             if not isinstance(versions, list):
                 versions = [versions]
-            if not _list_of_versions_is_good(versions):
-                return output, False
-            output[group][software] = versions
+            versions = _filter_list(versions)
+            if versions:
+                output[group][software] = versions
 
-    return output, True
+    return output
 
 
 def merge(a: dict, b: dict, path=None):
@@ -200,12 +199,13 @@ def merge(a: dict, b: dict, path=None):
 
 
 def sort_versions(versions):
-    """Sort list of versions in descending order. Accepts list with both strings and packaging.version.Version objects."""
-    try:
-        versions.sort()
-    except TypeError:
-        # If there is a mix, sort all as strings
-        versions.sort(key=str)
+    """
+    Sort list of versions in descending order. Accepts list with both strings and packaging.version.Version
+    objects.
+    """
+    version_objs = [v for v in versions if isinstance(v, packaging.version.Version)]
+    version_strs = [v for v in versions if not isinstance(v, packaging.version.Version)]
+    versions = sorted(version_objs) + sorted(sorted(version_strs))
     return versions
 
 


### PR DESCRIPTION
Added a bit of logic to clean up version strings, and also catch exceptions coming from `packaging.version.parse`:

```console
  /// MultiQC 🔍 | v1.18.dev0 (c62a430)

|           multiqc | Search path : /Users/ewels/Downloads/multiqc_input
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 84/84
|    custom_content | seqeralabs-nf-aggregate-summary: Found 1 sample (html)
|        seqera_cli | Found 9 reports
```

```python
Traceback (most recent call last):
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/bin/multiqc", line 8, in <module>
    sys.exit(run_multiqc())
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/__main__.py", line 23, in run_multiqc
    multiqc.run_cli(prog_name="multiqc")
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/rich_click/rich_command.py", line 126, in main
    rv = self.invoke(ctx)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/multiqc.py", line 300, in run_cli
    multiqc_run = run(**kwargs)
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/multiqc.py", line 804, in run
    software_versions.update_versions_from_config(config, report)
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/utils/software_versions.py", line 28, in update_versions_from_config
    versions_from_config = load_versions_from_config(config)
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/utils/software_versions.py", line 87, in load_versions_from_config
    software_versions_file_tmp, is_valid = validate_software_versions(software_versions_file_tmp)
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/utils/software_versions.py", line 169, in validate_software_versions
    if not _list_of_versions_is_good(versions):
  File "/Users/ewels/GitHub/MultiQC/MultiQC/multiqc/utils/software_versions.py", line 150, in _list_of_versions_is_good
    elif not packaging.version.parse(item):
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/packaging/version.py", line 54, in parse
    return Version(version)
  File "/Users/ewels/.miniconda3/miniconda3/envs/py3.10/lib/python3.10/site-packages/packaging/version.py", line 200, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: '0.9.0 (build 0cea70d)'
```


The regex in this PR normalises `0.9.0 (build 0cea70d)` to `0.9.0`, fixing the issue.

**But** - honestly, I'm not really sure if we want to do this.

Why do we have to validate that version strings look like version strings? Can we not just accept _any_ string?

Comments like this make me think that the code did that at some point:

> Accepts list with both strings and packaging.version.Version objects.

However, as far as I see it, if the version string isn't classic semver / recognised format, it's entirely excluded from the report:

```
| software_versions | Invalid version: '0.9.0 (build 0cea70d)'
| software_versions | Software versions loaded from ./11/software_mqc_versions.yml is not in a valid format, ignoring the file.
```

Worse - not just that version string, but all versions within that file.

Tagging @vladsavelyev @pontushojer 