### PR TITLE
`table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/ewels/MultiQC/pull/2191))
+
 ### New Modules
 
 ### Module updates

--- a/docs/core/reports/customisation.md
+++ b/docs/core/reports/customisation.md
@@ -760,6 +760,27 @@ table_columns_visible:
 Note that you can set these values to `True` to show columns that would otherwise be hidden
 by default.
 
+It can also be done for other module-specific tables in the report, where instead of
+the _Group_, you'd need to specify the table ID. To get the table ID, click
+_Configure Columns_ above the table, and look for the first line above the table contents.
+It should say something like "Uncheck the tick box ... Table ID: `quast_table`".
+
+For example, to hide the _# misassemblies_ column in the _Assembly Statistics_ table
+from QUAST, you would use the following config:
+
+```yaml
+table_columns_visible:
+  quast_table:
+    "# misassemblies": false
+```
+
+Or you can pass the column ID directly:
+
+```yaml
+table_columns_visible:
+  "# misassemblies": false
+```
+
 ### Column order
 
 In the same way, you can force a column to appear at the start or end of the table, or
@@ -795,6 +816,9 @@ table_columns_name:
   FastQC:
     percent_gc: "Percent of bases that are GC"
 ```
+
+It will also work for module-specific tables by using the table ID instead of the module name, and specifying the column ID directly.
+See the [Hiding columns](#hiding-columns) section above for more details.
 
 ### Conditional formatting
 

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -254,6 +254,7 @@ class MultiqcModule(BaseMultiqcModule):
         config = {
             "id": "quast_table",
             "min": 0,
+            "namespace": "QUAST",
         }
         return table.plot(self.quast_data, headers, config)
 

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -158,39 +158,43 @@ class DataTable:
 
                 # Overwrite "name" if set in user config
                 # Key can be a column ID, a table ID, or a namespace in the general stats table.
-                for key in config.table_columns_name.keys():
+                for key, val in config.table_columns_name.items():
+                    key = key.lower()
                     # Case-insensitive check if the outer key is a table ID or a namespace.
-                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
+                    if key in [pconfig["id"].lower(), headers[idx][k]["namespace"].lower()] and isinstance(val, dict):
                         # Assume a dict of specific column IDs
-                        headers[idx][k]["title"] = config.table_columns_name[key][k]
+                        for key2, new_title in val.items():
+                            key2 = key2.lower()
+                            if key2 in [k.lower(), headers[idx][k]["title"].lower()]:
+                                headers[idx][k]["title"] = new_title
 
                     # Case-insensitive check if the outer key is a column ID
-                    elif key.lower() == k.lower() or key.lower() == headers[idx][k]["title"].lower():
-                        if isinstance(config.table_columns_visible[key], bool):
-                            headers[idx][k]["title"] = config.table_columns_visible[key]
+                    elif key in [k.lower(), headers[idx][k]["title"].lower()] and isinstance(val, str):
+                        headers[idx][k]["title"] = val
 
                 # Overwrite "hidden" if set in user config
                 # Key can be a column ID, a table ID, or a namespace in the general stats table.
-                for key in config.table_columns_visible.keys():
+                for key, val in config.table_columns_visible.items():
+                    key = key.lower()
                     # Case-insensitive check if the outer key is a table ID or a namespace.
-                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
+                    if key in [pconfig["id"].lower(), headers[idx][k]["namespace"].lower()]:
                         # First - if config value is a bool, set all module columns to that value
-                        if isinstance(config.table_columns_visible[key], bool):
+                        if isinstance(val, bool):
                             # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
-                            headers[idx][k]["hidden"] = not config.table_columns_visible[key]
+                            headers[idx][k]["hidden"] = not val
 
                         # Not a bool, assume a dict of specific column IDs
-                        else:
-                            for col_key, visible in config.table_columns_visible[key].items():
-                                if col_key.lower() == k.lower() or col_key.lower() == headers[idx][k]["title"].lower():
+                        elif isinstance(val, dict):
+                            for key2, visible in val.items():
+                                key2 = key2.lower()
+                                if key2 in [k.lower(), headers[idx][k]["title"].lower()] and isinstance(visible, bool):
                                     # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
                                     headers[idx][k]["hidden"] = not visible
 
                     # Case-insensitive check if the outer key is a column ID
-                    elif key.lower() == k.lower() or key.lower() == headers[idx][k]["title"].lower():
-                        if isinstance(config.table_columns_visible[key], bool):
-                            # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
-                            headers[idx][k]["hidden"] = not config.table_columns_visible[key]
+                    elif key in [k.lower(), headers[idx][k]["title"].lower()] and isinstance(val, bool):
+                        # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
+                        headers[idx][k]["hidden"] = not val
 
                 # Also overwrite placement if set in config
                 try:

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -156,33 +156,41 @@ class DataTable:
                     for cpc_k, cpc_v in config.custom_plot_config[pconfig["id"]].items():
                         headers[idx][k][cpc_k] = cpc_v
 
-                # Overwrite hidden if set in user config
-                for ns in config.table_columns_visible.keys():
-                    # Make namespace key case-insensitive
-                    if ns.lower() == headers[idx][k]["namespace"].lower():
+                # Overwrite "hidden" if set in user config
+                # Key can be a column ID, a table ID, or a namespace in the general stats table.
+                for key in config.table_columns_visible.keys():
+                    # Case-insensitive check if the outer key is a table ID or a namespace.
+                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
                         # First - if config value is a bool, set all module columns to that value
-                        if isinstance(config.table_columns_visible[ns], bool):
-                            headers[idx][k]["hidden"] = not config.table_columns_visible[ns]
+                        if isinstance(config.table_columns_visible[key], bool):
+                            # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
+                            headers[idx][k]["hidden"] = not config.table_columns_visible[key]
 
-                        # Not a bool, assume a dict of the specific column IDs
-                        else:
-                            try:
-                                # Config has True = visibile, False = Hidden. Here we're setting "hidden" which is inverse
-                                headers[idx][k]["hidden"] = not config.table_columns_visible[ns][k]
-                            except KeyError:
-                                pass
+                        # Not a bool, assume a dict of specific column IDs
+                        elif k in config.table_columns_visible[key]:
+                            # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
+                            headers[idx][k]["hidden"] = not config.table_columns_visible[key][k]
 
-                # Overwrite name if set in user config
-                for ns in config.table_columns_name.keys():
-                    # Make namespace key case insensitive
-                    if ns.lower() == headers[idx][k]["namespace"].lower():
-                        # Assume a dict of the specific column IDs
-                        try:
-                            headers[idx][k]["title"] = config.table_columns_name[ns][k]
-                        except KeyError:
-                            pass
+                    # Case-insensitive check if the outer key is a column ID
+                    elif key.lower() == k.lower():
+                        if isinstance(config.table_columns_visible[key], bool):
+                            # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
+                            headers[idx][k]["hidden"] = not config.table_columns_visible[key]
 
-                # Also overwite placement if set in config
+                # Overwrite "name" if set in user config
+                # Key can be a column ID, a table ID, or a namespace in the general stats table.
+                for key in config.table_columns_name.keys():
+                    # Case-insensitive check if the outer key is a table ID or a namespace.
+                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
+                        # Assume a dict of specific column IDs
+                        headers[idx][k]["title"] = config.table_columns_name[key][k]
+
+                    # Case-insensitive check if the outer key is a column ID
+                    elif key.lower() == k.lower():
+                        if isinstance(config.table_columns_visible[key], bool):
+                            headers[idx][k]["title"] = config.table_columns_visible[key]
+
+                # Also overwrite placement if set in config
                 try:
                     headers[idx][k]["placement"] = float(
                         config.table_columns_placement[headers[idx][k]["namespace"]][k]

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -156,6 +156,19 @@ class DataTable:
                     for cpc_k, cpc_v in config.custom_plot_config[pconfig["id"]].items():
                         headers[idx][k][cpc_k] = cpc_v
 
+                # Overwrite "name" if set in user config
+                # Key can be a column ID, a table ID, or a namespace in the general stats table.
+                for key in config.table_columns_name.keys():
+                    # Case-insensitive check if the outer key is a table ID or a namespace.
+                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
+                        # Assume a dict of specific column IDs
+                        headers[idx][k]["title"] = config.table_columns_name[key][k]
+
+                    # Case-insensitive check if the outer key is a column ID
+                    elif key.lower() == k.lower() or key.lower() == headers[idx][k]["title"].lower():
+                        if isinstance(config.table_columns_visible[key], bool):
+                            headers[idx][k]["title"] = config.table_columns_visible[key]
+
                 # Overwrite "hidden" if set in user config
                 # Key can be a column ID, a table ID, or a namespace in the general stats table.
                 for key in config.table_columns_visible.keys():
@@ -167,28 +180,17 @@ class DataTable:
                             headers[idx][k]["hidden"] = not config.table_columns_visible[key]
 
                         # Not a bool, assume a dict of specific column IDs
-                        elif k in config.table_columns_visible[key]:
-                            # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
-                            headers[idx][k]["hidden"] = not config.table_columns_visible[key][k]
+                        else:
+                            for col_key, visible in config.table_columns_visible[key].items():
+                                if col_key.lower() == k.lower() or col_key.lower() == headers[idx][k]["title"].lower():
+                                    # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
+                                    headers[idx][k]["hidden"] = not visible
 
                     # Case-insensitive check if the outer key is a column ID
-                    elif key.lower() == k.lower():
+                    elif key.lower() == k.lower() or key.lower() == headers[idx][k]["title"].lower():
                         if isinstance(config.table_columns_visible[key], bool):
                             # Config has True = visible, False = Hidden. Here we're setting "hidden" which is inverse
                             headers[idx][k]["hidden"] = not config.table_columns_visible[key]
-
-                # Overwrite "name" if set in user config
-                # Key can be a column ID, a table ID, or a namespace in the general stats table.
-                for key in config.table_columns_name.keys():
-                    # Case-insensitive check if the outer key is a table ID or a namespace.
-                    if key.lower() == pconfig["id"].lower() or key.lower() == headers[idx][k]["namespace"].lower():
-                        # Assume a dict of specific column IDs
-                        headers[idx][k]["title"] = config.table_columns_name[key][k]
-
-                    # Case-insensitive check if the outer key is a column ID
-                    elif key.lower() == k.lower():
-                        if isinstance(config.table_columns_visible[key], bool):
-                            headers[idx][k]["title"] = config.table_columns_visible[key]
 
                 # Also overwrite placement if set in config
                 try:


### PR DESCRIPTION
Fix https://github.com/ewels/MultiQC/issues/2190

Using "Group" in `table_columns_visible` and `table_columns_name` only works for the general stats table:

```yaml
table_columns_visible:
  QUAST:
    "# misassemblies": false
```

As we don't normally pass the namespace to `table.plot()` (QUAST was an exception). Refactoring the plotting code and calling the functions through `self.table_plot()` would allow access to the module name in the plotting code, and make it work everywhere. But for now, we cannot rely on the namespace here.

Instead, we can support passing the table ID:

```yaml
table_columns_visible:
  quast_table:
    "# misassemblies": false
```

Or just making it flat  - the IDs should be unique anyway:

```yaml
table_columns_visible:
  "# misassemblies": false
```

Same is done for `table_columns_name`.

I also allowed column titles as keys:

```yaml
table_columns_visible:
  "Misassemblies": false
```

Finally, re-added namespace for QUAST for back-compatibility.