### PR TITLE
DeepTools: Handle missing data in plotProfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Module updates
 
+- **deepTools**: Handle missing data in plotProfile ([#2229](https://github.com/ewels/MultiQC/pull/2229))
 - **GATK**: square the BaseRecalibrator scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
 - **kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
 - **QualiMap**: BamQC: fix for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))

--- a/multiqc/modules/deeptools/plotProfile.py
+++ b/multiqc/modules/deeptools/plotProfile.py
@@ -115,6 +115,7 @@ class plotProfileMixin:
         d = dict()
         bin_labels = []
         bins = []
+        converted_bin_labels = []
         for line in f["f"].splitlines():
             cols = line.rstrip().split("\t")
             if cols[0] == "bin labels":
@@ -148,6 +149,11 @@ class plotProfileMixin:
                     converted_bin_labels = bins
 
                 for i in bins:
-                    d[s_name].update({converted_bin_labels[i - 1]: float(cols[i + 1])})
+                    v = cols[i + 1]
+                    try:
+                        v = float(v)
+                    except ValueError:
+                        v = None
+                    d[s_name].update({converted_bin_labels[i - 1]: v})
 
         return d, bin_labels, converted_bin_labels


### PR DESCRIPTION
Correctly handle input where missing value is represented with `--`.

Fixes https://github.com/ewels/MultiQC/issues/1939