### PR TITLE
When trying indexing lists/dicts while accessing config parameters, catch TypeError as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
+- When trying indexing lists/dicts while accessing config parameters, catch TypeError as well ([#2211](https://github.com/ewels/MultiQC/pull/2211))
 
 ### New Modules
 

--- a/multiqc/plots/boxplot.py
+++ b/multiqc/plots/boxplot.py
@@ -97,7 +97,7 @@ def matplotlib_boxplot(plotdata, pconfig=None):
     for k in range(len(plotdata)):
         try:
             name = pconfig["data_labels"][k]["name"]
-        except (KeyError, IndexError):
+        except Exception:
             name = k + 1
         pid = "mqc_{}_{}".format(pconfig["id"], name)
         pid = report.save_htmlid(pid, skiplint=True)
@@ -118,7 +118,7 @@ def matplotlib_boxplot(plotdata, pconfig=None):
             active = "active" if k == 0 else ""
             try:
                 name = pconfig["data_labels"][k]["name"]
-            except (KeyError, IndexError):
+            except Exception:
                 name = k + 1
             html += '<button class="btn btn-default btn-sm {a}" data-target="#{pid}">{n}</button>\n'.format(
                 a=active, pid=pid, n=name
@@ -161,7 +161,7 @@ def matplotlib_boxplot(plotdata, pconfig=None):
         # Dataset specific ymax
         try:
             axes.set_ylim((ymin, pconfig["data_labels"][pidx]["ymax"]))
-        except (KeyError, IndexError):
+        except Exception:
             pass
 
         default_xlimits = axes.get_xlim()

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -106,12 +106,12 @@ def plot(data, pconfig=None):
     if pconfig.get("ylab") is None:
         try:
             pconfig["ylab"] = pconfig["data_labels"][0]["ylab"]
-        except (KeyError, IndexError):
+        except Exception:
             pass
     if pconfig.get("xlab") is None:
         try:
             pconfig["xlab"] = pconfig["data_labels"][0]["xlab"]
-        except (KeyError, IndexError):
+        except Exception:
             pass
 
     # Generate the data dict structure expected by HighCharts series
@@ -209,7 +209,7 @@ def plot(data, pconfig=None):
             for i, es in enumerate(extra_series):
                 for s in es:
                     plotdata[i].append(s)
-    except (KeyError, IndexError):
+    except Exception:
         pass
 
     # Add colors to the categories if not set. Since the "plot_defaults" scale is
@@ -403,7 +403,7 @@ def matplotlib_linegraph(plotdata, pconfig=None):
                     else:
                         try:
                             fdata[d["name"]][pconfig["categories"][i]] = x
-                        except (KeyError, IndexError):
+                        except Exception:
                             fdata[d["name"]][str(i)] = x
 
             # Custom tsv output if the x-axis varies

--- a/multiqc/plots/scatter.py
+++ b/multiqc/plots/scatter.py
@@ -93,7 +93,7 @@ def plot(data, pconfig=None):
             for i, es in enumerate(extra_series):
                 for s in es:
                     plotdata[i].append(s)
-    except (KeyError, IndexError):
+    except Exception:
         pass
 
     # Make a plot
@@ -125,19 +125,19 @@ def highcharts_scatter_plot(plotdata, pconfig=None):
             active = "active" if k == 0 else ""
             try:
                 name = pconfig["data_labels"][k]["name"]
-            except (IndexError, KeyError):
+            except Exception:
                 name = k + 1
             try:
                 ylab = 'data-ylab="{}"'.format(pconfig["data_labels"][k]["ylab"])
-            except (IndexError, KeyError):
+            except Exception:
                 ylab = 'data-ylab="{}"'.format(name) if name != k + 1 else ""
             try:
                 ymax = 'data-ymax="{}"'.format(pconfig["data_labels"][k]["ymax"])
-            except (IndexError, KeyError):
+            except Exception:
                 ymax = ""
             try:
                 xlab = 'data-xlab="{}"'.format(pconfig["data_labels"][k]["xlab"])
-            except (IndexError, KeyError):
+            except Exception:
                 xlab = 'data-xlab="{}"'.format(name) if name != k + 1 else ""
             html += '<button class="btn btn-default btn-sm {a}" data-action="set_data" {y} {ym} {xl} data-newdata="{k}" data-target="{id}">{n}</button>\n'.format(
                 a=active, id=pconfig["id"], n=name, y=ylab, ym=ymax, xl=xlab, k=k


### PR DESCRIPTION
Fix artefact of Ruff refactoring. Previously used bare `except:` also handled `TypeError` which happens when a scalar type is attempted to be indexed. Ruff asked to remove base `except:` because it's too broad. But it's okay with `except Exception:`, which covers `TypeError`.

```py
try:
    fdata[d["name"]][pconfig["categories"][i]] = x
except Exception:
    fdata[d["name"]][str(i)] = x
```
Ideally we don't want to use `except Exception:` either, and instead explicitly statically type the config, and add proper checks instead of wrapping in try-catch, but that's for futher refactoring.