### PR TITLE
Re-add `run()` into the `multiqc` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/ewels/MultiQC/pull/1667))
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
+- Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
 
 ### New Modules
 

--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -13,8 +13,11 @@ Makes the following available under the main multiqc namespace:
 
 import logging
 
+from .multiqc import run
 from .utils import config
 
 config.logger = logging.getLogger(__name__)
 
 __version__ = config.version
+
+__all__ = ["run", "config", "__version__"]


### PR DESCRIPTION
Ruff [suggested](https://github.com/ewels/MultiQC/commit/64f9c63a789aa24cfecb9c826effb5fb6c95ed2c#diff-272bc7573ee7d640f5ae69b4bdf83c95f2d754fe4a615a1787b37f634f8ff1b1L16) removing the `from .multiqc import run` from `multiqc/__init__.py` as an "unused import". 

Adding `__all__ = ["run", "config", "__version__"]` to properly indicate which imports we want to add into this namespace.