### PR TITLE
Fix `"square": True` for scatter plot. Make the GATK BaseRecalibrator plot square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Highlights:
 
 - **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
 - **fastp**: correctly parse sample name from --in1/--in2 command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
+- **GATK**: make base recalibrator plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
 - **Kaiju**: fix "division by zero" ([#2179](https://github.com/ewels/MultiQC/pull/2179))
 - **Nanostat**: account for both tab and spaces in v1.41+ search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
 - **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/ewels/MultiQC/pull/2157))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### MultiQC updates
 
+- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
+
 ### New Modules
 
 ### Module updates
 
-- **GATK**: make the BaseRecalibrator plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
+- **GATK**: square the BaseRecalibrator scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
 
 ## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
 

--- a/CSP.txt
+++ b/CSP.txt
@@ -2,6 +2,9 @@
 # (Content Security Policy), you will need the following scripts allowlisted:
 
 script-src 'self'
+    # 1.19
+    'sha256-/C57+E7g4T7gJpkhM4cBNKuHqniEVV8thOcQDOUy640=' # multiqc/templates/default/assets/js/multiqc_plotting.js
+     
     # 1.18
     'sha256-aY1YMeLr1IxkwxjBe0x60QzbuT4u5Mh/QC6brcAN9Do=' # multiqc/templates/default/assets/js/multiqc_tables.js
 

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -182,8 +182,6 @@ class BaseRecalibratorMixin:
                 }
             )
 
-        # Making sure the scatter plot is square:
-        max_val = max([max([max(d["x"], d["y"]) for d in sample_data[0][s]]) for s in sample_data[0]])
         plot = scatter.plot(
             sample_data,
             pconfig={
@@ -195,8 +193,6 @@ class BaseRecalibratorMixin:
                 "data_labels": data_labels,
                 "xmin": 0,
                 "ymin": 0,
-                "xmax": max_val,
-                "ymax": max_val,
                 "square": True,
             },
         )

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -175,12 +175,7 @@ class BaseRecalibratorMixin:
             sample_data.append(reported_empirical)
 
             # Build data label configs for this data type
-            data_labels.append(
-                {
-                    "name": rt_type_name.replace("_", "-").capitalize(),
-                    "ylab": "Empirical quality score",
-                }
-            )
+            data_labels.append({"name": "{} Reported vs. Empirical Quality", "ylab": "Empirical quality score"})
 
         plot = scatter.plot(
             sample_data,

--- a/multiqc/modules/gatk/base_recalibrator.py
+++ b/multiqc/modules/gatk/base_recalibrator.py
@@ -175,7 +175,15 @@ class BaseRecalibratorMixin:
             sample_data.append(reported_empirical)
 
             # Build data label configs for this data type
-            data_labels.append({"name": "{} Reported vs. Empirical Quality", "ylab": "Empirical quality score"})
+            data_labels.append(
+                {
+                    "name": rt_type_name.replace("_", "-").capitalize(),
+                    "ylab": "Empirical quality score",
+                }
+            )
+
+        # Making sure the scatter plot is square:
+        max_val = max([max([max(d["x"], d["y"]) for d in sample_data[0][s]]) for s in sample_data[0]])
         plot = scatter.plot(
             sample_data,
             pconfig={
@@ -185,6 +193,11 @@ class BaseRecalibratorMixin:
                 "ylab": "Empirical quality score",
                 "xDecimals": False,
                 "data_labels": data_labels,
+                "xmin": 0,
+                "ymin": 0,
+                "xmax": max_val,
+                "ymax": max_val,
+                "square": True,
             },
         )
 

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -70,6 +70,18 @@ def plot(data, pconfig=None):
                 d.append(this_series)
         plotdata.append(d)
 
+    if pconfig.get("square"):
+        # Find the max value
+        max_val = 0
+        for d in plotdata:
+            for s in d:
+                max_val = max(max_val, s["x"], s["y"])
+        max_val = 1.02 * max_val  # add 2% padding
+        pconfig["xmax"] = max_val
+        pconfig["ymax"] = max_val
+        # Making sure HighCharts doesn't get creative in adding different paddings
+        pconfig["endOnTick"] = False
+
     # Add on annotation data series
     try:
         if pconfig.get("extra_series"):

--- a/multiqc/templates/default/assets/js/multiqc_plotting.js
+++ b/multiqc/templates/default/assets/js/multiqc_plotting.js
@@ -981,6 +981,7 @@ function plot_scatter_plot(target, ds) {
         allowDecimals: config["xDecimals"],
         plotBands: config["xPlotBands"],
         plotLines: config["xPlotLines"],
+        endOnTick: config["endOnTick"],
       },
       yAxis: {
         title: {
@@ -995,6 +996,7 @@ function plot_scatter_plot(target, ds) {
         allowDecimals: config["yDecimals"],
         plotBands: config["yPlotBands"],
         plotLines: config["yPlotLines"],
+        endOnTick: config["endOnTick"],
       },
       plotOptions: {
         series: {


### PR DESCRIPTION
Fix https://github.com/ewels/MultiQC/issues/2182

- Pass `"square"` to the plot config
- Set `xmin=0` and `ymax=0` .
- Assure `xmax` == `xmin` in the python plotting code.
- Fix the scatter plot plotting code to re-calculate the total max value, pass `endOfTick` and calculate padding manually to make sure HighCharts doesn't get creative with padding