### PR TITLE
Qualimap: BamQC: fix for global-only stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - **GATK**: square the BaseRecalibrator scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
 - **kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
+- **QualiMap**: BamQC: fix for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))
 
 ## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -143,13 +143,12 @@ def parse_genome_results(self, f):
         self.general_stats_data[s_name]["mean_coverage"] = d["mean_coverage"]
         self.general_stats_data[s_name]["regions_size"] = d["regions_size"]
         self.general_stats_data[s_name]["regions_mapped_reads"] = d["regions_mapped_reads"]
-        try:
+        if d["total_reads"] > 0:
             d["percentage_aligned"] = (d["mapped_reads"] / d["total_reads"]) * 100.0
-            self.general_stats_data[s_name]["percentage_aligned"] = d["percentage_aligned"]
+        self.general_stats_data[s_name]["percentage_aligned"] = d["percentage_aligned"]
+        if d["mapped_reads"] > 0:
             d["percentage_aligned_on_target"] = (d["regions_mapped_reads"] / d["mapped_reads"]) * 100.0
-            self.general_stats_data[s_name]["percentage_aligned_on_target"] = d["percentage_aligned_on_target"]
-        except ZeroDivisionError:
-            pass
+        self.general_stats_data[s_name]["percentage_aligned_on_target"] = d["percentage_aligned_on_target"]
     except KeyError:
         pass
 

--- a/multiqc/modules/qualimap/QM_BamQC.py
+++ b/multiqc/modules/qualimap/QM_BamQC.py
@@ -135,22 +135,26 @@ def parse_genome_results(self, f):
     # Get a nice sample name
     s_name = self.clean_s_name(d["bam_file"], f)
 
+    if "general_error_rate" in d:
+        d["general_error_rate"] = d["general_error_rate"] * 100.0
+    if "mapped_reads" in d and "total_reads" in d and d["total_reads"] > 0:
+        d["percentage_aligned"] = (d["mapped_reads"] / d["total_reads"]) * 100.0
+    if "regions_mapped_reads" in d and "mapped_reads" in d and d["mapped_reads"] > 0:
+        d["percentage_aligned_on_target"] = (d["regions_mapped_reads"] / d["mapped_reads"]) * 100.0
+
     # Add to general stats table & calculate a nice % aligned
-    try:
-        self.general_stats_data[s_name]["total_reads"] = d["total_reads"]
-        self.general_stats_data[s_name]["mapped_reads"] = d["mapped_reads"]
-        self.general_stats_data[s_name]["general_error_rate"] = d["general_error_rate"] * 100.0
-        self.general_stats_data[s_name]["mean_coverage"] = d["mean_coverage"]
-        self.general_stats_data[s_name]["regions_size"] = d["regions_size"]
-        self.general_stats_data[s_name]["regions_mapped_reads"] = d["regions_mapped_reads"]
-        if d["total_reads"] > 0:
-            d["percentage_aligned"] = (d["mapped_reads"] / d["total_reads"]) * 100.0
-        self.general_stats_data[s_name]["percentage_aligned"] = d["percentage_aligned"]
-        if d["mapped_reads"] > 0:
-            d["percentage_aligned_on_target"] = (d["regions_mapped_reads"] / d["mapped_reads"]) * 100.0
-        self.general_stats_data[s_name]["percentage_aligned_on_target"] = d["percentage_aligned_on_target"]
-    except KeyError:
-        pass
+    for k in [
+        "total_reads",
+        "mapped_reads",
+        "general_error_rate",
+        "mean_coverage",
+        "regions_size",
+        "regions_mapped_reads",
+        "percentage_aligned",
+        "percentage_aligned_on_target",
+    ]:
+        if k in d:
+            self.general_stats_data[s_name][k] = d[k]
 
     # Save results
     if s_name in self.qualimap_bamqc_genome_results:


### PR DESCRIPTION
Make sure that all columns are present when input is global-only (no `Globals inside` section with `regions_size` and `regions_mapped_reads` is available). Remove the broad try-except and be more granular in metric parsing.

Fixes https://github.com/ewels/MultiQC/issues/2199