### PR TITLE
Fix running `--no-report`

### DIFF
--- a/.github/workflows/multiqc.yml
+++ b/.github/workflows/multiqc.yml
@@ -123,6 +123,16 @@ jobs:
           cd test_data
           multiqc -m star -o tests/multiqc_report_dev -t default_dev -k json --file-list data/special_cases/file_list.txt
 
+      - name: No report
+        if: matrix.python-version == env.latest_python
+        run: |
+          cd test_data
+          multiqc -m star test_data/data/modules/star --no-report -n no-report
+          if [[ -f no-report.html ]]; then
+            echo "Running with the --no-report flag should not produce an HTML" >&2
+            exit 1
+          fi
+
       - name: Empty directory (confirm no report)
         if: matrix.python-version == env.latest_python
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
 - BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
+- Fix running `--no-report` ([#2212](https://github.com/ewels/MultiQC/pull/2212))
 
 ### New Modules
 

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -1061,7 +1061,8 @@ def run(
             )
             shutil.rmtree(config.data_tmp_dir)
 
-        logger.debug("Full report path: {}".format(os.path.realpath(config.output_fn)))
+        if config.output_fn is not None:
+            logger.debug(f"Full report path: {os.path.realpath(config.output_fn)}")
 
         # Copy across the static plot images if requested
         if config.export_plots:


### PR DESCRIPTION
Fixes the bug introduced with adding a "full path to the HTML" debug message.

Fixes https://github.com/ewels/MultiQC/issues/2198