### PR TITLE
kraken: fixed column keys in genstats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
+- change header keys in genstats for kraken module ([#2205](https://github.com/ewels/MultiQC/pull/2205))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
-- change header keys in genstats for kraken module ([#2205](https://github.com/ewels/MultiQC/pull/2205))
 
 ### New Modules
 
 ### Module updates
 
 - **GATK**: square the BaseRecalibrator scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
+- **kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
 
 ## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
 

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -283,14 +283,14 @@ class MultiqcModule(BaseMultiqcModule):
         # Column headers
         headers = dict()
 
-        top_one_hkey = None
+        top_one = None
 
         # don't include top-N % in general stats if all is unclassified.
         # unclassified is included separately, so also don't include twice
         if top_rank_code != "U":
-            top_one_hkey = "% {}".format(top_taxa[0])
-            headers[top_one_hkey] = {
-                "title": top_one_hkey,
+            top_one = "% {}".format(top_taxa[0])
+            headers['pct_top_one'] = {
+                "title": top_one,
                 "description": "Percentage of reads that were the top {} over all samples - {}".format(
                     top_rank_name, top_taxa[0]
                 ),
@@ -298,7 +298,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "max": 100,
                 "scale": "PuBuGn",
             }
-            headers["% Top"] = {
+            headers["pct_top_n"] = {
                 "title": f"% Top {self.top_n} {top_rank_name}",
                 "description": f"Percentage of reads that were classified by one of the top-{self.top_n} {top_rank_name} ({', '.join(top_taxa)})",
                 "suffix": "%",
@@ -306,7 +306,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "scale": "PuBu",
             }
 
-        headers["% Unclassified"] = {
+        headers["pct_unclassified"] = {
             "title": "% Unclassified",
             "description": "Percentage of reads that were unclassified",
             "suffix": "%",
@@ -324,14 +324,14 @@ class MultiqcModule(BaseMultiqcModule):
                 except ZeroDivisionError:
                     percent = 0
                 if row["rank_code"] == "U":
-                    tdata[s_name]["% Unclassified"] = percent
+                    tdata[s_name]["pct_unclassified"] = percent
                 if row["rank_code"] == top_rank_code and row["classif"] in top_taxa:
-                    tdata[s_name]["% Top"] = percent + tdata[s_name].get("% Top", 0)
+                    tdata[s_name]["pct_top_n"] = percent + tdata[s_name].get("pct_top_n", 0)
                 if row["rank_code"] == top_rank_code and row["classif"] == top_taxa[0]:
-                    tdata[s_name][top_one_hkey] = percent
+                    tdata[s_name]['pct_top_one'] = percent
 
-            if top_one_hkey is not None and top_one_hkey not in tdata[s_name]:
-                tdata[s_name][top_one_hkey] = 0
+            if top_one is not None and 'pct_top_one' not in tdata[s_name]:
+                tdata[s_name]['pct_top_one'] = 0
 
         self.general_stats_addcols(tdata, headers)
 

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -289,7 +289,7 @@ class MultiqcModule(BaseMultiqcModule):
         # unclassified is included separately, so also don't include twice
         if top_rank_code != "U":
             top_one = "% {}".format(top_taxa[0])
-            headers['pct_top_one'] = {
+            headers["pct_top_one"] = {
                 "title": top_one,
                 "description": "Percentage of reads that were the top {} over all samples - {}".format(
                     top_rank_name, top_taxa[0]
@@ -328,10 +328,10 @@ class MultiqcModule(BaseMultiqcModule):
                 if row["rank_code"] == top_rank_code and row["classif"] in top_taxa:
                     tdata[s_name]["pct_top_n"] = percent + tdata[s_name].get("pct_top_n", 0)
                 if row["rank_code"] == top_rank_code and row["classif"] == top_taxa[0]:
-                    tdata[s_name]['pct_top_one'] = percent
+                    tdata[s_name]["pct_top_one"] = percent
 
-            if top_one is not None and 'pct_top_one' not in tdata[s_name]:
-                tdata[s_name]['pct_top_one'] = 0
+            if top_one is not None and "pct_top_one" not in tdata[s_name]:
+                tdata[s_name]["pct_top_one"] = 0
 
         self.general_stats_addcols(tdata, headers)
 


### PR DESCRIPTION
Change header keys in kraken module as described in Issue #1228. Column headers should not be set dynamically since this makes it impossible to predictably place or disable columns. 

Keys for the two other columns from kraken in genstats are also changed to be more in line with naming conventions for other modules. 

The results for this branch on MultiQC_Testdata/data/modules/kraken yields identical results when compared to ewels/MultiQC/master.


- [x] This comment contains a description of changes (with reason)
