### PR TITLE
Remove position:absolute from table values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/ewels/MultiQC/pull/2143))
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
+- Remove position:absolute from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
 
 ### New Modules
 

--- a/multiqc/templates/default/assets/css/default_multiqc.css
+++ b/multiqc/templates/default/assets/css/default_multiqc.css
@@ -876,7 +876,6 @@ tbody .sorthandle {
 }
 .mqc_table .val {
   display: block;
-  position: absolute;
   padding: 5px;
   left: 0;
 }


### PR DESCRIPTION
Prevent text overlap from being hidden in tables.