### PR TITLE
Update num_lines for fastp search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - Refactor: replace `.format()` calls with f-strings ([#2224](https://github.com/ewels/MultiQC/pull/2224))
 - GATK MarkDuplicates: more search patterns ([#2226](https://github.com/ewels/MultiQC/pull/2226))
 - Add missing table `id` in DRAGEN modules, require them in linting ([#2228](https://github.com/ewels/MultiQC/pull/2228))
-- Update num_lines for fastp search ([#2235](https://github.com/ewels/MultiQC/pull/2235))
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Refactor: replace `.format()` calls with f-strings ([#2224](https://github.com/ewels/MultiQC/pull/2224))
 - GATK MarkDuplicates: more search patterns ([#2226](https://github.com/ewels/MultiQC/pull/2226))
 - Add missing table `id` in DRAGEN modules, require them in linting ([#2228](https://github.com/ewels/MultiQC/pull/2228))
+- Update num_lines for fastp search ([#2235](https://github.com/ewels/MultiQC/pull/2235))
 
 ### New Modules
 

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -323,7 +323,7 @@ eigenstratdatabasetools:
 fastp:
   fn: "*.json"
   contents: '"before_filtering": {'
-  num_lines: 5
+  num_lines: 10
 fastq_screen:
   fn: "*_screen.txt"
 fastqc/data:

--- a/multiqc/utils/search_patterns.yaml
+++ b/multiqc/utils/search_patterns.yaml
@@ -323,7 +323,7 @@ eigenstratdatabasetools:
 fastp:
   fn: "*.json"
   contents: '"before_filtering": {'
-  num_lines: 3
+  num_lines: 5
 fastq_screen:
   fn: "*_screen.txt"
 fastqc/data:


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Reverts change in 9d00f14a317a3eb40c8edb5b4e92fde4bf11689e - 3 lines is not enough. Data in https://github.com/ewels/MultiQC_TestData/tree/master/data/modules/fastp/issue_2138 cannot be parsed with only 3 lines.
