### PR TITLE
Add `.cram` to sample name cleaning defaults

### DIFF
--- a/multiqc/utils/config_defaults.yaml
+++ b/multiqc/utils/config_defaults.yaml
@@ -161,6 +161,7 @@ fn_clean_exts:
   - ".fastq"
   - ".fq"
   - ".bam"
+  - ".cram"
   - ".sam"
   - ".sra"
   - ".vcf"


### PR DESCRIPTION
We're already cleaning `.bam` and `.sam`, so should probably also be cleaning `.cram`.