### PR TITLE
New module: Parse Biosciences, implements Split pipe

### DIFF
--- a/docs/modules/parse_biosciences.md
+++ b/docs/modules/parse_biosciences.md
@@ -1,0 +1,8 @@
+---
+name: Parse Biosciences
+url: https://www.parsebiosciences.com
+description: >
+  provides single cell RNA-Seq pipelines
+---
+
+Implemented parsing reports for the Split pipeline.

--- a/multiqc/modules/parse_biosciences/__init__.py
+++ b/multiqc/modules/parse_biosciences/__init__.py
@@ -1,0 +1,3 @@
+from .parse_biosciences import MultiqcModule
+
+__all__ = ["MultiqcModule"]

--- a/multiqc/modules/parse_biosciences/parse_biosciences.py
+++ b/multiqc/modules/parse_biosciences/parse_biosciences.py
@@ -1,0 +1,167 @@
+""" MultiQC module to parse output from Parse Biosciences pipelines """
+from typing import Dict, Union
+
+import logging
+
+from multiqc.plots import table
+from multiqc.utils import config
+
+from multiqc.modules.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+
+# Initialise the logger
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    def __init__(self):
+        # Initialise the parent object
+        super(MultiqcModule, self).__init__(
+            name="Parse Biosciences",
+            anchor="parse_biosciences",
+            href="https://www.parsebiosciences.com/",
+            info="provides single cell RNA-Seq pipelines",
+            # doi="",
+        )
+
+        split_pipe_samples = self.parse_split_pipe()
+        if split_pipe_samples > 0:
+            log.info(f"Found {split_pipe_samples} samples in Parse Biosciences Split pipeline outputs")
+
+        if split_pipe_samples == 0:
+            raise ModuleNoSamplesFound
+
+    CSV_HEADERS = {
+        "sample_well_count": {
+            "title": "Sample wells",
+            "description": "Number of wells with cells",
+            "format": "{:,d}",
+            "min": 0,
+        },
+        "number_of_cells": {
+            "rid": "bpsplit_cells",
+            "title": "Cells",
+            "description": "Number of cells detected",
+            "format": "{:,d}",
+            "min": 0,
+            "scale": "RdPu",
+        },
+        "mean_reads_per_cell": {
+            "title": "Reads per cell",
+            "description": "Mean reads per cell",
+            "format": "{:,.0f}",
+            "min": 0,
+            "scale": "Blues",
+        },
+        "number_of_reads": {
+            "rid": "bpsplit_reads",
+            "title": f"{config.read_count_prefix} Reads",
+            "description": f"Number of reads ({config.read_count_desc})",
+            "modify": lambda x: x * config.read_count_multiplier,
+            "shared_key": "read_count",
+            "scale": "YlGn",
+        },
+        "number_of_tscps": {
+            "title": f"{config.read_count_prefix} TSCP",
+            "description": f"Number of TSCP ({config.read_count_desc})",
+            "modify": lambda x: x * config.read_count_multiplier,
+            "shared_key": "read_count",
+        },
+        "sequencing_saturation": {
+            "title": "Saturation",
+            "description": "Sequencing saturation",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "scale": "YlOrRd",
+        },
+        "valid_barcode_fraction": {
+            "title": "Valid BC",
+            "description": "Valid barcode fraction",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "scale": "Spectral",
+        },
+        "bc1_Q30": {
+            "title": "BC1 Q30",
+            "description": "BC1 Q30",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "hidden": True,
+        },
+        "bc2_Q30": {
+            "title": "BC2 Q30",
+            "description": "BC2 Q30",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+        },
+        "bc3_Q30": {
+            "title": "BC3 Q30",
+            "description": "BC3 Q30",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "hidden": True,
+        },
+        "cDNA_Q30": {
+            "title": "cDNA Q30",
+            "description": "cDNA Q30",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "hidden": True,
+        },
+        "polyN_Q30": {
+            "title": "PolyN Q30",
+            "description": "PolyN Q30",
+            "format": "{:.2%}",
+            "min": 0,
+            "max": 1,
+            "hidden": True,
+        },
+    }
+
+    def parse_split_pipe(self) -> int:
+        data_by_sample = dict()
+        for f in self.find_log_files("parse_biosciences/split_pipe_csv", filehandles=True):
+            d_by_sn = self._parse_split_pipe_csv(f["f"])
+            if not d_by_sn:
+                return 0
+            self.add_data_source(f)
+            if any(sn in data_by_sample for sn in d_by_sn):
+                log.debug(f"Duplicate sample names found in {f['fn']}! Overwriting: {', '.join(d_by_sn.keys())}")
+            data_by_sample.update(d_by_sn)
+
+        self.add_section(
+            name="Split pipe",
+            anchor="pb-split-pipe-stats",
+            description="Summary QC metrics from Parse Biosciences Split pipeline",
+            plot=table.plot(data_by_sample, MultiqcModule.CSV_HEADERS, pconfig={"namespace": "Split pipe"}),
+        )
+        self.write_data_file(data_by_sample, "multiqc_bp_split")
+        return len(data_by_sample)
+
+    @staticmethod
+    def _parse_split_pipe_csv(fh) -> Dict[str, Dict[str, Union[float, int]]]:
+        header = next(fh).strip().split(",")
+        if header[0] != "statistic":
+            return {}
+        sample_names = header[1:]
+        data_by_sample = {sn: {} for sn in sample_names}
+        for line in fh:
+            row = line.strip().split(",")
+            metric = row[0]
+            if metric not in MultiqcModule.CSV_HEADERS:
+                continue
+            for si, val in enumerate(row[1:]):
+                try:
+                    val = float(val)
+                except ValueError:
+                    log.debug(f"Could not parse {val} as float on line {line.strip()} in {fh.name}")
+                    continue
+                if MultiqcModule.CSV_HEADERS[metric].get("format") == "{:,d}":
+                    val = int(val)
+                data_by_sample[sample_names[si]][metric] = val
+        return data_by_sample

--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -684,6 +684,10 @@ module_order:
       module_tag:
         - RNA
         - single-cell
+  - parse_biosciences:
+      module_tag:
+        - RNA
+        - single-cell
   - snpsplit:
       module_tag:
         - DNA

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -573,6 +573,10 @@ sourmash/compare:
 sourmash/gather:
   contents: "intersect_bp,f_orig_query,f_match,f_unique_to_query,f_unique_weighted,"
   num_lines: 1
+parse_biosciences/split_pipe_csv:
+  fn: "*.csv"
+  contents: "sample_well_count"
+  num_lines: 2
 pbmarkdup:
   contents_re: "LIBRARY +READS +UNIQUE MOLECULES +DUPLICATE READS"
   num_lines: 5

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,7 @@ setup(
             "odgi = multiqc.modules.odgi:MultiqcModule",
             "optitype = multiqc.modules.optitype:MultiqcModule",
             "pangolin = multiqc.modules.pangolin:MultiqcModule",
+            "parse_biosciences = multiqc.modules.parse_biosciences:MultiqcModule",
             "pbmarkdup = multiqc.modules.pbmarkdup:MultiqcModule",
             "peddy = multiqc.modules.peddy:MultiqcModule",
             "phantompeakqualtools = multiqc.modules.phantompeakqualtools:MultiqcModule",


### PR DESCRIPTION
Addresses https://github.com/ewels/MultiQC/issues/2145

So far, only the CSV is parsed and rendered as a table. 

TODO:
- [ ] Parse CSV and render as table.
- [ ] Parsing HTMLs for identified cells / saturation for transcripts / saturation for genes / heatmaps
- [ ] Parse the log for version.
- [ ] Add general stats?