### PR TITLE
Fix custom anchors for kraken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
 - Remove position:absolute from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
+- fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
 - Remove position:absolute from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
-- fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
+- Fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
 
 ### New Modules
 

--- a/multiqc/modules/bracken/bracken.py
+++ b/multiqc/modules/bracken/bracken.py
@@ -21,4 +21,5 @@ class MultiqcModule(KrakenModule):
             href="https://ccb.jhu.edu/software/bracken/",
             info="is a highly accurate statistical method that computes the abundance of species in DNA sequences from a metagenomics sample.",
             doi="10.7717/peerj-cs.104",
+            sp_key="bracken",
         )

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any kraken reports
         self.kraken_raw_data = dict()
         new_report_present = False
-        for f in self.find_log_files(self.anchor, filehandles=True):
+        for f in self.find_log_files("kraken", filehandles=True):
             log_version = self.get_log_version(f)
             f["f"].seek(0)
             if log_version == "old":

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -23,6 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
         href="https://ccb.jhu.edu/software/kraken/",
         info="is a taxonomic classification tool that uses exact k-mer matches to find the lowest common ancestor (LCA) of a given sequence.",
         doi="10.1186/gb-2014-15-3-r46",
+        sp_key="kraken",
     ):
         super(MultiqcModule, self).__init__(
             name=name,
@@ -48,7 +49,7 @@ class MultiqcModule(BaseMultiqcModule):
         # Find and load any kraken reports
         self.kraken_raw_data = dict()
         new_report_present = False
-        for f in self.find_log_files("kraken", filehandles=True):
+        for f in self.find_log_files(sp_key, filehandles=True):
             log_version = self.get_log_version(f)
             f["f"].seek(0)
             if log_version == "old":


### PR DESCRIPTION

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` has been updated
    - Is this automated now? I saw some added actions automation around changelog in .github/workflows/changelog.yml

This change broke custom anchors for the kraken module: https://github.com/ewels/MultiQC/pull/1372/files#diff-10bfc7513ddf0bd9fd13bbb456bb610f9d45592b3a2e9337bc44a6dba05c335eR29

I don't believe `find_log_files` should use the anchor (which is an html detail as best I understand).

I'm not uber confident on this fix, but it does revert to how it was before, and fix our issues.

Without fix:

```
root@58ce75507ca9:/src/MultiQC_TestData/data/modules/kraken# multiqc -f .

  /// MultiQC 🔍 | v1.18.dev0

|           multiqc | Search path : /src/MultiQC_TestData/data/modules/kraken
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 16/16  
╭───────────────────────────────── Oops! The 'kraken' MultiQC module broke... ─────────────────────────────────╮
│ Please copy this log and report it at https://github.com/ewels/MultiQC/issues                                │
│ Please attach a file that triggers the error. The last file found was: ./v2.0.8_beta/sample1.kraken2.report  │
│                                                                                                              │
│ Traceback (most recent call last):                                                                           │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/multiqc.py", line 691, in run                        │
│     output = mod()                                                                                           │
│              ^^^^^                                                                                           │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/modules/kraken/kraken.py", line 51, in __init__      │
│     for f in self.find_log_files(self.anchor, filehandles=True):                                             │
│   File "/usr/local/lib/python3.12/site-packages/multiqc/modules/base_module.py", line 139, in find_log_files │
│     for f in report.files[sp_key]:                                                                           │
│              ~~~~~~~~~~~~^^^^^^^^                                                                            │
│ KeyError: 'not_kraken'                                                                                       │
│                                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
|           multiqc | No analysis results found. Cleaning up..
|           multiqc | MultiQC complete
```

With fix:
```
root@58ce75507ca9:/src/MultiQC_TestData/data/modules/kraken# multiqc -f .

  /// MultiQC 🔍 | v1.18.dev0

|           multiqc | Search path : /src/MultiQC_TestData/data/modules/kraken
|         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 16/16  
|            kraken | Found 12 reports
|            kraken | Kraken2 reports of different versions were found
|           multiqc | Report      : multiqc_report.html   (overwritten)
|           multiqc | Data        : multiqc_data   (overwritten)
|           multiqc | MultiQC complete
```

Here is a TestData report with the fix (zipped so github allows it):

[multiqc_report.zip](https://github.com/ewels/MultiQC/files/13323067/multiqc_report.zip)


Here's how I tested:
1. Add a config yaml in `MultiQC_TestData/data/modules/kraken/multiqc_config.yaml`:
    
    ```yaml
    module_order:
      - kraken:
          anchor: not_kraken
    ```
2. Installed multiqc locally
3. `cd` to the kraken testdata dir and run

cc @vladsavelyev 