### PR TITLE
Custom content plot: do not assume first row are samples

### DIFF
--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -60,6 +60,9 @@ def _find_module_info(py_path: Path) -> dict[str]:
     initialization. But that's actually alright: we avoid installing and importing
     MultiQC and the action runs faster.
     """
+    if py_path.name == "custom_content.py":
+        return {"name": "Custom content", "anchor": "custom-content", "url": "", "info": ""}
+
     with py_path.open("r") as f:
         contents = f.read()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
+- Custom content plot: do not assume first row are samples ([#2208](https://github.com/ewels/MultiQC/pull/2208))
 
 ### New Modules
 

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -528,11 +528,10 @@ def _parse_txt(f, conf):
     first_row_str = 0
     for i, line in enumerate(d):
         for j, v in enumerate(line):
-            if j != 0:  # we don't want to convert sample names to numbers
-                try:
-                    v = float(v)
-                except ValueError:
-                    pass
+            try:
+                v = float(v)
+            except ValueError:
+                pass
             if isinstance(v, str):
                 if (v.startswith('"') and v.endswith('"')) or (v.startswith("'") and v.endswith("'")):
                     v = v[1:-1]

--- a/multiqc/modules/custom_content/custom_content.py
+++ b/multiqc/modules/custom_content/custom_content.py
@@ -361,7 +361,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Bar plot
         elif mod["config"].get("plot_type") == "bargraph":
-            mod["data"] = {k: v for k, v in sorted(mod["data"].items())}
+            mod["data"] = {str(k): v for k, v in mod["data"].items()}
             plot = bargraph.plot(mod["data"], mod["config"].get("categories"), pconfig)
 
         # Line plot


### PR DESCRIPTION
Fix: https://github.com/ewels/MultiQC/issues/2200

There as a previous fix custom contents bar plot, and it may have contained categories with numeric names. That fix for it worked, but using a wrong assumption that the first row would contain sample names. As a side effect, 2-column TSVs started to be interpreted as bar plots, instead of line plots as before (thus the issue above).

Reverting that change, and instead for explicit bar plots with numerical categories, converting numeric categories back to strings as a proper fix for the previous issue.

In any case, a better approach would be to require the `plot_type` to be specified in all ambiguous situations.