### PR TITLE
Remove "update changelog" from PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,6 @@ Please fill in the appropriate checklist below (delete whatever is not relevant)
 -->
 
 - [ ] This comment contains a description of changes (with reason)
-- [ ] `CHANGELOG.md` has been updated
 
 <!-- If this PR is for a NEW module - delete if not -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
 - Remove position:absolute from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
-- remove changelog update from pr template ([#2171](https://github.com/ewels/MultiQC/pull/2171))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Nanostat: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - Clean version strings with build IDs ([#2166](https://github.com/ewels/MultiQC/pull/2166))
 - Remove position:absolute from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
+- remove changelog update from pr template ([#2171](https://github.com/ewels/MultiQC/pull/2171))
 
 ### New Modules
 


### PR DESCRIPTION
Looks like changelog gets auto-updated now by a github actions workflow. Figured this could be removed from the PR template.

Thanks for the hard work!
