### PR TITLE
Add missing table `id` in DRAGEN modules, require them in linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fastp: search pattern: look at content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
 - Bar graphs: add `sort_samples: false` config option, also do not sort `OrderedDict` data ([#2210](https://github.com/ewels/MultiQC/pull/2210))
 - Refactor: replace `.format()` calls with f-strings ([#2224](https://github.com/ewels/MultiQC/pull/2224))
+- Add missing table `id` in DRAGEN modules, require them in linting ([#2228](https://github.com/ewels/MultiQC/pull/2228))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bar graphs: add `sort_samples: false` config option, also do not sort `OrderedDict` data ([#2210](https://github.com/ewels/MultiQC/pull/2210))
 - Refactor: replace `.format()` calls with f-strings ([#2224](https://github.com/ewels/MultiQC/pull/2224))
 - GATK MarkDuplicates: more search patterns ([#2226](https://github.com/ewels/MultiQC/pull/2226))
+- Add missing table `id` in DRAGEN modules, require them in linting ([#2228](https://github.com/ewels/MultiQC/pull/2228))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,23 @@
 - Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/ewels/MultiQC/pull/1666))
 - Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/ewels/MultiQC/pull/1667))
 - Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
+- BCLConvert: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - Re-add `run()` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
 - When trying indexing lists/dicts while accessing config parameters, catch TypeError as well ([#2211](https://github.com/ewels/MultiQC/pull/2211))
 - Fix running `--no-report` ([#2212](https://github.com/ewels/MultiQC/pull/2212))
 - Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/ewels/MultiQC/pull/2209))
 - Custom content plot: do not assume first row are samples ([#2208](https://github.com/ewels/MultiQC/pull/2208))
+- Fastp: search pattern: look at content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
 - Bar graphs: add `sort_samples: false` config option, also do not sort `OrderedDict` data ([#2210](https://github.com/ewels/MultiQC/pull/2210))
 - Refactor: replace `.format()` calls with f-strings ([#2224](https://github.com/ewels/MultiQC/pull/2224))
+- GATK MarkDuplicates: more search patterns ([#2226](https://github.com/ewels/MultiQC/pull/2226))
 
 ### New Modules
 
 ### Module updates
 
-- **BCLConvert**: fix mean quality, fix count-per-lane barplot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
 - **deepTools**: Handle missing data in plotProfile ([#2229](https://github.com/ewels/MultiQC/pull/2229))
-- **DRAGEN**: Add missing table `id` in DRAGEN modules, require them in linting ([#2228](https://github.com/ewels/MultiQC/pull/2228))
-- **Fastp**: search pattern: look at content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
 - **GATK**: square the BaseRecalibrator scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
-- **GATK**: MarkDuplicates - more search patterns ([#2226](https://github.com/ewels/MultiQC/pull/2226))
 - **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/ewels/MultiQC/pull/2230))
 - **kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
 - **QualiMap**: BamQC: fix for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))

--- a/multiqc/modules/bamtools/stats.py
+++ b/multiqc/modules/bamtools/stats.py
@@ -106,7 +106,11 @@ def parse_reports(self):
     keys["bt_read_2"] = dict(num_defaults, **{"title": "Read 2", "description": "Read 2 (millions)"})
     keys["singletons_pct"] = dict(defaults, **{"title": "Singletons"})
 
-    self.add_section(name="Bamtools Stats", anchor="bamtools-stats", plot=beeswarm.plot(self.bamtools_stats_data, keys))
+    self.add_section(
+        name="Bamtools Stats",
+        anchor="bamtools-stats",
+        plot=beeswarm.plot(self.bamtools_stats_data, keys, pconfig={"id": "bamtools-stats-plot"}),
+    )
 
     # Return number of samples found
     return len(self.bamtools_stats_data)

--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -229,7 +229,14 @@ class StatsReportMixin:
                 self.add_section(
                     name="Bcftools Stats",
                     anchor="bcftools-stats_stats",
-                    plot=table.plot(self.bcftools_stats, stats_headers, {"namespace": "Stats"}),
+                    plot=table.plot(
+                        self.bcftools_stats,
+                        stats_headers,
+                        {
+                            "namespace": "Stats",
+                            "id": "bcftools-stats-table",
+                        },
+                    ),
                 )
 
             # Make bargraph plot of substitution types

--- a/multiqc/modules/cellranger/count.py
+++ b/multiqc/modules/cellranger/count.py
@@ -102,14 +102,28 @@ class CellRangerCountMixin:
                 name="Count - Warnings",
                 anchor="cellranger-count-warnings",
                 description="Warnings encountered during the analysis",
-                plot=table.plot(self.cellrangercount_warnings, self.count_warnings_headers, {"namespace": "Count"}),
+                plot=table.plot(
+                    self.cellrangercount_warnings,
+                    self.count_warnings_headers,
+                    {
+                        "namespace": "Count",
+                        "id": "cellranger-count-warnings-table",
+                    },
+                ),
             )
 
         self.add_section(
             name="Count - Summary stats",
             anchor="cellranger-count-stats",
             description="Summary QC metrics from Cell Ranger count",
-            plot=table.plot(self.cellrangercount_data, self.count_data_headers, {"namespace": "Count"}),
+            plot=table.plot(
+                self.cellrangercount_data,
+                self.count_data_headers,
+                {
+                    "namespace": "Count",
+                    "id": "cellranger-count-stats-table",
+                },
+            ),
         )
 
         self.add_section(
@@ -148,7 +162,12 @@ class CellRangerCountMixin:
                 anchor="cellranger-antibody-stats",
                 description="Summary QC metrics from Cell Ranger count",
                 plot=table.plot(
-                    self.cellrangercount_antibody_data, self.antibody_data_headers, {"namespace": "Antibody"}
+                    self.cellrangercount_antibody_data,
+                    self.antibody_data_headers,
+                    {
+                        "namespace": "Antibody",
+                        "id": "cellranger-antibody-stats-table",
+                    },
                 ),
             )
 

--- a/multiqc/modules/cellranger/vdj.py
+++ b/multiqc/modules/cellranger/vdj.py
@@ -110,21 +110,42 @@ class CellRangerVdjMixin:
                     name="VDJ - Warnings",
                     anchor="cellranger-vdj-warnings",
                     description="Warnings encountered during the analysis",
-                    plot=table.plot(self.cellrangervdj_warnings, self.vdj_warnings_headers, {"namespace": "VDJ"}),
+                    plot=table.plot(
+                        self.cellrangervdj_warnings,
+                        self.vdj_warnings_headers,
+                        {
+                            "namespace": "VDJ",
+                            "id": "cellranger-vdj-warnings-table",
+                        },
+                    ),
                 )
 
             self.add_section(
                 name="VDJ - Summary stats",
                 anchor="cellranger-vdj-stats",
                 description="Summary QC metrics from Cell Ranger count",
-                plot=table.plot(self.cellrangervdj_mapping, self.vdj_mapping_headers, {"namespace": "VDJ"}),
+                plot=table.plot(
+                    self.cellrangervdj_mapping,
+                    self.vdj_mapping_headers,
+                    {
+                        "namespace": "VDJ",
+                        "id": "cellranger-vdj-stats-table",
+                    },
+                ),
             )
 
             self.add_section(
                 name="VDJ - Annotations",
                 anchor="cellranger-vdj-annot",
                 description="V(D)J annotations from Cell Ranger VDJ analysis",
-                plot=table.plot(self.cellrangervdj_annotations, self.vdj_annotations_headers, {"namespace": "VDJ"}),
+                plot=table.plot(
+                    self.cellrangervdj_annotations,
+                    self.vdj_annotations_headers,
+                    {
+                        "namespace": "VDJ",
+                        "id": "cellranger-vdj-annot-table",
+                    },
+                ),
             )
 
             self.add_section(

--- a/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
+++ b/multiqc/modules/deeptools/bamPEFragmentSizeTable.py
@@ -86,7 +86,10 @@ class bamPEFragmentSizeTableMixin:
                 "shared_key": "read_length",
             },
         }
-        config = {"namespace": "deepTools bamPEFragmentSize"}
+        config = {
+            "namespace": "deepTools bamPEFragmentSize",
+            "id": "deeptools_readlengths_table",
+        }
         self.add_section(
             name="Read length metrics",
             anchor="deeptools_readlengths",
@@ -154,6 +157,10 @@ class bamPEFragmentSizeTableMixin:
                 PE = True
                 break
         if PE:
+            config = {
+                "namespace": "deepTools bamPEFragmentSize",
+                "id": "deeptools_fragmentlengths_table",
+            }
             self.add_section(
                 name="Fragment length metrics",
                 anchor="deeptools_fragmentlengths",

--- a/multiqc/modules/deeptools/estimateReadFiltering.py
+++ b/multiqc/modules/deeptools/estimateReadFiltering.py
@@ -124,7 +124,10 @@ class EstimateReadFilteringMixin:
                 "pct_Strand_Filtered": 100.0 * v["strand"] / float(v["total"]),
             }
 
-        config = {"namespace": "deepTools bamPEFragmentSize"}
+        config = {
+            "namespace": "deepTools bamPEFragmentSize",
+            "id": "deeptools_estimate_read_filtering_table",
+        }
         self.add_section(
             name="Filtering metrics",
             anchor="estimateReadFiltering",

--- a/multiqc/modules/deeptools/plotCoverage.py
+++ b/multiqc/modules/deeptools/plotCoverage.py
@@ -72,7 +72,10 @@ class plotCoverageMixin:
                     "shared_key": "coverage",
                 },
             }
-            config = {"namespace": "deepTools plotCoverage"}
+            config = {
+                "namespace": "deepTools plotCoverage",
+                "id": "deeptools_coverage_metrics_table",
+            }
             self.add_section(
                 name="Coverage metrics",
                 anchor="deeptools_coverage_metrics",

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -902,7 +902,7 @@ def create_table_handlers():
                     + "\n\nPress the `Help` button for details."
                 )
                 anchor = "dragen-cov-metrics-own-section-" + re.sub(r"(\s|-|\.|_)+", "-", phenotype)
-                plots[phenotype]["config"]["id"] = anchor + "-table"
+                plots[phenotype]["config"]["id"] = f"{anchor}-table"
                 sections.append(
                     {
                         "name": make_section_name(phenotype),

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -603,7 +603,7 @@ def make_data_for_txt_reports(coverage_data, metrics):
     for sample in coverage_data:
         for phenotype in coverage_data[sample]:
             # Replace any sequence of spaces/hyphens/dots/underscores by single underscore.
-            new_phenotype = re.sub("(\s|-|\.|_)+", "_", phenotype)
+            new_phenotype = re.sub(r"(\s|-|\.|_)+", "_", phenotype)
             # Transform phenotype as in the previous code version.
             if new_phenotype == "wgs":
                 new_phenotype += "_cov_metrics"
@@ -731,9 +731,9 @@ def create_table_handlers():
     * make_own_coverage_sections"""
 
     # Regexes for the well-known standard phenotypes.
-    RGX_WGS_PHENOTYPE = re.compile("^wgs$", re.IGNORECASE)
-    RGX_QC_PHENOTYPE = re.compile("^qc-coverage-region-(?P<number>\d+)$", re.IGNORECASE)
-    RGX_BED_PHENOTYPE = re.compile("^target_bed$", re.IGNORECASE)
+    RGX_WGS_PHENOTYPE = re.compile(r"^wgs$", re.IGNORECASE)
+    RGX_QC_PHENOTYPE = re.compile(r"^qc-coverage-region-(?P<number>\d+)$", re.IGNORECASE)
+    RGX_BED_PHENOTYPE = re.compile(r"^target_bed$", re.IGNORECASE)
 
     def improve_gen_phenotype(phenotype):
         """Improve phenotype's appearance for columns' titles in the general table."""
@@ -776,7 +776,7 @@ def create_table_handlers():
                         # PCT of region with coverage [10x: 50x]
                         # will both reference the same HTML ID.
                         # Irrelevant in this module, but may not in general.
-                        m_id = re.sub("(\s|-|\.|_)+", " ", phenotype + "_" + metric)
+                        m_id = re.sub(r"(\s|-|\.|_)+", " ", phenotype + "_" + metric)
                         gen_data[sample][m_id] = data[metric]
                         gen_headers[m_id] = coverage_headers[_metric].copy()
                         """
@@ -813,7 +813,7 @@ def create_table_handlers():
             return "Target Bed Coverage Metrics"
 
         # Try to make it better looking a little bit.
-        phenotype = re.sub("(\s|-|\.|_)+", " ", phenotype).strip()
+        phenotype = re.sub(r"(\s|-|\.|_)+", " ", phenotype).strip()
         phenotype = phenotype[0].capitalize() + phenotype[1:]
         return phenotype + " Coverage Metrics"
 
@@ -852,7 +852,7 @@ def create_table_handlers():
                         if metric + region in coverage_headers:
                             _metric += region
                     if not ("exclude_own" in coverage_headers[_metric] and coverage_headers[_metric]["exclude_own"]):
-                        m_id = re.sub("(\s|-|\.|_)+", " ", phenotype + "_" + metric)
+                        m_id = re.sub(r"(\s|-|\.|_)+", " ", phenotype + "_" + metric)
                         data[sample][m_id] = real_data[metric]
                         headers[m_id] = coverage_headers[_metric].copy()
 
@@ -901,10 +901,12 @@ def create_table_handlers():
                     + bed_texts[phenotype]["description"]
                     + "\n\nPress the `Help` button for details."
                 )
+                anchor = "dragen-cov-metrics-own-section-" + re.sub(r"(\s|-|\.|_)+", "-", phenotype)
+                plots[phenotype]["config"]["id"] = anchor + "-table"
                 sections.append(
                     {
                         "name": make_section_name(phenotype),
-                        "anchor": "dragen-cov-metrics-own-section-" + re.sub("(\s|-|\.|_)+", "-", phenotype),
+                        "anchor": anchor,
                         "helptext": helptext + bed_texts[phenotype]["helptext"],
                         "description": description,
                         "plot": table.plot(
@@ -980,7 +982,7 @@ def construct_coverage_parser():
 
     def make_consistent_metric(metric):
         """Tries to fix consistency issues that may arise in coverage metrics data."""
-        metric = re.sub("\s+", " ", metric).strip()
+        metric = re.sub(r"\s+", " ", metric).strip()
 
         pct_case = PCT_RGX.search(metric)
         if pct_case:
@@ -1002,8 +1004,8 @@ def construct_coverage_parser():
         else:
             return suffix
 
-    FILE_RGX = re.compile("(.+)\.(.+)_coverage_metrics(.*)\.csv$")
-    LINE_RGX = re.compile("^COVERAGE SUMMARY,,([^,]+),([^,]+),?([^,]*)$")
+    FILE_RGX = re.compile(r"(.+)\.(.+)_coverage_metrics(.*)\.csv$")
+    LINE_RGX = re.compile(r"^COVERAGE SUMMARY,,([^,]+),([^,]+),?([^,]*)$")
 
     def coverage_metrics_parser(file_handler):
         """Parser for coverage metrics csv files.
@@ -1065,7 +1067,7 @@ def construct_coverage_parser():
 
             # Otherwise check if line is empty. If not then report it. Go to the next line.
             else:
-                if not re.search("^\s*$", line):
+                if not re.search(r"^\s*$", line):
                     log_data["invalid_file_lines"][root][file].append(line)
                 continue
 
@@ -1086,7 +1088,7 @@ def construct_coverage_parser():
                 try:
                     value1 = float(value1)
                 except ValueError:
-                    if not re.search("^NA$", value1.strip(), re.IGNORECASE):
+                    if not re.search(r"^NA$", value1.strip(), re.IGNORECASE):
                         log_data["unusual_values"][root][file][metric] = value1
 
             data[consistent_metric_id] = value1
@@ -1098,7 +1100,7 @@ def construct_coverage_parser():
                     try:
                         value2 = int(value2)
                     except ValueError:
-                        if not re.search("^NA$", value2.strip(), re.IGNORECASE):
+                        if not re.search(r"^NA$", value2.strip(), re.IGNORECASE):
                             log_data["unusual_values"][root][file][metric + " (second value)"] = value2
 
                 data[consistent_metric_id + V2] = value2
@@ -1126,34 +1128,34 @@ def create_coverage_headers_handler():
     # All regexes are constructed to be as general and simple as possible to speed up the matching.
     # "make_configs" will point later to a function, which automatically sets some header's configs.
     R_B_PAT = {
-        "RGX": re.compile("^Aligned (?P<entity>reads|bases)$", re.IGNORECASE),
+        "RGX": re.compile(r"^Aligned (?P<entity>reads|bases)$", re.IGNORECASE),
         "make_configs": None,
     }
     ALN_PAT = {
-        "RGX": re.compile("^Aligned (?P<entity>.+?) in (?P<region>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"^Aligned (?P<entity>.+?) in (?P<region>.+)", re.IGNORECASE),
         "make_configs": None,
     }
     AVG_PAT = {
-        "RGX": re.compile("^Average (?P<entity>.+?) coverage over (?P<region>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"^Average (?P<entity>.+?) coverage over (?P<region>.+)", re.IGNORECASE),
         "make_configs": None,
     }
     PCT_PAT = {
-        "RGX": re.compile("^PCT of (?P<region>.+?) with coverage (?P<entity>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"^PCT of (?P<region>.+?) with coverage (?P<entity>.+)", re.IGNORECASE),
         "make_configs": None,
     }
     UNI_PAT = {
-        "RGX": re.compile("^Uniformity of coverage (?P<entity>.+?) over (?P<region>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"^Uniformity of coverage (?P<entity>.+?) over (?P<region>.+)", re.IGNORECASE),
         "make_configs": None,
     }
     MED_PAT = {
-        "RGX": re.compile("^Median (?P<entity>.+?) coverage over (?P<region>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"^Median (?P<entity>.+?) coverage over (?P<region>.+)", re.IGNORECASE),
         "make_configs": None,
     }
     RAT_PAT = {
-        "RGX": re.compile("(?P<entity>.+?) ratio over (?P<region>.+)", re.IGNORECASE),
+        "RGX": re.compile(r"(?P<entity>.+?) ratio over (?P<region>.+)", re.IGNORECASE),
         "make_configs": None,
     }
-    ANY_PAT = {"RGX": re.compile(".+"), "make_configs": None}
+    ANY_PAT = {"RGX": re.compile(r".+"), "make_configs": None}
 
     # The order is based on the structure of regexes and amount of patterns found in examined data.
     METRIC_PATTERNS_FOR_REGIONS = [PCT_PAT, AVG_PAT, ALN_PAT, UNI_PAT, MED_PAT, RAT_PAT]
@@ -1250,10 +1252,10 @@ def create_coverage_headers_handler():
         pct_case = PCT_PAT["RGX"].search(metric)
         uni_case = UNI_PAT["RGX"].search(metric)
         if pct_case:
-            metric = re.sub("\[\d+x:", "[ix:", metric)
-            metric = re.sub(":\d+x\)", ":jx)", metric)
+            metric = re.sub(r"\[\d+x:", "[ix:", metric)
+            metric = re.sub(r":\d+x\)", ":jx)", metric)
         if uni_case:
-            metric = re.sub("\d+", "d", metric)
+            metric = re.sub(r"\d+", "d", metric)
 
         # Now set region-specific parameters for the given metric.
         if metric in METRICS:
@@ -1265,7 +1267,7 @@ def create_coverage_headers_handler():
 
             # Try to set (ix:inf)/(ix:jx)-specific settings.
             if pct_case:
-                ix_jx_match = re.search("\[(\d+x):(inf|\d+x)\)", pct_case["entity"])
+                ix_jx_match = re.search(r"\[(\d+x):(inf|\d+x)\)", pct_case["entity"])
                 if ix_jx_match:
                     ix_jx = (ix_jx_match.group(1), ix_jx_match.group(2))
                     if ix_jx in _configs["extra"]:
@@ -1276,7 +1278,7 @@ def create_coverage_headers_handler():
 
             # Try to match the float and set specific configs.
             if uni_case:
-                float_match = re.search("\(pct > (\d+\.\d+)\*mean\)", uni_case["entity"])
+                float_match = re.search(r"\(pct > (\d+\.\d+)\*mean\)", uni_case["entity"])
                 if float_match:
                     _float = float_match.group(1)
                     if _float in _configs["extra"]:
@@ -1555,7 +1557,7 @@ def create_coverage_headers_handler():
 
     # Special regex to match (PCT > d.d*mean) substring.
     # Placed here because it may be used more than once.
-    RGX_FLOAT = re.compile("\(pct\s*>\s*(\d+\.\d+)\*mean\)")
+    RGX_FLOAT = re.compile(r"\(pct\s*>\s*(\d+\.\d+)\*mean\)")
 
     def get_Uniformity_configs(metric_pattern_match):
         """The following metrics are supported:
@@ -1603,7 +1605,7 @@ def create_coverage_headers_handler():
 
     # Special regex to match the [ix, inf) and [ix, jx)
     # Placed here because it will be used more than once.
-    IX_JX = re.compile("\[(\d+)x:(inf|\d+x)\)")
+    IX_JX = re.compile(r"\[(\d+)x:(inf|\d+x)\)")
 
     def get_PCT_configs(metric_pattern_match):
         """The following metrics are supported:

--- a/multiqc/modules/dragen/dragen_gc_metrics.py
+++ b/multiqc/modules/dragen/dragen_gc_metrics.py
@@ -69,7 +69,13 @@ class DragenGcMetrics(BaseMultiqcModule):
             description="""
             Summary GC metrics shown on the sample level.
             """,
-            plot=table.plot(table_data, pconfig={"namespace": DragenGcMetrics.NAMESPACE}),
+            plot=table.plot(
+                table_data,
+                pconfig={
+                    "id": "dragen-gc-metrics-summary-table",
+                    "namespace": DragenGcMetrics.NAMESPACE,
+                },
+            ),
         )
 
         return data_by_sample.keys()

--- a/multiqc/modules/dragen/mapping_metrics.py
+++ b/multiqc/modules/dragen/mapping_metrics.py
@@ -109,7 +109,14 @@ class DragenMappingMetics(BaseMultiqcModule):
             Shown on per read group level. To see per-sample level metrics, refer to the general
             stats table.
             """,
-            plot=table.plot(data_by_rg, own_tabl_headers, pconfig={"namespace": NAMESPACE}),
+            plot=table.plot(
+                data_by_rg,
+                own_tabl_headers,
+                pconfig={
+                    "id": "dragen-mapping-metrics-table",
+                    "namespace": NAMESPACE,
+                },
+            ),
         )
 
         # Skip adding the barplot if it's not informative, such as if all

--- a/multiqc/modules/dragen/sc_atac_metrics.py
+++ b/multiqc/modules/dragen/sc_atac_metrics.py
@@ -69,6 +69,10 @@ class DragenScAtacMetrics(BaseMultiqcModule):
                     for sample_name, metric in data_by_sample.items()
                 },
                 table_headers,
+                pconfig={
+                    "namespace": "Single-Cell ATAC Metrics",
+                    "id": "dragen-sc-atac-metrics-table",
+                },
             ),
         )
 

--- a/multiqc/modules/dragen/sc_rna_metrics.py
+++ b/multiqc/modules/dragen/sc_rna_metrics.py
@@ -70,6 +70,10 @@ class DragenScRnaMetrics(BaseMultiqcModule):
                     for sample_name, metric in data_by_sample.items()
                 },
                 table_headers,
+                pconfig={
+                    "namespace": "Single-Cell RNA Metrics",
+                    "id": "dragen-sc-rna-metrics-table",
+                },
             ),
         )
 

--- a/multiqc/modules/dragen/trimmer_metrics.py
+++ b/multiqc/modules/dragen/trimmer_metrics.py
@@ -40,7 +40,13 @@ class DragenTrimmerMetrics(BaseMultiqcModule):
             description="""
             Metrics on trimmed reads.
             """,
-            plot=table.plot(table_data),
+            plot=table.plot(
+                table_data,
+                pconfig={
+                    "id": "dragen-trimmer-metrics-table",
+                    "namespace": "Trimmer Metrics",
+                },
+            ),
         )
 
         return data_by_sample.keys()

--- a/multiqc/modules/dragen/vc_metrics.py
+++ b/multiqc/modules/dragen/vc_metrics.py
@@ -55,7 +55,14 @@ class DragenVCMetrics(BaseMultiqcModule):
             except for the "Filtered" metrics which represent how many variants were filtered out
             from pre-filter VCF to generate the post-filter VCF.
             """,
-            plot=table.plot(data_by_sample, vc_table_headers, pconfig={"namespace": NAMESPACE}),
+            plot=table.plot(
+                data_by_sample,
+                vc_table_headers,
+                pconfig={
+                    "id": "dragen-vc-metrics-table",
+                    "namespace": NAMESPACE,
+                },
+            ),
         )
         return data_by_sample.keys()
 

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -53,7 +53,11 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             """,
-            plot=table.plot(self.happy_indel_data, self.gen_headers("_indel")),
+            plot=table.plot(
+                self.happy_indel_data,
+                self.gen_headers("_indel"),
+                pconfig={"id": "happy_indel_plot"},
+            ),
         )
 
         self.add_section(
@@ -65,7 +69,11 @@ class MultiqcModule(BaseMultiqcModule):
 
                 Ideally, precision, recall and F1 Score should all be as close to 1 as possible.
             """,
-            plot=table.plot(self.happy_snp_data, self.gen_headers("_snp")),
+            plot=table.plot(
+                self.happy_snp_data,
+                self.gen_headers("_snp"),
+                pconfig={"id": "happy_snp_plot"},
+            ),
         )
 
     def parse_file(self, f):

--- a/multiqc/modules/hicpro/hicpro.py
+++ b/multiqc/modules/hicpro/hicpro.py
@@ -319,7 +319,7 @@ class MultiqcModule(BaseMultiqcModule):
                     try:
                         d["Failed_To_Align_Read"] = int(n_total) - int(n_mapped)
                     except ValueError:
-                        log.warning(
+                        log.debug(
                             f"Could not parse mapped_R{r}={n_mapped} or total_R{r}={n_total} "
                             f"as an integer number for sample {s_name}"
                         )

--- a/multiqc/modules/hicpro/hicpro.py
+++ b/multiqc/modules/hicpro/hicpro.py
@@ -319,7 +319,7 @@ class MultiqcModule(BaseMultiqcModule):
                     try:
                         d["Failed_To_Align_Read"] = int(n_total) - int(n_mapped)
                     except ValueError:
-                        log.debug(
+                        log.warning(
                             f"Could not parse mapped_R{r}={n_mapped} or total_R{r}={n_total} "
                             f"as an integer number for sample {s_name}"
                         )

--- a/multiqc/modules/hicpro/hicpro.py
+++ b/multiqc/modules/hicpro/hicpro.py
@@ -38,21 +38,38 @@ class MultiqcModule(BaseMultiqcModule):
         for s_name in self.hicpro_data:
             data = self.hicpro_data[s_name]
             try:
-                data["duplicates"] = data["valid_interaction"] - data["valid_interaction_rmdup"]
-                data["percent_duplicates"] = float(data["duplicates"]) / float(data["valid_interaction"]) * 100.0
-                data["percent_mapped_R1"] = float(data["mapped_R1"]) / float(data["total_R1"]) * 100.0
-                data["percent_mapped_R2"] = float(data["mapped_R2"]) / float(data["total_R2"]) * 100.0
-                data["paired_reads"] = int(data["Reported_pairs"])
-                data["percent_paired_reads"] = float(data["Reported_pairs"]) / float(data["total_R1"]) * 100.0
-                data["percent_valid"] = float(data["valid_interaction"]) / float(data["total_R1"]) * 100.0
-                data["Failed_To_Align_Read_R1"] = int(data["total_R1"]) - int(data["mapped_R1"])
-                data["Failed_To_Align_Read_R2"] = int(data["total_R2"]) - int(data["mapped_R2"])
+                if "total_R1" in data:
+                    if "valid_interaction" in data:
+                        if float(data["total_R1"]) > 0:
+                            data["percent_valid"] = float(data["valid_interaction"]) / float(data["total_R1"]) * 100.0
+                        if "valid_pairs_on_target" in data:
+                            data["valid_pairs_off_target"] = int(data["valid_interaction"]) - int(
+                                data["valid_pairs_on_target"]
+                            )
+                        if "valid_interaction_rmdup" in data:
+                            data["duplicates"] = data["valid_interaction"] - data["valid_interaction_rmdup"]
+                            if float(data["valid_interaction"]) > 0:
+                                data["percent_duplicates"] = (
+                                    float(data["duplicates"]) / float(data["valid_interaction"]) * 100.0
+                                )
+                    if "Reported_pairs" in data:
+                        data["paired_reads"] = int(data["Reported_pairs"])
+                        if float(data["total_R1"]) > 0:
+                            data["percent_paired_reads"] = (
+                                float(data["Reported_pairs"]) / float(data["total_R1"]) * 100.0
+                            )
+                    if "mapped_R1" in data:
+                        data["Failed_To_Align_Read_R1"] = int(data["total_R1"]) - int(data["mapped_R1"])
+                        if float(data["total_R1"]) > 0:
+                            data["percent_mapped_R1"] = float(data["mapped_R1"]) / float(data["total_R1"]) * 100.0
+                if "total_R2" in data:
+                    if "mapped_R2" in data:
+                        data["Failed_To_Align_Read_R2"] = int(data["total_R2"]) - int(data["mapped_R2"])
+                        if float(data["total_R2"]) > 0:
+                            data["percent_mapped_R2"] = float(data["mapped_R2"]) / float(data["total_R2"]) * 100.0
             except KeyError as e:
                 log.error(f"Missing expected key {e} in sample '{s_name}'")
-
-            try:
-                data["valid_pairs_off_target"] = int(data["valid_interaction"]) - int(data["valid_pairs_on_target"])
-            except KeyError:
+            except TypeError:
                 pass
 
         # Filter to strip out ignored sample names
@@ -169,7 +186,7 @@ class MultiqcModule(BaseMultiqcModule):
                         self.hicpro_data[s_name][s[0]] = float(s[1])
                     # Otherwise just store the value as is.
                     except ValueError:
-                        self.hicpro_data[s_name][s[0]] = s[1]
+                        log.error(f"Could not parse value for key '{s[0]}' as a number in sample '{s_name}': '{s[1]}'")
 
     def hicpro_stats_table(self):
         """Add HiC-Pro stats to the general stats table"""
@@ -289,15 +306,24 @@ class MultiqcModule(BaseMultiqcModule):
         data = [{}, {}]
         for s_name in self.hicpro_data:
             for r in [1, 2]:
-                try:
-                    data[r - 1][f"{s_name} [R{r}]"] = {
-                        "Full_Alignments_Read": self.hicpro_data[s_name][f"global_R{r}"],
-                        "Trimmed_Alignments_Read": self.hicpro_data[s_name][f"local_R{r}"],
-                        "Failed_To_Align_Read": int(self.hicpro_data[s_name][f"total_R{r}"])
-                        - int(self.hicpro_data[s_name][f"mapped_R{r}"]),
-                    }
-                except KeyError as e:
-                    log.error(f"Missing expected plot key {e} in {s_name} Read {r}")
+                n_global = self.hicpro_data[s_name].get(f"global_R{r}")
+                n_local = self.hicpro_data[s_name].get(f"local_R{r}")
+                n_mapped = self.hicpro_data[s_name].get(f"mapped_R{r}")
+                n_total = self.hicpro_data[s_name].get(f"total_R{r}")
+                d = dict()
+                if n_global is not None:
+                    d["Full_Alignments_Read"] = n_global
+                if n_local is not None:
+                    d["Trimmed_Alignments_Read"] = n_local
+                if n_mapped is not None and n_total is not None:
+                    try:
+                        d["Failed_To_Align_Read"] = int(n_total) - int(n_mapped)
+                    except ValueError:
+                        log.debug(
+                            f"Could not parse mapped_R{r}={n_mapped} or total_R{r}={n_total} "
+                            f"as an integer number for sample {s_name}"
+                        )
+                data[r - 1][f"{s_name} [R{r}]"] = d
 
         # Config for the plot
         config = {

--- a/multiqc/modules/kat/kat.py
+++ b/multiqc/modules/kat/kat.py
@@ -73,6 +73,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         kat_config = {
             "namespace": "KAT",
+            "id": "kat-table",
         }
 
         # Basic Stats Table

--- a/multiqc/modules/picard/ValidateSamFile.py
+++ b/multiqc/modules/picard/ValidateSamFile.py
@@ -348,6 +348,7 @@ def _generate_detailed_table(data):
 
     table_config = {
         "table_title": "Picard: SAM/BAM File Validation",
+        "id": "picard_validatesamfile_table",
     }
 
     return table.plot(data=data, headers=headers, pconfig=table_config)

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -996,7 +996,7 @@ class MultiqcModule(BaseMultiqcModule):
             self.add_data_source(f, s_name, section=analysis_mode)
 
         except KeyError as ex:
-            log.error(
+            log.debug(
                 "The entry {} was not found in the qc3C JSON file '{}', skipping sample {}".format(
                     str(ex), os.path.join(f["root"], f["fn"]), f["s_name"]
                 )

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -436,5 +436,12 @@ class MultiqcModule(BaseMultiqcModule):
         self.add_section(
             name="WhatsHap statistics",
             anchor="whatshap-table",
-            plot=table.plot(general, stats_headers),
+            plot=table.plot(
+                general,
+                stats_headers,
+                {
+                    "namespace": "WhatsHap",
+                    "id": "whatshap-stats-table",
+                },
+            ),
         )

--- a/multiqc/modules/xengsort/xengsort.py
+++ b/multiqc/modules/xengsort/xengsort.py
@@ -116,7 +116,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.add_section(
             name="Summary table",
             anchor=f"{self.anchor}-summary-table-section",
-            plot=table.plot(table_data, detail_headers),
+            plot=table.plot(table_data, detail_headers, {"id": f"{self.anchor}-summary-table"}),
         )
 
     def _build_plot(self):

--- a/multiqc/modules/xenome/xenome.py
+++ b/multiqc/modules/xenome/xenome.py
@@ -231,7 +231,7 @@ class MultiqcModule(BaseMultiqcModule):
         self.add_section(
             name="Summary table",
             anchor="xenome-summary-table",
-            plot=table.plot(table_data, detail_headers),
+            plot=table.plot(table_data, detail_headers, pconfig={"id": "xenome-table"}),
         )
 
     def _xenome_stats_plot(self):

--- a/multiqc/plots/table.py
+++ b/multiqc/plots/table.py
@@ -3,7 +3,6 @@
 """ MultiQC functions to plot a table """
 
 import logging
-import random
 from collections import defaultdict
 
 from multiqc.plots import beeswarm, table_object
@@ -54,8 +53,7 @@ def make_table(dt: table_object.DataTable):
     :param dt: MultiQC datatable object
     """
 
-    table_id = dt.pconfig.get("id", f"table_{''.join(random.sample(letters, 4))}")
-    table_id = report.save_htmlid(table_id)
+    table_id = dt.pconfig["id"]
     t_headers = dict()
     t_modal_headers = dict()
     t_rows = dict()

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -3,7 +3,9 @@
 """ MultiQC datatable class, used by tables and beeswarm plots """
 
 import logging
+import random
 import re
+import string
 from collections import defaultdict
 from typing import List, Tuple, Dict
 
@@ -24,9 +26,16 @@ class DataTable:
             pconfig = {}
 
         # Allow user to overwrite any given config for this plot
-        if "id" in pconfig and pconfig["id"] and pconfig["id"] in config.custom_plot_config:
+        if pconfig.get("id") and pconfig["id"] in config.custom_plot_config:
             for k, v in config.custom_plot_config[pconfig["id"]].items():
                 pconfig[k] = v
+
+        if not pconfig.get("id"):
+            if config.strict:
+                errmsg = f"LINT: 'id' is missing from plot pconfig: {pconfig}"
+                logger.error(errmsg)
+                report.lint_errors.append(errmsg)
+            pconfig["id"] = report.save_htmlid(f"table_{''.join(random.sample(string.ascii_lowercase, 4))}")
 
         # Given one dataset - turn it into a list
         if not isinstance(data, list):


### PR DESCRIPTION
Add missing `pconfig` with `namespace` and `id` in DRAGEN submodules. Fixes settings table column visibility configuration, e.g.

```yaml
table_columns_visible:
  dragen-trimmer-metrics-table:
    Total input reads: False
    Unmapped reads pct: False
    Number of duplicate marked reads pct: False
    Total: False
    Total input bases R2: False
```

Fixes https://github.com/ewels/MultiQC/issues/1954

Require `id` to be set in pconfig when `--strict`. When it's not set, auto-generate random `id` earlier to make the config options work.

As some additional refactoring, removed warnings of missing `r` prefixes in regex strings.

TODO: 
- [x] now fix the rest of the linting :)