### PR TITLE
Move GitHub repository to `MultiQC` organisation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ A few pointers to bear in mind:
 Once you've submitted a new pull request, here's what you can expect from me:
 
 - I usually don't look at your code at all until the automated tests pass
-  - The tests use example data in the [MultiQC_TestData](https://github.com/ewels/MultiQC_TestData) repository, so you'll need some files there before the PR will go any further.
+  - The tests use example data in the [test-data](https://github.com/MultiQC/test-data) repository, so you'll need some files there before the PR will go any further.
   - The tests use [GitHub Actions](https://github.com/features/actions) so should also run automatically on your fork.
 - First pass - I go through and give feedback just by reading the code
 - Second pass - I download and run your code, usually more feedback

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you'd like to write some code for MultiQC, the standard workflow
 is as follows:
 
 1. Check that there isn't already an issue about your idea in the
-   [MultiQC issues](https://github.com/ewels/MultiQC/issues) to avoid
+   [MultiQC issues](https://github.com/MultiQC/MultiQC/issues) to avoid
    duplicating work.
    - Feel free to add a new issue here for the same reason.
 2. Fork the MultiQC repository to your GitHub account

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Please fill in the appropriate checklist below (delete whatever is not relevant)
 
 <!-- If this PR is for a NEW module - delete if not -->
 
-- [ ] There is example tool output for tools in the <https://github.com/ewels/MultiQC_TestData> repository or attached to this PR
+- [ ] There is example tool output for tools in the <https://github.com/MultiQC/test-data> repository or attached to this PR
 - [ ] Code is tested and works locally (including with `--strict` flag)
 - [ ] `docs/README.md` is updated with link to below
 - [ ] `docs/modulename.md` is created

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -50,12 +50,12 @@ This checklist is for my own reference, as I forget the steps every time.
 8. Commit and push version updates
 9. Generate new rich-codex screenshots
    - On github.com, make a new branch using the branch dropdown called `rich-codex` (or whatever).
-   - Go to _Actions_ and then [_Docs screenshots_](https://github.com/ewels/MultiQC/actions/workflows/screenshots.yml)
+   - Go to _Actions_ and then [_Docs screenshots_](https://github.com/MultiQC/MultiQC/actions/workflows/screenshots.yml)
    - Click _Run Workflow_ top right, and **select your new branch**
    - Click Run. Wait for the action to complete.
    - Make a PR from this branch to `master` and check that the new screenshot looks ok. Merge if so.
 10. Make sure that all tests are passing
-11. Make a [release](https://github.com/ewels/MultiQC/releases) on GitHub - paste changelog section.
+11. Make a [release](https://github.com/MultiQC/MultiQC/releases) on GitHub - paste changelog section.
 12. Check that [PyPI listing page](https://pypi.python.org/pypi/multiqc/) looks sane
 13. Update version numbers to new dev version in `setup.py` + a new section in the changelog for the development version
 14. Commit and push version bump
@@ -88,7 +88,7 @@ conda skeleton pypi multiqc
 # Update with new release header - see https://goo.gl/ZfRnmj
 cd ../multiqc && code .
 # Get the sha256sum of the release
-curl -OL https://github.com/ewels/MultiQC/archive/v1.5.tar.gz
+curl -OL https://github.com/MultiQC/MultiQC/archive/v1.5.tar.gz
 shasum --algorithm 256 v1.5.tar.gz
 # Switch out download for GitHub release and remove all other cruft
 # commit changes

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -53,7 +53,7 @@ This checklist is for my own reference, as I forget the steps every time.
    - Go to _Actions_ and then [_Docs screenshots_](https://github.com/MultiQC/MultiQC/actions/workflows/screenshots.yml)
    - Click _Run Workflow_ top right, and **select your new branch**
    - Click Run. Wait for the action to complete.
-   - Make a PR from this branch to `master` and check that the new screenshot looks ok. Merge if so.
+   - Make a PR from this branch to `main` and check that the new screenshot looks ok. Merge if so.
 10. Make sure that all tests are passing
 11. Make a [release](https://github.com/MultiQC/MultiQC/releases) on GitHub - paste changelog section.
 12. Check that [PyPI listing page](https://pypi.python.org/pypi/multiqc/) looks sane
@@ -76,8 +76,8 @@ Instructions for complete rebuild of BioConda:
 ```bash
 # Update to latest bioconda
 cd ../bioconda-recipes
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git push
 git branch -D multiqc
 # Build new conda recipe from PyPI to automatically collect new dependencies

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -161,7 +161,7 @@ def _load_file_content_after_pr(path) -> str:
     _run_cmd(f"cd {workspace_path} && gh pr checkout {pr_number}")
     with (workspace_path / path).open() as f:
         text = f.read()
-    _run_cmd(f"cd {workspace_path} && git checkout master")
+    _run_cmd(f"cd {workspace_path} && git checkout main")
     return text
 
 

--- a/.github/workflows/changelog.py
+++ b/.github/workflows/changelog.py
@@ -4,16 +4,16 @@ PR_TITLE, PR_NUMBER, GITHUB_WORKSPACE.
 
 Adds a line into the CHANGELOG.md:
 * If a PR title starts with "New module: ", checks that a single module is added,
- and appends an entry under the ""### New modules" section. 
+ and appends an entry under the ""### New modules" section.
 * If a single module was modified, checks that the PR starts with a name of the
  modified module (e.g. "FastQC: new stuff") and adds a line under "### Module updates".
 * All other change will go under the "### MultiQC updates" section.
 * If an entry for the PR is already added, will replace it.
 
 Other assumptions:
-- CHANGELOG.md has a running section for an ongoing "dev" version 
+- CHANGELOG.md has a running section for an ongoing "dev" version
 (i.e. titled "## MultiQC vX.Ydev").
-- Under that section, there are sections "### MultiQC updates", "### New modules" 
+- Under that section, there are sections "### MultiQC updates", "### New modules"
 and "### Module updates".
 - For module's info, checks the file multiqc/modules/<module_name>/<module_name>.py.
 """
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import yaml
 
-REPO_URL = "https://github.com/ewels/MultiQC"
+REPO_URL = "https://github.com/MultiQC/MultiQC"
 MODULES_DIR = Path("multiqc/modules")
 
 # Assumes the environment is set by the GitHub action.
@@ -329,7 +329,7 @@ while orig_lines:
         updated_lines.append(line)
 
         # Parse version from the line ## MultiQC v1.10dev or
-        # ## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) ...
+        # ## [MultiQC v1.15](https://github.com/MultiQC/MultiQC/releases/tag/v1.15) ...
         if not (m := re.match(r".*MultiQC (v\d+\.\d+(dev)?).*", line)):
             print(f"Cannot parse version from line {line.strip()}.", file=sys.stderr)
             sys.exit(1)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     # Run if comment is on a PR with the main repo, and if it contains the magic keywords.
     # Or run on PR creation, unless asked otherwise in the title.
     if: |
-      github.repository_owner == 'ewels' && (
+      github.repository_owner == 'MultiQC' && (
         github.event_name == 'pull_request_target' ||
         github.event.issue.pull_request && startsWith(github.event.comment.body, '@multiqc-bot changelog')
       )

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -25,12 +25,12 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish MultiQC to PyPI
-        if: github.repository == 'ewels/MultiQC'
+        if: github.repository == 'MultiQC/MultiQC'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 #      - name: Tweet
-#        if: github.repository == 'ewels/MultiQC'
+#        if: github.repository == 'MultiQC/MultiQC'
 #        uses: snow-actions/tweet@v1.3.0
 #        with:
 #          status: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Publish Docker image
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ewels/multiqc:dev
+            multiqc/multiqc:dev
             ghcr.io/multiqc/multiqc:dev
 
       - name: Push release image
@@ -60,7 +60,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ewels/multiqc:${{ github.event.release.tag_name }}
-            ewels/multiqc:latest
+            multiqc/multiqc:${{ github.event.release.tag_name }}
+            multiqc/multiqc:latest
             ghcr.io/multiqc/multiqc:${{ github.event.release.tag_name }}
             ghcr.io/multiqc/multiqc:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   push_to_registry:
-    if: github.repository == 'ewels/MultiQC'
+    if: github.repository == 'MultiQC/MultiQC'
     name: Build + Push Docker image
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +48,7 @@ jobs:
           push: true
           tags: |
             ewels/multiqc:dev
-            ghcr.io/ewels/multiqc:dev
+            ghcr.io/multiqc/multiqc:dev
 
       - name: Push release image
         uses: docker/build-push-action@v3
@@ -62,5 +62,5 @@ jobs:
           tags: |
             ewels/multiqc:${{ github.event.release.tag_name }}
             ewels/multiqc:latest
-            ghcr.io/ewels/multiqc:${{ github.event.release.tag_name }}
-            ghcr.io/ewels/multiqc:latest
+            ghcr.io/multiqc/multiqc:${{ github.event.release.tag_name }}
+            ghcr.io/multiqc/multiqc:latest

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -3,7 +3,7 @@ name: Docs - Netlify deploy
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "docs/**"
       - ".github/workflows/docs_deploy.yml"

--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     name: "Request deployment"
     runs-on: ubuntu-latest
-    if: github.repository == 'ewels/MultiQC'
+    if: github.repository == 'MultiQC/MultiQC'
     steps:
       - name: Curl request
         run: curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}

--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     name: "Deploy preview"
     runs-on: ubuntu-latest
-    if: github.repository == 'ewels/MultiQC'
+    if: github.repository == 'MultiQC/MultiQC'
     defaults:
       run:
         working-directory: ./MultiQC_website

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
     if: >
-      github.repository_owner == 'ewels' &&
+      github.repository_owner == 'MultiQC' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@multiqc-bot fix linting')
 

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,7 +1,7 @@
 name: Lint Code Base
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/multiqc.yml
+++ b/.github/workflows/multiqc.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Download test data
         uses: actions/checkout@v3
         with:
-          repository: ewels/MultiQC_TestData
+          repository: MultiQC/test-data
           path: test_data
 
       # Run all of the tests!
@@ -179,10 +179,10 @@ jobs:
       # NB: Download zip file instead of git clone, as Windows complains about reserved filenames and certain characters
       - name: Download test data
         run: |
-          curl -fsSL https://github.com/ewels/MultiQC_TestData/archive/master.zip -o test_data.zip
+          curl -fsSL https://github.com/MultiQC/test-data/archive/master.zip -o test_data.zip
           7z x test_data.zip -y -o"test_data"
-          dir test_data\MultiQC_TestData-master
+          dir test_data\test-data-master
 
       # Run all of the tests! Remember the BACKslash path separator!
       - name: All modules / Custom report filename
-        run: multiqc ${{ needs.changes.outputs.single_module }} --strict test_data\MultiQC_TestData-master\data\modules\ --filename full_report.html
+        run: multiqc ${{ needs.changes.outputs.single_module }} --strict test_data\test-data-master\data\modules\ --filename full_report.html

--- a/.github/workflows/multiqc.yml
+++ b/.github/workflows/multiqc.yml
@@ -2,7 +2,7 @@ name: "MultiQC"
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - "docs/**"
       - "*.md"
@@ -179,10 +179,10 @@ jobs:
       # NB: Download zip file instead of git clone, as Windows complains about reserved filenames and certain characters
       - name: Download test data
         run: |
-          curl -fsSL https://github.com/MultiQC/test-data/archive/master.zip -o test_data.zip
+          curl -fsSL https://github.com/MultiQC/test-data/archive/main.zip -o test_data.zip
           7z x test_data.zip -y -o"test_data"
-          dir test_data\test-data-master
+          dir test_data\test-data-main
 
       # Run all of the tests! Remember the BACKslash path separator!
       - name: All modules / Custom report filename
-        run: multiqc ${{ needs.changes.outputs.single_module }} --strict test_data\test-data-master\data\modules\ --filename full_report.html
+        run: multiqc ${{ needs.changes.outputs.single_module }} --strict test_data\test-data-main\data\modules\ --filename full_report.html

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,9 +17,9 @@ jobs:
 
       - name: Download test data
         run: |
-          wget https://github.com/MultiQC/test-data/archive/refs/heads/master.zip
-          unzip master.zip
-          mv test-data-master/ test_data/
+          wget https://github.com/MultiQC/test-data/archive/refs/heads/main.zip
+          unzip main.zip
+          mv test-data-main/ test_data/
 
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@v1

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -17,9 +17,9 @@ jobs:
 
       - name: Download test data
         run: |
-          wget https://github.com/ewels/MultiQC_TestData/archive/refs/heads/master.zip
+          wget https://github.com/MultiQC/test-data/archive/refs/heads/master.zip
           unzip master.zip
-          mv MultiQC_TestData-master/ test_data/
+          mv test-data-master/ test_data/
 
       - name: Generate terminal images with rich-codex
         uses: ewels/rich-codex@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests"]
 	path = tests
-	url = https://github.com/ewels/MultiQC_TestData.git
+	url = https://github.com/MultiQC/test-data.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### MultiQC updates
 
-- Update repo name ([#2243](https://github.com/MultiQC/MultiQC/pull/2243))
+- Move GitHub repository to `MultiQC` organisation ([#2243](https://github.com/MultiQC/MultiQC/pull/2243))
 
 ### New modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,41 +10,41 @@
 
 ### Module updates
 
-## [MultiQC v1.19](https://github.com/MultiQC/MultiQC/releases/tag/v1.19) - 2023-12-18
+## [MultiQC v1.19](https://github.com/ewels/MultiQC/releases/tag/v1.19) - 2023-12-18
 
 ### MultiQC updates
 
-- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/MultiQC/MultiQC/pull/2228))
-- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/MultiQC/MultiQC/pull/2191))
-- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/MultiQC/MultiQC/pull/2210))
-- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/MultiQC/MultiQC/pull/1666))
-- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/MultiQC/MultiQC/pull/2224))
-- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/MultiQC/MultiQC/pull/1667))
-- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/MultiQC/MultiQC/pull/2195))
-- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/MultiQC/MultiQC/pull/2209))
+- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/ewels/MultiQC/pull/2228))
+- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/ewels/MultiQC/pull/2191))
+- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/ewels/MultiQC/pull/2210))
+- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/ewels/MultiQC/pull/1666))
+- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/ewels/MultiQC/pull/2224))
+- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/ewels/MultiQC/pull/1667))
+- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
+- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/ewels/MultiQC/pull/2209))
 
 ### MultiQC bug fixes
 
-- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/MultiQC/MultiQC/pull/2202))
-- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
-- Fix running with the `--no-report` flag ([#2212](https://github.com/MultiQC/MultiQC/pull/2212))
-- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/MultiQC/MultiQC/pull/2208))
-- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/MultiQC/MultiQC/pull/2234))
+- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
+- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
+- Fix running with the `--no-report` flag ([#2212](https://github.com/ewels/MultiQC/pull/2212))
+- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/ewels/MultiQC/pull/2208))
+- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/ewels/MultiQC/pull/2234))
 
 ### Module updates
 
-- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/MultiQC/MultiQC/pull/2197))
-- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/MultiQC/MultiQC/pull/2229))
-- **Fastp**: search content instead of file name ([#2213](https://github.com/MultiQC/MultiQC/pull/2213))
-- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
-- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/MultiQC/MultiQC/pull/2233))
-- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/MultiQC/MultiQC/pull/2230))
-- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/MultiQC/MultiQC/pull/2205))
-- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/MultiQC/MultiQC/pull/2207))
-- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/MultiQC/MultiQC/pull/2226))
-- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/MultiQC/MultiQC/pull/1485))
+- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
+- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/ewels/MultiQC/pull/2229))
+- **Fastp**: search content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
+- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
+- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/ewels/MultiQC/pull/2233))
+- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/ewels/MultiQC/pull/2230))
+- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
+- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))
+- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/ewels/MultiQC/pull/2226))
+- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/ewels/MultiQC/pull/1485))
 
-## [MultiQC v1.18](https://github.com/MultiQC/MultiQC/releases/tag/v1.18) - 2023-11-17
+## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
 
 ### Highlights
 
@@ -76,40 +76,40 @@ If you were using the Sentieon module in your pipelines, make sure to update any
 
 ### MultiQC updates
 
-- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
-- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/MultiQC/MultiQC/pull/2183))
-- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/MultiQC/MultiQC/pull/2181))
-- Software versions: allow any string as a version tag ([#2166](https://github.com/MultiQC/MultiQC/pull/2166))
-- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/MultiQC/MultiQC/pull/2176))
-- Stricter config variable typing ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
-- Remove `position:absolute` CSS from table values ([#2169](https://github.com/MultiQC/MultiQC/pull/2169))
-- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/MultiQC/MultiQC/pull/2143))
-- Fix custom anchors for kraken ([#2170](https://github.com/MultiQC/MultiQC/pull/2170))
-- Fix logging spillover bug ([#2174](https://github.com/MultiQC/MultiQC/pull/2174))
+- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/ewels/MultiQC/pull/2178))
+- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/ewels/MultiQC/pull/2183))
+- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/ewels/MultiQC/pull/2181))
+- Software versions: allow any string as a version tag ([#2166](https://github.com/ewels/MultiQC/pull/2166))
+- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/ewels/MultiQC/pull/2176))
+- Stricter config variable typing ([#2178](https://github.com/ewels/MultiQC/pull/2178))
+- Remove `position:absolute` CSS from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
+- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/ewels/MultiQC/pull/2143))
+- Fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
+- Fix logging spillover bug ([#2174](https://github.com/ewels/MultiQC/pull/2174))
 
 ### New Modules
 
-- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/MultiQC/MultiQC/pull/2151))
+- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/ewels/MultiQC/pull/2151))
   - Seqera Platform CLI reports statistics generated by the Seqera Platform CLI.
-- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/MultiQC/MultiQC/pull/1860))
+- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/ewels/MultiQC/pull/1860))
   - A tool for classifying reads from xenograft sources.
-- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/MultiQC/MultiQC/pull/2168))
+- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/ewels/MultiQC/pull/2168))
   - xengsort is a fast xenograft read sorter based on space-efficient k-mer hashing
 
 ### Module updates
 
-- **fastp**: add version parsing ([#2159](https://github.com/MultiQC/MultiQC/pull/2159))
-- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/MultiQC/MultiQC/pull/2139))
-- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/MultiQC/MultiQC/pull/2179))
-- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/MultiQC/MultiQC/pull/2155))
-- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/MultiQC/MultiQC/pull/2157))
-- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
-- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
+- **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
+- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
+- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/ewels/MultiQC/pull/2179))
+- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
+- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/ewels/MultiQC/pull/2157))
+- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/ewels/MultiQC/pull/2110))
+- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/ewels/MultiQC/pull/2110))
   - Note that any code that relies on the module name needs to be updated, e.g. `-m sentieon` will no longer work
   - The exported plot and data files will be now be prefixed as `picard` instead of `sentieon`, etc.
   - Note that the Sentieon module used to fetch the sample names from the file names by default, and now it follows the Picard module's logic, and prioritizes the commands recorded in the logs. To override, use the `use_filename_as_sample_name` config flag
 
-## [MultiQC v1.17](https://github.com/MultiQC/MultiQC/releases/tag/v1.17) - 2023-10-17
+## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
 
 ### The one with the new logo
 
@@ -124,45 +124,45 @@ Highlights:
 
 ### MultiQC updates
 
-- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/MultiQC/MultiQC/pull/2025), [#2102](https://github.com/MultiQC/MultiQC/pull/2102), [#2115](https://github.com/MultiQC/MultiQC/pull/2115))
-- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/MultiQC/MultiQC/pull/2082))
-- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/MultiQC/MultiQC/pull/2049))
-- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/MultiQC/MultiQC/pull/2081))
-- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/MultiQC/MultiQC/pull/2101))
-- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/MultiQC/MultiQC/pull/1632))
-- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/MultiQC/MultiQC/pull/2124))
-- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/MultiQC/MultiQC/pull/2109))
+- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025), [#2102](https://github.com/ewels/MultiQC/pull/2102), [#2115](https://github.com/ewels/MultiQC/pull/2115))
+- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
+- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/ewels/MultiQC/pull/2049))
+- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
+- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/ewels/MultiQC/pull/2101))
+- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/ewels/MultiQC/pull/1632))
+- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/ewels/MultiQC/pull/2124))
+- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/ewels/MultiQC/pull/2109))
 - Fixes for python 3.12
-  - Replace removed `distutils` ([#2113](https://github.com/MultiQC/MultiQC/pull/2113))
-  - Bundle lzstring ([#2119](https://github.com/MultiQC/MultiQC/pull/2119))
-- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/MultiQC/MultiQC/pull/2121))
-- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/MultiQC/MultiQC/pull/2074))
+  - Replace removed `distutils` ([#2113](https://github.com/ewels/MultiQC/pull/2113))
+  - Bundle lzstring ([#2119](https://github.com/ewels/MultiQC/pull/2119))
+- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/ewels/MultiQC/pull/2121))
+- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
 - <img src="./multiqc/templates/default/assets/img/favicon-16x16.png" alt="///" width="10px"/> New logo
-- Set name and anchor for the custom content "module" [#2131](https://github.com/MultiQC/MultiQC/pull/2131)
-- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/MultiQC/MultiQC/pull/2133))
+- Set name and anchor for the custom content "module" [#2131](https://github.com/ewels/MultiQC/pull/2131)
+- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/ewels/MultiQC/pull/2133))
 
 ### New Modules
 
 - [**Bracken**](https://ccb.jhu.edu/software/bracken/)
   - A highly accurate statistical method that computes the abundance of species in DNA sequences from a metagenomics sample.
-- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/MultiQC/MultiQC/pull/1751))
+- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/ewels/MultiQC/pull/1751))
   - Truvari is a toolkit for benchmarking, merging, and annotating structural variants
 
 ### Module updates
 
-- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/MultiQC/MultiQC/pull/2128))
-- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/MultiQC/MultiQC/pull/2118))
-- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/MultiQC/MultiQC/pull/2108))
-- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/MultiQC/MultiQC/pull/2075))
-- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/MultiQC/MultiQC/pull/2126))
-- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/MultiQC/MultiQC/pull/2129))
-- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/MultiQC/MultiQC/pull/2106))
-- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/MultiQC/MultiQC/pull/2127))
-- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/MultiQC/MultiQC/pull/2083), [#2094](https://github.com/MultiQC/MultiQC/pull/2094))
-- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/MultiQC/MultiQC/pull/2123))
-- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/MultiQC/MultiQC/pull/2095))
+- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/ewels/MultiQC/pull/2128))
+- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/ewels/MultiQC/pull/2118))
+- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/ewels/MultiQC/pull/2108))
+- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
+- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/ewels/MultiQC/pull/2126))
+- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/ewels/MultiQC/pull/2129))
+- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/ewels/MultiQC/pull/2106))
+- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/ewels/MultiQC/pull/2127))
+- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/ewels/MultiQC/pull/2083), [#2094](https://github.com/ewels/MultiQC/pull/2094))
+- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/ewels/MultiQC/pull/2123))
+- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
 
-## [MultiQC v1.16](https://github.com/MultiQC/MultiQC/releases/tag/v1.16) - 2023-09-22
+## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
 
 ### Highlight: Software versions
 
@@ -180,21 +180,21 @@ See the documentation for more ([writing modules](https://multiqc.info/docs/deve
 [supplying stand-alone](https://multiqc.info/docs/reports/customisation/#listing-software-versions))
 
 Huge thanks to [@pontushojer](https://https://github.com/pontushojer) for the
-contribution ([#1927](https://github.com/MultiQC/MultiQC/pull/1927)).
-This idea goes way back to [issue #290](https://github.com/MultiQC/MultiQC/issues/290), made in 2016!
+contribution ([#1927](https://github.com/ewels/MultiQC/pull/1927)).
+This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/290), made in 2016!
 
 ### MultiQC updates
 
-- Removed `simplejson` unused dependency ([#1973](https://github.com/MultiQC/MultiQC/pull/1973))
+- Removed `simplejson` unused dependency ([#1973](https://github.com/ewels/MultiQC/pull/1973))
 - Give config `custom_plot_config` priority over column-specific settings set by modules
-- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/MultiQC/MultiQC/pull/1976))
+- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/ewels/MultiQC/pull/1976))
 - Fixed parsing of `plot_type: "html"` `data` in json custom content
 - Replace deprecated `pkg_resources`
-- [Fix](https://github.com/MultiQC/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/MultiQC/MultiQC/pull/2037)).
-- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/MultiQC/MultiQC/pull/2055)
-- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/MultiQC/MultiQC/pull/2058))
-- Fix table column color scaling then there are negative numbers ([1869](https://github.com/MultiQC/MultiQC/issues/1869))
-- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/MultiQC/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
+- [Fix](https://github.com/ewels/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/ewels/MultiQC/pull/2037)).
+- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/ewels/MultiQC/pull/2055)
+- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/ewels/MultiQC/pull/2058))
+- Fix table column color scaling then there are negative numbers ([1869](https://github.com/ewels/MultiQC/issues/1869))
+- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/ewels/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
 
 ### New Modules
 
@@ -208,36 +208,36 @@ This idea goes way back to [issue #290](https://github.com/MultiQC/MultiQC/issue
 ### Module updates
 
 - **BcfTools**
-  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/MultiQC/MultiQC/issues/2052))
+  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/ewels/MultiQC/issues/2052))
 - **Custom content**
-  - Don't convert sample IDs to floats ([#1883](https://github.com/MultiQC/MultiQC/issues/1883))
+  - Don't convert sample IDs to floats ([#1883](https://github.com/ewels/MultiQC/issues/1883))
 - **DRAGEN**
-  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/MultiQC/MultiQC/pull/1994))
+  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/ewels/MultiQC/pull/1994))
 - **FastQC**:
-  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/MultiQC/MultiQC/issues/2024))
+  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/ewels/MultiQC/issues/2024))
 - **Kaiju**:
-  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/MultiQC/MultiQC/pull/2023))
+  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/ewels/MultiQC/pull/2023))
 - **Kraken**
-  - Parametrize top-N through config ([#2060](https://github.com/MultiQC/MultiQC/pull/2060))
-  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/MultiQC/MultiQC/issues/1766)).
+  - Parametrize top-N through config ([#2060](https://github.com/ewels/MultiQC/pull/2060))
+  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/ewels/MultiQC/issues/1766)).
 - **Mosdepth**
-  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/MultiQC/MultiQC/issues/1978))
+  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/ewels/MultiQC/issues/1978))
   - Added the `perchrom_fraction_cutoff` option into the config to help avoid clutter in contig-level plots
   - Fix a bug happening when both `region` and `global` coverage histograms for a sample are available (i.e. when mosdepth was run with `--by`, see [mosdepth docs](https://github.com/brentp/mosdepth#usage)). In this case, data was effectively merged. Instead, summarise it separately and add a separate report section for the region-based coverage data.
-  - Do not fail when all input samples have no coverage ([#2005](https://github.com/MultiQC/MultiQC/pull/2005)).
+  - Do not fail when all input samples have no coverage ([#2005](https://github.com/ewels/MultiQC/pull/2005)).
 - **NanoStat**
-  - Support new format ([#1997](https://github.com/MultiQC/MultiQC/pull/1997)).
+  - Support new format ([#1997](https://github.com/ewels/MultiQC/pull/1997)).
 - **RSeQC**
-  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/MultiQC/MultiQC/issues/1985))
-  - Fix division by zero on all-zero input ([#2040](https://github.com/MultiQC/MultiQC/pull/2040))
+  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/ewels/MultiQC/issues/1985))
+  - Fix division by zero on all-zero input ([#2040](https://github.com/ewels/MultiQC/pull/2040))
 - **Samtools**
-  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/MultiQC/MultiQC/pull/1972))
+  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/ewels/MultiQC/pull/1972))
 - **Qualimap**
-  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/MultiQC/MultiQC/issues/2019))
+  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/ewels/MultiQC/issues/2019))
 - **WhatsHap**
-  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/MultiQC/MultiQC/pull/1981))
+  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/ewels/MultiQC/pull/1981))
 
-## [MultiQC v1.15](https://github.com/MultiQC/MultiQC/releases/tag/v1.15) - 2023-08-04
+## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
 
 #### Potential breaking change in some edge cases
 
@@ -254,13 +254,13 @@ for more information.
 
 ### MultiQC updates
 
-- Refactor file search for performance improvements ([#1904](https://github.com/MultiQC/MultiQC/pull/1904))
+- Refactor file search for performance improvements ([#1904](https://github.com/ewels/MultiQC/pull/1904))
 - Bump `log_filesize_limit` default (to skip large files in the search) from 10MB to 50MB.
-- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/MultiQC/MultiQC/issues/1739))
-- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/MultiQC/MultiQC/issues/1861))
+- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/ewels/MultiQC/issues/1739))
+- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/ewels/MultiQC/issues/1861))
 - Don't print DOI in module if it's set to an empty string.
-- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/MultiQC/MultiQC/pull/1891))
-- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/MultiQC/MultiQC/issues/1866))
+- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/ewels/MultiQC/pull/1891))
+- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/ewels/MultiQC/issues/1866))
 - New back-end to preview + deploy the new website when the docs are edited.
 - Fixed a _lot_ of broken links in the documentation from the new website change in structure.
 
@@ -274,46 +274,46 @@ for more information.
 ### Module updates
 
 - **Conpair**
-  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/MultiQC/MultiQC/issues/1851))
+  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/ewels/MultiQC/issues/1851))
 - **Cell Ranger**
-  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/MultiQC/MultiQC/issues/1853), [#1871](https://github.com/MultiQC/MultiQC/issues/1871))
+  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/ewels/MultiQC/issues/1853), [#1871](https://github.com/ewels/MultiQC/issues/1871))
 - **DRAGEN**
-  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/MultiQC/MultiQC/issues/1844))
-  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/MultiQC/MultiQC/pull/1958))
+  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/ewels/MultiQC/issues/1844))
+  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/ewels/MultiQC/pull/1958))
 - **filtlong**
-  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/MultiQC/MultiQC/issues/1843))
+  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/ewels/MultiQC/issues/1843))
 - **GATK**
   - Adds support for [AnalyzeSaturationMutagenesis submodule](https://gatk.broadinstitute.org/hc/en-us/articles/360037594771-AnalyzeSaturationMutagenesis-BETA-)
 - **HUMID**
-  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/MultiQC/MultiQC/issues/1856))
+  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/ewels/MultiQC/issues/1856))
 - **Mosdepth**
-  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Fill in missing values for general stats table ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
-  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/MultiQC/MultiQC/issues/1960))
+  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Fill in missing values for general stats table ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
+  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/ewels/MultiQC/issues/1960))
 - **Picard**
-  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/MultiQC/MultiQC/issues/1888))
-  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/MultiQC/MultiQC/pull/1928))
+  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/ewels/MultiQC/issues/1888))
+  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/ewels/MultiQC/pull/1928))
 - **Porechop**
-  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/MultiQC/MultiQC/issues/1850))
+  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/ewels/MultiQC/issues/1850))
   - Added report section listing samples that had no adapters trimmed
 - **RSeQC**
-  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/MultiQC/MultiQC/issues/1735))
+  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/ewels/MultiQC/issues/1735))
 - **UMI-tools**
-  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/MultiQC/MultiQC/issues/1845))
+  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/ewels/MultiQC/issues/1845))
 
-## [MultiQC v1.14](https://github.com/MultiQC/MultiQC/releases/tag/v1.14) - 2023-01-08
+## [MultiQC v1.14](https://github.com/ewels/MultiQC/releases/tag/v1.14) - 2023-01-08
 
 ### MultiQC new features
 
-- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/MultiQC/MultiQC/pull/1541), [#1541](https://github.com/MultiQC/MultiQC/pull/1541))
-- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/MultiQC/MultiQC/pull/1835))
-- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/MultiQC/MultiQC/issues/915))
+- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/ewels/MultiQC/pull/1541), [#1541](https://github.com/ewels/MultiQC/pull/1541))
+- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/ewels/MultiQC/pull/1835))
+- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/ewels/MultiQC/issues/915))
 - Add CI testing for Python 3.10 and 3.11
-- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/MultiQC/MultiQC/pull/1668))
+- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/ewels/MultiQC/pull/1668))
 - Parsing output file column headers is much faster.
 
 ### MultiQC code cleanup
@@ -325,12 +325,12 @@ for more information.
 
 ### MultiQC updates
 
-- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/MultiQC/MultiQC/issues/1722))
-- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/MultiQC/MultiQC/issues/1642))
-- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/MultiQC/MultiQC/issues/1638))
-- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/MultiQC/MultiQC/issues/1308))
+- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
+- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
+- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
+- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/ewels/MultiQC/issues/1308))
 - Fix sorting of table columns with text values
-- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
+- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/ewels/MultiQC/issues/1540))
 - New logos! MultiQC is now developed and maintained at [Seqera Labs](https://seqera.io/). Updated logos and email addresses accordingly.
 
 ### New Modules
@@ -370,63 +370,63 @@ for more information.
 ### Module updates
 
 - **Bcftools stats**
-  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/MultiQC/MultiQC/pull/1777))
-  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/MultiQC/MultiQC/issues/1832))
+  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/ewels/MultiQC/pull/1777))
+  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/ewels/MultiQC/issues/1832))
 - **BCL Convert**
-  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/MultiQC/MultiQC/issues/1697))
-  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/MultiQC/MultiQC/issues/1774))
+  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/ewels/MultiQC/issues/1774))
   - Handle single-index paired-end data correctly
-  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/MultiQC/MultiQC/pull/1709))
+  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/ewels/MultiQC/pull/1709))
 - **BUSCO**
   - Update BUSCO pass/warning/fail scheme to be more clear for users
 - **Bustools**
   - Show median reads per barcode statistic
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
-  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
-  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
+  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
+  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
 - **fastp**
-  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/MultiQC/MultiQC/issues/1744))
-  - Don't crash for invalid JSON files ([#1652](https://github.com/MultiQC/MultiQC/issues/1652))
+  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/ewels/MultiQC/issues/1744))
+  - Don't crash for invalid JSON files ([#1652](https://github.com/ewels/MultiQC/issues/1652))
 - **FastQC**
-  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/MultiQC/MultiQC/pull/1745))
+  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/ewels/MultiQC/pull/1745))
 - **Kaiju**
-  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
+  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/ewels/MultiQC/issues/1540))
 - **Kallisto**
-  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/MultiQC/MultiQC/issues/1746))
+  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/ewels/MultiQC/issues/1746))
 - **Kraken**
-  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/MultiQC/MultiQC/pull/1779))
+  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/ewels/MultiQC/pull/1779))
   - Make heatmap full width
-  - Handle empty kreports gracefully ([#1637](https://github.com/MultiQC/MultiQC/issues/1637))
-  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/MultiQC/MultiQC/pull/1639))
+  - Handle empty kreports gracefully ([#1637](https://github.com/ewels/MultiQC/issues/1637))
+  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/ewels/MultiQC/pull/1639))
 - **malt**
-  - Fixed division by 0 in malt module ([#1683](https://github.com/MultiQC/MultiQC/issues/1683))
+  - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
 - **miRTop**
-  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/MultiQC/MultiQC/issues/1778))
+  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/ewels/MultiQC/issues/1778))
 - **Mosdepth**
-  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/MultiQC/MultiQC/pull/1810))
+  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/ewels/MultiQC/pull/1810))
 - **Picard**
   - HsMetrics: Allow custom columns in General Stats too, with `HsMetrics_genstats_table_cols` and `HsMetrics_genstats_table_cols_hidden`
 - **Qualimap**
-  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/MultiQC/MultiQC/pull/1798))
-  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/MultiQC/MultiQC/issues/1780))
+  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/ewels/MultiQC/pull/1798))
+  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780))
 - **RSeQC**
-  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/MultiQC/MultiQC/pull/1792))
+  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/ewels/MultiQC/pull/1792))
 - **Sambamba Markdup**
-  - Catch zero division in sambamba markdup ([#1654](https://github.com/MultiQC/MultiQC/issues/1654))
+  - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
 - **Samtools**
-  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/MultiQC/MultiQC/issues/1733))
+  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/ewels/MultiQC/issues/1733))
 - **VEP**
-  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/MultiQC/MultiQC/issues/1681))
+  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/ewels/MultiQC/issues/1681))
 
-## [MultiQC v1.13](https://github.com/MultiQC/MultiQC/releases/tag/v1.13) - 2022-09-08
+## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
 
 ### MultiQC updates
 
 - Major spruce of the command line help, using the new [rich-click](https://github.com/ewels/rich-click) package
 - Drop some of the Python 2k compatability code (eg. custom requirements)
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/MultiQC/MultiQC/issues/1643))
+  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/ewels/MultiQC/issues/1643))
 - Added new config option `custom_table_header_config` to override any config for any table header
 - Fixed edge-case bug in custom content where a `description` that doesn't terminate in `.` gave duplicate section descriptions.
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
@@ -438,53 +438,53 @@ for more information.
 ### Module updates
 
 - **AdapterRemoval**
-  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/MultiQC/MultiQC/issues/1647))
+  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
 - **VEP**
-  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/MultiQC/MultiQC/pull/1656))
+  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
 - **Custom content**
-  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/MultiQC/MultiQC/issues/1629))
-  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/MultiQC/MultiQC/issues/1686))
-  - Fix crash when `info` isn't set ([#1688](https://github.com/MultiQC/MultiQC/issues/1688))
+  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
+  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/ewels/MultiQC/issues/1686))
+  - Fix crash when `info` isn't set ([#1688](https://github.com/ewels/MultiQC/issues/1688))
 - **Nanostat**
-  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/MultiQC/MultiQC/pull/1659))
-  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/MultiQC/MultiQC/issues/1717))
+  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
+  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/ewels/MultiQC/issues/1717))
 - **Pangolin**
-  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/MultiQC/MultiQC/pull/1660))
+  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
 - **Somalier**
-  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/MultiQC/MultiQC/pull/1670))
+  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
 - **miRTop**
-  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/MultiQC/MultiQC/issues/1712))
-  - Fix module crashing due to zero division ([#1719](https://github.com/MultiQC/MultiQC/issues/1719))
+  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/ewels/MultiQC/issues/1712))
+  - Fix module crashing due to zero division ([#1719](https://github.com/ewels/MultiQC/issues/1719))
 - **FastQC**
-  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/MultiQC/MultiQC/pull/1725))
+  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/ewels/MultiQC/pull/1725))
 
-## [MultiQC v1.12](https://github.com/MultiQC/MultiQC/releases/tag/v1.12) - 2022-02-08
+## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
 
 ### MultiQC - new features
 
-- Added option to customise default plot height in plot config ([#1432](https://github.com/MultiQC/MultiQC/issues/1432))
-- Added `--no-report` flag to skip report generation ([#1462](https://github.com/MultiQC/MultiQC/issues/1462))
-- Added support for priting tool DOI in report sections ([#1177](https://github.com/MultiQC/MultiQC/issues/1177))
-- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/MultiQC/MultiQC/pull/1573))
-- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/MultiQC/MultiQC/pull/1576))
-- Added support for customising table column names ([#1255](https://github.com/MultiQC/MultiQC/issues/1255))
+- Added option to customise default plot height in plot config ([#1432](https://github.com/ewels/MultiQC/issues/1432))
+- Added `--no-report` flag to skip report generation ([#1462](https://github.com/ewels/MultiQC/issues/1462))
+- Added support for priting tool DOI in report sections ([#1177](https://github.com/ewels/MultiQC/issues/1177))
+- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/ewels/MultiQC/pull/1573))
+- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/ewels/MultiQC/pull/1576))
+- Added support for customising table column names ([#1255](https://github.com/ewels/MultiQC/issues/1255))
 
 ### MultiQC - updates
 
-- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/MultiQC/MultiQC/issues/1463))
+- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/ewels/MultiQC/issues/1463))
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/MultiQC/MultiQC/issues/1141))
-  - Init/reset global state between runs ([#1596](https://github.com/MultiQC/MultiQC/pull/1596))
-- Added commonly missing functions to several modules ([#1468](https://github.com/MultiQC/MultiQC/issues/1468))
+  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/ewels/MultiQC/issues/1141))
+  - Init/reset global state between runs ([#1596](https://github.com/ewels/MultiQC/pull/1596))
+- Added commonly missing functions to several modules ([#1468](https://github.com/ewels/MultiQC/issues/1468))
 - Wrote new script to check for the above function calls that should be in every module (`.github/workflows/code_checks.py`), runs on GitHub actions CI
-- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/MultiQC/MultiQC/issues/761))
-- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/MultiQC/MultiQC/pull/1579))
-- Fixed a problem with numeric filenames ([#1606](https://github.com/MultiQC/MultiQC/issues/1606))
-- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/MultiQC/MultiQC/issues/1568))
-- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/MultiQC/MultiQC/issues/1598))
-- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/MultiQC/MultiQC/issues/1539))
+- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/ewels/MultiQC/issues/761))
+- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/ewels/MultiQC/pull/1579))
+- Fixed a problem with numeric filenames ([#1606](https://github.com/ewels/MultiQC/issues/1606))
+- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/ewels/MultiQC/issues/1568))
+- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/ewels/MultiQC/issues/1598))
+- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/ewels/MultiQC/issues/1539))
 
 ### New Modules
 
@@ -498,75 +498,75 @@ for more information.
 ### Module feature additions
 
 - **BBMap**
-  - Added handling for `qchist` output ([#1021](https://github.com/MultiQC/MultiQC/issues/1021))
+  - Added handling for `qchist` output ([#1021](https://github.com/ewels/MultiQC/issues/1021))
 - **bcftools**
-  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/MultiQC/MultiQC/issues/1087))
+  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/ewels/MultiQC/issues/1087))
 - **Mosdepth**
-  - Added mean coverage [#1566](https://github.com/MultiQC/MultiQC/issues/1566)
+  - Added mean coverage [#1566](https://github.com/ewels/MultiQC/issues/1566)
 - **NanoStat**
-  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/MultiQC/MultiQC/issues/1547))
+  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/ewels/MultiQC/issues/1547))
 
 ### Module updates
 
 - **BBMap**
-  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/MultiQC/MultiQC/issues/1556))
+  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/ewels/MultiQC/issues/1556))
 - **BCL Convert**
-  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/MultiQC/MultiQC/issues/1563))
+  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/ewels/MultiQC/issues/1563))
 - **bowtie**
-  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/MultiQC/MultiQC/issues/1615))
+  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/ewels/MultiQC/issues/1615))
 - **CCS**
-  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/MultiQC/MultiQC/pull/1486))
-  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/MultiQC/MultiQC/issues/1583))
+  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/ewels/MultiQC/pull/1486))
+  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/ewels/MultiQC/issues/1583))
 - **Custom content**
-  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/MultiQC/MultiQC/issues/1515))
-  - Use filename for section header in files with no headers ([#1550](https://github.com/MultiQC/MultiQC/issues/1550))
-  - Sort custom content bargraph data by default ([#1412](https://github.com/MultiQC/MultiQC/issues/1412))
-  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/MultiQC/MultiQC/issues/1194))
+  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/ewels/MultiQC/issues/1515))
+  - Use filename for section header in files with no headers ([#1550](https://github.com/ewels/MultiQC/issues/1550))
+  - Sort custom content bargraph data by default ([#1412](https://github.com/ewels/MultiQC/issues/1412))
+  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/ewels/MultiQC/issues/1194))
 - **DRAGEN**
-  - Fixed bug in sample name regular expression ([#1537](https://github.com/MultiQC/MultiQC/pull/1537))
+  - Fixed bug in sample name regular expression ([#1537](https://github.com/ewels/MultiQC/pull/1537))
 - **Fastp**
-  - Fixed % pass filter statistics ([#1574](https://github.com/MultiQC/MultiQC/issues/1574))
+  - Fixed % pass filter statistics ([#1574](https://github.com/ewels/MultiQC/issues/1574))
 - **FastQC**
-  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/MultiQC/MultiQC/issues/1488), [#1533](https://github.com/MultiQC/MultiQC/issues/1533))
+  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/ewels/MultiQC/issues/1488), [#1533](https://github.com/ewels/MultiQC/issues/1533))
   - Clarify general statistics table header for length
 - **goleft/indexcov**
-  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/MultiQC/MultiQC/issues/1586))
+  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/ewels/MultiQC/issues/1586))
 - **HiCPro**
-  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/MultiQC/MultiQC/issues/1366))
+  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/ewels/MultiQC/issues/1366))
 - **Lima**
-  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/MultiQC/MultiQC/pull/1483))
+  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/ewels/MultiQC/pull/1483))
 - **miRTrace**
-  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/MultiQC/MultiQC/pull/1263))
+  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/ewels/MultiQC/pull/1263))
 - **Mosdepth**
-  - Fixed issue [#1568](https://github.com/MultiQC/MultiQC/issues/1568)
+  - Fixed issue [#1568](https://github.com/ewels/MultiQC/issues/1568)
   - Fixed a bug when reporting per contig coverage
 - **Picard**
-  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/MultiQC/MultiQC/pull/1611))
+  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/ewels/MultiQC/pull/1611))
 - **Qualimap**
-  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/MultiQC/MultiQC/issues/1492))
+  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/ewels/MultiQC/issues/1492))
 - **QUAST**
   - Clarify general statistics table header for length
 - **RSeQC**
-  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/MultiQC/MultiQC/issues/1484))
-  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/MultiQC/MultiQC/issues/1582))
-  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/MultiQC/MultiQC/issues/1604))
-  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/MultiQC/MultiQC/issues/1571))
+  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
+  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/ewels/MultiQC/issues/1582))
+  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/ewels/MultiQC/issues/1604))
+  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/ewels/MultiQC/issues/1571))
 - **Sambamba**
-  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/MultiQC/MultiQC/issues/1617))
+  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/ewels/MultiQC/issues/1617))
 - **Skewer**
-  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/MultiQC/MultiQC/issues/1622))
+  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/ewels/MultiQC/issues/1622))
 - **Somalier**
-  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/MultiQC/MultiQC/issues/1546))
+  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/ewels/MultiQC/issues/1546))
 - **VEP**
-  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/MultiQC/MultiQC/issues/1597))
+  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/ewels/MultiQC/issues/1597))
 
-## [MultiQC v1.11](https://github.com/MultiQC/MultiQC/releases/tag/v1.11) - 2021-07-05
+## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
 
 ### MultiQC new features
 
-- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/MultiQC/MultiQC/issues/1427))
+- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/ewels/MultiQC/issues/1427))
 - Added new `--replace-names` / config `sample_names_replace` option to replace sample names during report generation
-- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949), [#890](https://github.com/MultiQC/MultiQC/issues/890), [#864](https://github.com/MultiQC/MultiQC/issues/864), [#998](https://github.com/MultiQC/MultiQC/issues/998), [#1390](https://github.com/MultiQC/MultiQC/issues/1390))
+- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/ewels/MultiQC/issues/949), [#890](https://github.com/ewels/MultiQC/issues/890), [#864](https://github.com/ewels/MultiQC/issues/864), [#998](https://github.com/ewels/MultiQC/issues/998), [#1390](https://github.com/ewels/MultiQC/issues/1390))
   - Forces modules to use the log filename for the sample identifier, even if the module usually takes this from the file contents
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
@@ -577,9 +577,9 @@ for more information.
 - Make the module crash tracebacks much prettier using `rich`
 - Refine the cli log output a little (nicely formatted header line + drop the `[INFO]`)
 - Added docs describing tools for downstream analysis of MultiQC outputs.
-- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/MultiQC/MultiQC/issues/1413))
-- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/MultiQC/MultiQC/issues/1416))
-- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/MultiQC/MultiQC/issues/1254))
+- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/ewels/MultiQC/issues/1413))
+- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/ewels/MultiQC/issues/1416))
+- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/ewels/MultiQC/issues/1254))
 - Fix the `mqc_colours` util function to lighten colours even when passing categorical or single-length lists.
 - Bugfix for Custom Content, using YAML configuration (eg. section headers) for images should now work
 
@@ -607,22 +607,22 @@ for more information.
   - Rapid haploid variant calling and core genome alignment.
 - [**VEP**](https://www.ensembl.org/info/docs/tools/vep/index.html)
   - Added MultiQC module to add summary statistics of Ensembl VEP annotations.
-  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/MultiQC/MultiQC/issues/1446))
+  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
 
 ### Module feature additions
 
 - **Cutadapt**
-  - Added support for linked adapters [#1329](https://github.com/MultiQC/MultiQC/issues/1329)]
+  - Added support for linked adapters [#1329](https://github.com/ewels/MultiQC/issues/1329)]
   - Parse whether trimming was 5' or 3' for _Lengths of Trimmed Sequences_ plot where possible
 - **Mosdepth**
   - Include or exclude contigs based on patterns for coverage-per-contig plots
 - **Picard**
-  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/MultiQC/MultiQC/pull/1336))
+  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/ewels/MultiQC/pull/1336))
   - New `insertsize_xmax` configuration option to limit the plotted maximum insert size for `InsertSizeMetrics`
 - **Qualimap**
-  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
+  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/ewels/MultiQC/issues/1258))
 - **RSeQC**
-  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/MultiQC/MultiQC/issues/737))
+  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/ewels/MultiQC/issues/737))
 
 ### Module updates
 
@@ -633,68 +633,68 @@ for more information.
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
 - **Cutadapt**
-  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/MultiQC/MultiQC/issues/1328))
-  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949))
+  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/ewels/MultiQC/issues/1328))
+  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/ewels/MultiQC/issues/949))
 - **Dragen**
-  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/MultiQC/MultiQC/issues/1374))
+  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
 - **fastp**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/MultiQC/MultiQC/issues/1444))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
 - **FastQC**
-  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/MultiQC/MultiQC/issues/1444))
+  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/ewels/MultiQC/issues/1444))
 - **Flexbar**
-  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/MultiQC/MultiQC/issues/1407))
+  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/ewels/MultiQC/issues/1407))
 - **Kraken**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/MultiQC/MultiQC/issues/1440))
-  - Updated search patterns to handle edge case ([#1428](https://github.com/MultiQC/MultiQC/issues/1428))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/ewels/MultiQC/issues/1440))
+  - Updated search patterns to handle edge case ([#1428](https://github.com/ewels/MultiQC/issues/1428))
 - **Mosdepth**
   - Show barplot instead of line graph for coverage-per-contig plot if there is only one contig.
 - **Picard**
-  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/MultiQC/MultiQC/issues/1408))
-  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/MultiQC/MultiQC/issues/1414))
-  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/MultiQC/MultiQC/issues/1296))
+  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
+  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
+  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/ewels/MultiQC/issues/1296))
 - **qc3C**
   - Updated module to not fail on older field names.
 - **Qualimap**
-  - Fixed wrong units in tool tip label ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
+  - Fixed wrong units in tool tip label ([#1258](https://github.com/ewels/MultiQC/issues/1258))
 - **QUAST**
-  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/MultiQC/MultiQC/issues/1442))
+  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
 - **Sentieon**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/MultiQC/MultiQC/issues/1420))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
 - **RSEM**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/MultiQC/MultiQC/issues/1040))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/ewels/MultiQC/issues/1040))
 - **RSeQC**
-  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/MultiQC/MultiQC/issues/1457))
+  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/ewels/MultiQC/issues/1457))
 
-## [MultiQC v1.10.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.10.1) - 2021-04-01
+## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 
 ### MultiQC updates
 
 - Dropped the `Skipping search pattern` log message from a warning to debug
-- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/MultiQC/MultiQC/issues/1264))
-- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/MultiQC/MultiQC/issues/1257))
+- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/ewels/MultiQC/issues/1264))
+- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/ewels/MultiQC/issues/1257))
 - Allow scientific notation numbers in colour scheme generation
   - Fixed bug with very small minimum numbers that only revelead itself after a bugfix done in the v1.10 release
-- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/MultiQC/MultiQC/issues/1274))
-- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/MultiQC/MultiQC/issues/1393))
-- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/MultiQC/MultiQC/issues/1395))
+- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/ewels/MultiQC/issues/1274))
+- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/ewels/MultiQC/issues/1393))
+- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/ewels/MultiQC/issues/1395))
 
 #### Module updates
 
 - **bcftools**
-  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/MultiQC/MultiQC/issues/1400))
+  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/ewels/MultiQC/issues/1400))
 - **bowtie2**
-  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/MultiQC/MultiQC/issues/1230))
+  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/ewels/MultiQC/issues/1230))
 - **Deeptools**
-  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/MultiQC/MultiQC/issues/1317))
-  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/MultiQC/MultiQC/issues/1275))
+  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/ewels/MultiQC/issues/1317))
+  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/ewels/MultiQC/issues/1275))
 - **FastQC**
-  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/MultiQC/MultiQC/issues/1246))
+  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/ewels/MultiQC/issues/1246))
 - **Picard**
-  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/MultiQC/MultiQC/issues/1397))
+  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/ewels/MultiQC/issues/1397))
 - **Somalier**
-  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/MultiQC/MultiQC/issues/1234))
+  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/ewels/MultiQC/issues/1234))
 
-## [MultiQC v1.10](https://github.com/MultiQC/MultiQC/releases/tag/v1.10) - 2021-03-08
+## [MultiQC v1.10](https://github.com/ewels/MultiQC/releases/tag/v1.10) - 2021-03-08
 
 ### Update for developers: Code linting
 
@@ -729,7 +729,7 @@ For further information, please see the [documentation](https://multiqc.info/doc
     allowes module developers to format table cell values as labels.
 - New CI test looks for git merge markers in files
 - Beautiful new [progress bar](https://rich.readthedocs.io/en/stable/progress.html) from the amazing [willmcgugan/rich](https://github.com/willmcgugan/rich) package.
-- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/MultiQC/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
+- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/ewels/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
 - Added `timeout-minutes: 10` to the CI test workflow to check that changes aren't negatively affecting run time too much.
 - New table header option `bars_zero_centrepoint` to treat `0` as zero width bars and plot bar length based on absolute values
 
@@ -757,29 +757,29 @@ For further information, please see the [documentation](https://multiqc.info/doc
 #### Module updates
 
 - **DRAGEN**
-  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/MultiQC/MultiQC/issues/1223))
-  - Added support for whole-exome / targetted data ([#1290](https://github.com/MultiQC/MultiQC/issues/1290))
+  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/ewels/MultiQC/issues/1223))
+  - Added support for whole-exome / targetted data ([#1290](https://github.com/ewels/MultiQC/issues/1290))
 - **featureCounts**
-  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/MultiQC/MultiQC/issues/1022))
+  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/ewels/MultiQC/issues/1022))
 - **fgbio**
-  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/MultiQC/MultiQC/pull/1251))
-  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/MultiQC/MultiQC/pull/1304))
+  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/ewels/MultiQC/pull/1251))
+  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
 - **Fastp**
-  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/MultiQC/MultiQC/pull/1313))
+  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/ewels/MultiQC/pull/1313))
 - **GATK**
   - Add support for the creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
 - **hap.py**
-  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/MultiQC/MultiQC/issues/1241))
+  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/ewels/MultiQC/issues/1241))
 - **indexcov**
-  - Fixed bug when making the PED file plots ([#1265](https://github.com/MultiQC/MultiQC/issues/1265))
+  - Fixed bug when making the PED file plots ([#1265](https://github.com/ewels/MultiQC/issues/1265))
 - **interop**
   - Added the `% Occupied` metric to `Read Metrics per Lane` table which is reported for NovaSeq and iSeq platforms.
 - **Kaiju**
-  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/MultiQC/MultiQC/issues/1217))
-  - Rework barplot, add top 5 taxons ([#1219](https://github.com/MultiQC/MultiQC/issues/1219))
+  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/ewels/MultiQC/issues/1217))
+  - Rework barplot, add top 5 taxons ([#1219](https://github.com/ewels/MultiQC/issues/1219))
 - **Kraken**
-  - Fix `ZeroDivisionError` ([#1276](https://github.com/MultiQC/MultiQC/issues/1276))
-  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/MultiQC/MultiQC/pull/1380))
+  - Fix `ZeroDivisionError` ([#1276](https://github.com/ewels/MultiQC/issues/1276))
+  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/ewels/MultiQC/pull/1380))
 - **MALT**
   - Fix y-axis labelling in bargraphs
 - **MACS2**
@@ -788,21 +788,21 @@ For further information, please see the [documentation](https://multiqc.info/doc
   - Enable prepending of directory to sample names
   - Display contig names in _Coverage per contig_ plot tooltip
 - **Picard**
-  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/MultiQC/MultiQC/issues/1212))
-  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/MultiQC/MultiQC/issues/1310))
+  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/ewels/MultiQC/issues/1212))
+  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/ewels/MultiQC/issues/1310))
   - Make `WgsMetrics` histogram smoothed if more than 1000 data points (avoids huge plots that crash the browser)
   - Multiple new config options for `WgsMetrics` to customise coverage histogram and speed up MultiQC with very high coverage files.
-  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/MultiQC/MultiQC/issues/1293))
-  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/MultiQC/MultiQC/issues/1327))
+  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/ewels/MultiQC/issues/1293))
+  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/ewels/MultiQC/issues/1327))
 - **PycoQC**
-  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/MultiQC/MultiQC/issues/1214))
+  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
 - **Rockhopper**
-  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
+  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/ewels/MultiQC/issues/1333))
   - Fix issue properly parsing multiple samples within a single Rockhopper summary file
 - **Salmon**
   - Only try to generate a plot for fragment length if the data was found.
 - **verifyBamID**
-  - Fix `CHIP` value detection ([#1316](https://github.com/MultiQC/MultiQC/pull/1316)).
+  - Fix `CHIP` value detection ([#1316](https://github.com/ewels/MultiQC/pull/1316)).
 
 #### New Custom Content features
 
@@ -813,12 +813,12 @@ For further information, please see the [documentation](https://multiqc.info/doc
 
 #### Bug Fixes
 
-- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
+- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/ewels/MultiQC/issues/1333))
 - Fixed MatPlotLib warning: `FixedFormatter should only be used together with FixedLocator`
 - Fixed long-standing min/max bug with shared minimum values for table columns using `shared_key`
 - Made table colour schemes work with negative numbers (don't strip `-` from values when making scheme)
 
-## [MultiQC v1.9](https://github.com/MultiQC/MultiQC/releases/tag/v1.9) - 2020-05-30
+## [MultiQC v1.9](https://github.com/ewels/MultiQC/releases/tag/v1.9) - 2020-05-30
 
 #### Dropped official support for Python 2
 
@@ -850,8 +850,8 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Still testing on both Linux and Windows, with multiple versions of Python
   - CI tests should now run automatically for anyone who forks the MultiQC repository
 - Linting with `--lint` now checks line graphs as well as bar graphs
-- New `gathered` template with no tool name sections ([#1119](https://github.com/MultiQC/MultiQC/issues/1119))
-- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/MultiQC/MultiQC/issues/1125))
+- New `gathered` template with no tool name sections ([#1119](https://github.com/ewels/MultiQC/issues/1119))
+- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/ewels/MultiQC/issues/1125))
   - Buttons control the report toolbox Show/Hide tool, filtering your samples
   - Allows reports to be pre-configured based on a supplied list of sample names at report-generation time.
 - Line graphs can now have `Log10` buttons (same functionality as bar graphs)
@@ -864,9 +864,9 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Should help to prevent duplicates requiring `-1` suffixes when running a module multiple times
 - New heatmap plot config options `xcats_samples` and `ycats_samples`
   - If set to `False`, the report toolbox options (_highlight_, _rename_, _show/hide_) do not affect that axis.
-  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/MultiQC/MultiQC/issues/1172))
+  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/ewels/MultiQC/issues/1172))
 - Report header time and analysis paths can now be hidden
-  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/MultiQC/MultiQC/issues/1113))
+  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/ewels/MultiQC/issues/1113))
 - New search pattern key `skip: true` to skip specific searches when modules look for a lot of different files (eg. Picard).
 - New `--profile-runtime` command line option (`config.profile_runtime`) to give analysis of how long the report takes to be generated
   - Plots of the file search results and durations are added to the end of the MultiQC report as a special module called _Run Time_
@@ -875,7 +875,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Defaults to `true`, set to `false` to also show any data columns that are not defined as headers
   - Useful as allows table-wide defaults to be set with column-specific overrides
 - New `module` key allowed for `config.extra_fn_clean_exts` and `config.fn_clean_exts`
-  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/MultiQC/MultiQC/issues/905))
+  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/ewels/MultiQC/issues/905))
 
 #### New Custom Content features
 
@@ -883,10 +883,10 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Native handling of HTML snippets as files, no MultiQC config or YAML file required.
   - Also with embedded custom content configuration at the start of the file as a HTML comment.
 - Add ability to group custom-content files into report sections
-  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/MultiQC/MultiQC/issues/1008))
+  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/ewels/MultiQC/issues/1008))
 - Custom Content files can now be configured using `custom_data`, without giving search patterns or data
-  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/MultiQC/MultiQC/issues/1026))
-  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/MultiQC/MultiQC/issues/1205))
+  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/ewels/MultiQC/issues/1026))
+  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/ewels/MultiQC/issues/1205))
 
 #### New Modules
 
@@ -906,7 +906,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [**MultiVCFAnalyzer**](https://github.com/alexherbig/multivcfanalyzer)
   - Combining multiple VCF files into one coherent report and format for downstream analysis.
 - **Picard** - new submodules for `QualityByCycleMetrics`, `QualityScoreDistributionMetrics` & `QualityYieldMetrics`
-  - See [#1116](https://github.com/MultiQC/MultiQC/issues/1114)
+  - See [#1116](https://github.com/ewels/MultiQC/issues/1114)
 - [**Rockhopper**](https://cs.wellesley.edu/~btjaden/Rockhopper/)
   - RNA-seq tool for bacteria, includes bar plot showing where features map.
 - [**Sickle**](https://github.com/najoshi/sickle)
@@ -921,13 +921,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **BISCUIT**
   - Major rewrite to work with new BISCUIT QC script (BISCUIT `v0.3.16+`)
     - This change breaks backwards-compatability with previous BISCUIT versions. If you are unable to upgrade BISCUIT, please use MultiQC v1.8.
-  - Fixed error when missing data in log files ([#1101](https://github.com/MultiQC/MultiQC/issues/1101))
+  - Fixed error when missing data in log files ([#1101](https://github.com/ewels/MultiQC/issues/1101))
 - **bcl2fastq**
-  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/MultiQC/MultiQC/issues/1094))
+  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
 - **BUSCO**
-  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/MultiQC/MultiQC/issues/1163))
+  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/ewels/MultiQC/issues/1163))
 - **Cutadapt**
-  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/MultiQC/MultiQC/issues/1198))
+  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/ewels/MultiQC/issues/1198))
 - **DamageProfiler**
   - Removes redundant typo in init name. This makes referring to the module's column consistent with other modules when customising general stats table.
 - **DeDup**
@@ -935,69 +935,69 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Fixes reporting errors - barplot total represents _mapped_ reads, not total reads in BAM file
   - New: Adds 'Post-DeDup Mapped Reads' column to general stats table.
 - **FastQC**
-  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/MultiQC/MultiQC/issues/1092))
-  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/MultiQC/MultiQC/issues/1129))
+  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/ewels/MultiQC/issues/1092))
+  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/ewels/MultiQC/issues/1129))
 - **FastQ Screen**
-  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
-  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
+  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
+  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
   - New plot for _Bisulfite Reads_, if data is present
   - Categories in main plot are now sorted by the total read count and hidden if 0 across all samples
 - **fgbio**
   - New: Plot error rate by read position from `ErrorRateByReadPosition`
-  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/MultiQC/MultiQC/pull/1147))
+  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/ewels/MultiQC/pull/1147))
 - **FLASh**
-  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/MultiQC/MultiQC/issues/1173))
+  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/ewels/MultiQC/issues/1173))
 - **GATK**
-  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/MultiQC/MultiQC/issues/1158))
+  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/ewels/MultiQC/issues/1158))
 - **MTNucRatioCalculator**
   - Fixed misleading value suffix in general stats table
 - **Picard MarkDuplicates**
   - **Major change** - previously, if multiple libraries (read-groups) were found then only the first would be used and all others ignored. Now, values from all libraries are merged and `PERCENT_DUPLICATION` and `ESTIMATED_LIBRARY_SIZE` are recalculated. Libraries can be kept as separate samples with a new MultiQC configuration option - `picard_config: markdups_merge_multiple_libraries: False`
-  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/MultiQC/MultiQC/issues/1142))
+  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/ewels/MultiQC/issues/1142))
 - **Picard HsMetrics**
-  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/MultiQC/MultiQC/issues/831))
+  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/ewels/MultiQC/issues/831))
 - **Picard WgsMetrics**
-  - Updated parsing code to recognise new java class string ([#1114](https://github.com/MultiQC/MultiQC/issues/1114))
+  - Updated parsing code to recognise new java class string ([#1114](https://github.com/ewels/MultiQC/issues/1114))
 - **QualiMap**
-  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/MultiQC/MultiQC/issues/1082), [#1077](https://github.com/MultiQC/MultiQC/issues/1082)
+  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/ewels/MultiQC/issues/1082), [#1077](https://github.com/ewels/MultiQC/issues/1082)
 - **RSeqC**
-  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/MultiQC/MultiQC/issues/844))
-  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/MultiQC/MultiQC/issues/1133))
+  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/ewels/MultiQC/issues/844))
+  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/ewels/MultiQC/issues/1133))
 - **RNASeQC2**
   - Updated to handle the parsing metric files from the [newer rewrite of RNA-SeqQC](https://github.com/broadinstitute/rnaseqc).
 - **Samblaster**
-  - Improved parsing to handle variable whitespace ([#1176](https://github.com/MultiQC/MultiQC/issues/1176))
+  - Improved parsing to handle variable whitespace ([#1176](https://github.com/ewels/MultiQC/issues/1176))
 - **Samtools**
-  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/MultiQC/MultiQC/issues/1076](https://github.com/MultiQC/MultiQC/issues/1076)).
-  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/MultiQC/MultiQC/issues/1118))
+  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
+  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
   - Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
 - **sortmerna**
-  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/MultiQC/MultiQC/issues/1121))
+  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
 - **sexdeterrmine**
   - Added a scatter plot of relative X- vs Y-coverage to the generated report.
 - **VerifyBAMID**
-  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/MultiQC/MultiQC/issues/1112))
+  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/ewels/MultiQC/issues/1112))
 
 #### Bug Fixes
 
 - Added a new test to check that modules work correctly with `--ignore-samples`. A lot of them didn't:
   - `Mosdepth`, `conpair`, `Qualimap BamQC`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
   - These modules have now all been fixed and `--ignore-samples` should work as you expect for whatever data you have.
-- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/MultiQC/MultiQC/issues/1130))
+- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/ewels/MultiQC/issues/1130))
 - Made folder naming behaviour of `multiqc_plots` consistent with `multiqc_data`
   - Incremental numeric suffixes now added if folder already exists
   - Plots folder properly renamed if using `-n`/`--filename`
-- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/MultiQC/MultiQC/issues/1136))
+- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/ewels/MultiQC/issues/1136))
 - Plot config `logswitch_active` now works as advertised
-- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/MultiQC/MultiQC/issues/1175))
+- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/ewels/MultiQC/issues/1175))
 - Fixed minor bug where tables could report negative numbers of columns in their header text
-- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/MultiQC/MultiQC/issues/1091))
-- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/MultiQC/MultiQC/issues/1071))
+- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/ewels/MultiQC/issues/1091))
+- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/ewels/MultiQC/issues/1071))
 - Replaced deprecated 'warn()' with 'warning()' of the logging module
 - Custom content now supports `section_extra` config key to add custom HTML after description.
 - Barplots with `ymax` set now ignore this when you click the _Percentages_ tab.
 
-## [MultiQC v1.8](https://github.com/MultiQC/MultiQC/releases/tag/v1.8) - 2019-11-20
+## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
 
 #### New Modules
 
@@ -1029,16 +1029,16 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **damageprofiler**
   - Added writing metrics to data output file.
 - **DeepTools**
-  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/MultiQC/MultiQC/issues/1057))
-  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/MultiQC/MultiQC/issues/1011))
+  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/ewels/MultiQC/issues/1057))
+  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/ewels/MultiQC/issues/1011))
   - Fixed bug that prevented running on only plotProfile files when no other deepTools files found.
 - **fastp**
-  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/MultiQC/MultiQC/issues/936))
+  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/ewels/MultiQC/issues/936))
 - **FastQC**
   - When including a FastQC section multiple times in one report, the Per Base Sequence Content heatmaps now behave as you would expect.
   - Added heatmap showing FastQC status checks for every section report across all samples
-  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/MultiQC/MultiQC/issues/777))
-  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/MultiQC/MultiQC/issues/742))
+  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/ewels/MultiQC/issues/777))
+  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/ewels/MultiQC/issues/742))
 - **FastQ Screen**
   - When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
   - Fixed MultiQC linting errors
@@ -1052,18 +1052,18 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Updated the format of the report to fits the changes which have been applied to the QC report of hicexplorer v3.3
   - Updated code to save parsed results to `multiqc_data`
 - **HTSeq**
-  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/MultiQC/MultiQC/issues/1006))
+  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/ewels/MultiQC/issues/1006))
 - **LongRanger**
   - Added support for the LongRanger Align pipeline.
 - **miRTrace**
-  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/MultiQC/MultiQC/issues/932))
+  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/ewels/MultiQC/issues/932))
 - **Peddy**
-  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/MultiQC/MultiQC/issues/1024))
+  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/ewels/MultiQC/issues/1024))
   - All plots (including _Het Check_ and _Sex Check_) now hidden if no data
 - **Picard**
   - Modified `OxoGMetrics` so that it will find files created with GATK `CollectMultipleMetrics` and `ConvertSequencingArtifactToOxoG`.
 - **QoRTs**
-  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/MultiQC/MultiQC/issues/821))
+  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/ewels/MultiQC/issues/821))
 - **Qualimap**
   - Added in mean coverage computation for general statistics report
   - Creates now tables of collected data in `multiqc_data`
@@ -1072,13 +1072,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **RSeQC**
   - Fixed bug where Junction Saturation plot when clicking a single sample was mislabelling the lines.
   - When including a RSeQC section multiple times in one report, clicking Junction Saturation plot now behaves as you would expect.
-  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/MultiQC/MultiQC/issues/1017))
+  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/ewels/MultiQC/issues/1017))
 - **Samtools**
   - Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 - **SnpEff**
   - Increased the default summary csv file-size limit from 1MB to 5MB.
 - **Stacks**
-  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/MultiQC/MultiQC/issues/906))
+  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/ewels/MultiQC/issues/906))
 - **TopHat**
   - Fixed bug where TopHat would try to run with files from Bowtie2 or HiSAT2 and crash
 - **VCFTools**
@@ -1103,22 +1103,22 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Windows support for base `multiqc` command
   - Support for running as a python module: `python -m multiqc .`
   - Support for running within a script: `import multiqc` and `multiqc.run('/path/to/files')`
-- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/MultiQC/MultiQC/issues/1044))
-- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/MultiQC/MultiQC/issues/541))
+- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/ewels/MultiQC/issues/1044))
+- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/ewels/MultiQC/issues/541))
 
 #### Bug Fixes
 
 - MultiQC now ignores all `.md5` files
 - Use `SafeLoader` for PyYaml load calls, avoiding recent warning messages.
 - Hide `multiqc_config_example.yaml` in the `test` directory to stop people from using it without modification.
-- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/MultiQC/MultiQC/issues))
-- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/MultiQC/MultiQC/issues/835))
+- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/ewels/MultiQC/issues))
+- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/ewels/MultiQC/issues/835))
 - Sample name cleaning: All sample names are now truncated to their basename, without a path.
   - This includes for `regex` and `replace` (before was only the default `truncate`).
   - Only affects modules that take sample names from file contents, such as cutadapt.
-  - See [#897](https://github.com/MultiQC/MultiQC/issues/897) for discussion.
+  - See [#897](https://github.com/ewels/MultiQC/issues/897) for discussion.
 
-## [MultiQC v1.7](https://github.com/MultiQC/MultiQC/releases/tag/v1.7) - 2018-12-21
+## [MultiQC v1.7](https://github.com/ewels/MultiQC/releases/tag/v1.7) - 2018-12-21
 
 #### New Modules
 
@@ -1144,7 +1144,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 #### Module updates
 
 - **AdapterRemoval**
-  - Handle error when zero bases are trimmed. See [#838](https://github.com/MultiQC/MultiQC/issues/838).
+  - Handle error when zero bases are trimmed. See [#838](https://github.com/ewels/MultiQC/issues/838).
 - **Bcl2fastq**
   - New plot showing the top twenty of undetermined barcodes by lane.
   - Informations for R1/R2 are now separated in the General Statistics table.
@@ -1156,12 +1156,12 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - New sequence distribution profiles around genes, from the `plotProfile` function (written by [@chuan-wang](https://github.com/chuan-wang/))
   - Reordered sections
 - **Fastp**
-  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/MultiQC/MultiQC/issues/845).
+  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/ewels/MultiQC/issues/845).
 - **FastQC**
-  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/MultiQC/MultiQC/issues/812).
+  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/ewels/MultiQC/issues/812).
   - When including a FastQC section multiple times in one report, the summary progress bars now behave as you would expect.
 - **FastQ Screen**
-  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/MultiQC/MultiQC/issues/829).
+  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/ewels/MultiQC/issues/829).
 - **InterOp**
   - Fixed bug where read counts and base pair yields were not displaying in tables correctly.
   - Number formatting for these fields can now be customised in the same way as with other modules, as described [in the docs](http://multiqc.info/docs/#number-base-multiplier)
@@ -1174,14 +1174,14 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Properly clean sample names
 - **Trimmomatic**
   - Updated Trimmomatic module documentation to be more helpful
-  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/MultiQC/MultiQC/issues/864).
+  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/ewels/MultiQC/issues/864).
 
 #### New MultiQC Features
 
 - Embed your custom images with a new Custom Content feature! Just add `_mqc` to the end of the filename for `.png`, `.jpg` or `.jpeg` files.
 - Documentation for Custom Content reordered to make it a little more sane
 - You can now add or override any config parameter for any MultiQC plot! See [the documentation](http://multiqc.info/docs/#customising-plots) for more info.
-- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/MultiQC/MultiQC/issues/841).
+- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/ewels/MultiQC/issues/841).
 - Improved visual spacing between grouped bar plots
 
 #### Bug Fixes
@@ -1191,7 +1191,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [Sample name directory prefixes](https://multiqc.info/docs/#sample-names-prefixed-with-directories) are now added _after_ cleanup.
 - If a module is run multiple times in one report, it's CSS and JS files will only be included once (`default` template)
 
-## [MultiQC v1.6](https://github.com/MultiQC/MultiQC/releases/tag/v1.6) - 2018-08-04
+## [MultiQC v1.6](https://github.com/ewels/MultiQC/releases/tag/v1.6) - 2018-08-04
 
 Some of these updates are thanks to the efforts of people who attended the [NASPM](https://twitter.com/NordicGenomics) 2018 MultiQC hackathon session. Thanks to everyone who attended!
 
@@ -1271,10 +1271,10 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Fix linegraph and scatter plots data conversion (sporadically the incorrect `ymax` was used to drop data points) ([@cpavanrun](https://github.com/cpavanrun))
 - Adjusted behavior of ceiling and floor axis limits
 - Adjusted multiple file search patterns to make them more specific
-  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/MultiQC/MultiQC/pull/727))
-- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/MultiQC/MultiQC/issues/801))
+  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/ewels/MultiQC/pull/727))
+- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/ewels/MultiQC/issues/801))
 
-## [MultiQC v1.5](https://github.com/MultiQC/MultiQC/releases/tag/v1.5) - 2018-03-15
+## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15
 
 #### New Modules
 
@@ -1334,7 +1334,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Locked the `matplotlib` version to `v2.1.0` and below
   - Due to [two](https://github.com/matplotlib/matplotlib/issues/10476) [bugs](https://github.com/matplotlib/matplotlib/issues/10784) that appeared in `v2.2.0` - will remove this constraint when there's a new release that works again.
 
-## [MultiQC v1.4](https://github.com/MultiQC/MultiQC/releases/tag/v1.4) - 2018-01-11
+## [MultiQC v1.4](https://github.com/ewels/MultiQC/releases/tag/v1.4) - 2018-01-11
 
 A slightly earlier-than-expected release due to a new problem with dependency packages that is breaking MultiQC installations since 2018-01-11.
 
@@ -1388,7 +1388,7 @@ A slightly earlier-than-expected release due to a new problem with dependency pa
 - Updated pandoc command used in `--pdf` to work with new releases of Pandoc
 - Made config `table_columns_visible` module name key matching case insensitive to make less frustrating
 
-## [MultiQC v1.3](https://github.com/MultiQC/MultiQC/releases/tag/v1.3) - 2017-11-03
+## [MultiQC v1.3](https://github.com/ewels/MultiQC/releases/tag/v1.3) - 2017-11-03
 
 #### Breaking changes - custom search patterns
 
@@ -1473,7 +1473,7 @@ string beginning with the name of your module, anything you like after the first
 - Don't prepend the directory separator (`|`) to sample names with `-d` when there are no subdirs
 - `yPlotLines` now works even if you don't set `width`
 
-## [MultiQC v1.2](https://github.com/MultiQC/MultiQC/releases/tag/v1.2) - 2017-08-16
+## [MultiQC v1.2](https://github.com/ewels/MultiQC/releases/tag/v1.2) - 2017-08-16
 
 #### CodeFest 2017 Contributions
 
@@ -1569,7 +1569,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.1) - 2017-07-18
+## [MultiQC v1.1](https://github.com/ewels/MultiQC/releases/tag/v1.1) - 2017-07-18
 
 #### New Modules
 
@@ -1651,7 +1651,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.0](https://github.com/MultiQC/MultiQC/releases/tag/v1.0) - 2017-05-17
+## [MultiQC v1.0](https://github.com/ewels/MultiQC/releases/tag/v1.0) - 2017-05-17
 
 Version 1.0! This release has been a long time coming and brings with it some fairly
 major improvements in speed, report filesize and report performance. There's also
@@ -1819,7 +1819,7 @@ To see what changes need to applied to your custom plugin code, please see the [
 
 ---
 
-## [MultiQC v0.9](https://github.com/MultiQC/MultiQC/releases/tag/v0.9) - 2016-12-21
+## [MultiQC v0.9](https://github.com/ewels/MultiQC/releases/tag/v0.9) - 2016-12-21
 
 A major new feature is released in v0.9 - support for _custom content_. This means
 that MultiQC can now easily include output from custom scripts within reports without
@@ -1912,7 +1912,7 @@ the need for a new module or plugin. For more information, please see the
 
 ---
 
-## [MultiQC v0.8](https://github.com/MultiQC/MultiQC/releases/tag/v0.8) - 2016-09-26
+## [MultiQC v0.8](https://github.com/ewels/MultiQC/releases/tag/v0.8) - 2016-09-26
 
 #### New Modules
 
@@ -1988,7 +1988,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.7](https://github.com/MultiQC/MultiQC/releases/tag/v0.7) - 2016-07-04
+## [MultiQC v0.7](https://github.com/ewels/MultiQC/releases/tag/v0.7) - 2016-07-04
 
 #### Module updates
 
@@ -2057,7 +2057,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.6](https://github.com/MultiQC/MultiQC/releases/tag/v0.6) - 2016-04-29
+## [MultiQC v0.6](https://github.com/ewels/MultiQC/releases/tag/v0.6) - 2016-04-29
 
 #### Module updates
 
@@ -2097,7 +2097,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.5](https://github.com/MultiQC/MultiQC/releases/tag/v0.5) - 2016-03-29
+## [MultiQC v0.5](https://github.com/ewels/MultiQC/releases/tag/v0.5) - 2016-03-29
 
 #### Module updates
 
@@ -2130,7 +2130,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.4](https://github.com/MultiQC/MultiQC/releases/tag/v0.4) - 2016-02-16
+## [MultiQC v0.4](https://github.com/ewels/MultiQC/releases/tag/v0.4) - 2016-02-16
 
 - New `multiqc_sources.txt` which identifies the paths used to collect all report data for each sample
 - Export parsed data as tab-delimited text, `JSON` or `YAML` using the new `-k`/`--data-format` command line option
@@ -2150,7 +2150,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.2) - 2016-02-08
+## [MultiQC v0.3.2](https://github.com/ewels/MultiQC/releases/tag/v0.3.2) - 2016-02-08
 
 - All modules now load their log file search parameters from a config
   file, allowing you to overwrite them using your user config file
@@ -2196,7 +2196,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.1) - 2015-11-04
+## [MultiQC v0.3.1](https://github.com/ewels/MultiQC/releases/tag/v0.3.1) - 2015-11-04
 
 - Hotfix patch to fix broken FastQC module (wasn't finding `.zip` files properly)
 - General Stats table colours now flat. Should improve browser speed.
@@ -2205,7 +2205,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3](https://github.com/MultiQC/MultiQC/releases/tag/v0.3) - 2015-11-04
+## [MultiQC v0.3](https://github.com/ewels/MultiQC/releases/tag/v0.3) - 2015-11-04
 
 - Lots of lovely new documentation!
 - Child templates - easily customise specific parts of the default report template
@@ -2242,11 +2242,11 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.2) - 2015-09-18
+## [MultiQC v0.2](https://github.com/ewels/MultiQC/releases/tag/v0.2) - 2015-09-18
 
 - Code restructuring for nearly all modules. Common base module
   functions now handle many more functions (plots, config, file import)
-  - See the [contributing notes](https://github.com/MultiQC/MultiQC/blob/master/CONTRIBUTING.md)
+  - See the [contributing notes](https://github.com/ewels/MultiQC/blob/master/CONTRIBUTING.md)
     for instructions on how to use these new helpers to make your own module
 - New report toolbox - sample highlighting, renaming, hiding
   - Config is autosaved by default, can also export to a file for sharing
@@ -2265,7 +2265,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.1) - 2015-09-01
+## [MultiQC v0.1](https://github.com/ewels/MultiQC/releases/tag/v0.1) - 2015-09-01
 
 - The first public release of MultiQC, after a month of development. Basic
   structure in place and modules for FastQC, FastQ Screen, Cutadapt, Bismark,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### MultiQC updates
 
+- Update repo name ([#2243](https://github.com/MultiQC/MultiQC/pull/2243))
+
 ### New modules
 
 ### Module updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,41 +8,41 @@
 
 ### Module updates
 
-## [MultiQC v1.19](https://github.com/ewels/MultiQC/releases/tag/v1.19) - 2023-12-18
+## [MultiQC v1.19](https://github.com/MultiQC/MultiQC/releases/tag/v1.19) - 2023-12-18
 
 ### MultiQC updates
 
-- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/ewels/MultiQC/pull/2228))
-- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/ewels/MultiQC/pull/2191))
-- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/ewels/MultiQC/pull/2210))
-- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/ewels/MultiQC/pull/1666))
-- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/ewels/MultiQC/pull/2224))
-- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/ewels/MultiQC/pull/1667))
-- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/ewels/MultiQC/pull/2195))
-- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/ewels/MultiQC/pull/2209))
+- Add missing table `id` in DRAGEN modules, and require `id` in plot configs in strict mode ([#2228](https://github.com/MultiQC/MultiQC/pull/2228))
+- Config `table_columns_visible` and `table_columns_name`: support flat config and `table_id` as a group ([#2191](https://github.com/MultiQC/MultiQC/pull/2191))
+- Add `sort_samples: false` config option for bar graphs ([#2210](https://github.com/MultiQC/MultiQC/pull/2210))
+- Upgrade the jQuery tablesorter plugin to v2 ([#1666](https://github.com/MultiQC/MultiQC/pull/1666))
+- Refactor pre-Python-3.6 code, prefer f-strings over `.format()` calls ([#2224](https://github.com/MultiQC/MultiQC/pull/2224))
+- Allow specifying default sort columns for tables with `defaultsort` ([#1667](https://github.com/MultiQC/MultiQC/pull/1667))
+- Create CODE_OF_CONDUCT.md ([#2195](https://github.com/MultiQC/MultiQC/pull/2195))
+- Add `.cram` to sample name cleaning defaults ([#2209](https://github.com/MultiQC/MultiQC/pull/2209))
 
 ### MultiQC bug fixes
 
-- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/ewels/MultiQC/pull/2202))
-- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/ewels/MultiQC/pull/2189))
-- Fix running with the `--no-report` flag ([#2212](https://github.com/ewels/MultiQC/pull/2212))
-- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/ewels/MultiQC/pull/2208))
-- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/ewels/MultiQC/pull/2234))
+- Re-add `run` into the `multiqc` namespace ([#2202](https://github.com/MultiQC/MultiQC/pull/2202))
+- Fix the `"square": True` flag to scatter plot to actually make the plot square ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
+- Fix running with the `--no-report` flag ([#2212](https://github.com/MultiQC/MultiQC/pull/2212))
+- Fix guessing custom content plot type: do not assume first row of a bar plot data are sample names ([#2208](https://github.com/MultiQC/MultiQC/pull/2208))
+- Fix detection of changed specific module in Changelog CI ([#2234](https://github.com/MultiQC/MultiQC/pull/2234))
 
 ### Module updates
 
-- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/ewels/MultiQC/pull/2197))
-- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/ewels/MultiQC/pull/2229))
-- **Fastp**: search content instead of file name ([#2213](https://github.com/ewels/MultiQC/pull/2213))
-- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/ewels/MultiQC/pull/2189))
-- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/ewels/MultiQC/pull/2233))
-- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/ewels/MultiQC/pull/2230))
-- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/ewels/MultiQC/pull/2205))
-- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/ewels/MultiQC/pull/2207))
-- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/ewels/MultiQC/pull/2226))
-- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/ewels/MultiQC/pull/1485))
+- **BCLConvert**: fix mean quality, fix count-per-lane bar plot ([#2197](https://github.com/MultiQC/MultiQC/pull/2197))
+- **deepTools**: handle missing data in `plotProfile` ([#2229](https://github.com/MultiQC/MultiQC/pull/2229))
+- **Fastp**: search content instead of file name ([#2213](https://github.com/MultiQC/MultiQC/pull/2213))
+- **GATK**: square the `BaseRecalibrator` scatter plot ([#2189](https://github.com/MultiQC/MultiQC/pull/2189))
+- **HiC-Pro**: add missing search patterns and better handling of missing data ([#2233](https://github.com/MultiQC/MultiQC/pull/2233))
+- **Kraken**: fix `UnboundLocalError` ([#2230](https://github.com/MultiQC/MultiQC/pull/2230))
+- **Kraken**: fixed column keys in genstats ([#2205](https://github.com/MultiQC/MultiQC/pull/2205))
+- **QualiMap**: fix `BamQC` for global-only stats ([#2207](https://github.com/MultiQC/MultiQC/pull/2207))
+- **Picard**: add more search patterns for `MarkDuplicates`, including `MarkDuplicatesSpark` ([#2226](https://github.com/MultiQC/MultiQC/pull/2226))
+- **Salmon**: add `library_types`, `compatible_fragment_ratio`, `strand_mapping_bias` to the general stats table ([#1485](https://github.com/MultiQC/MultiQC/pull/1485))
 
-## [MultiQC v1.18](https://github.com/ewels/MultiQC/releases/tag/v1.18) - 2023-11-17
+## [MultiQC v1.18](https://github.com/MultiQC/MultiQC/releases/tag/v1.18) - 2023-11-17
 
 ### Highlights
 
@@ -74,40 +74,40 @@ If you were using the Sentieon module in your pipelines, make sure to update any
 
 ### MultiQC updates
 
-- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/ewels/MultiQC/pull/2178))
-- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/ewels/MultiQC/pull/2183))
-- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/ewels/MultiQC/pull/2181))
-- Software versions: allow any string as a version tag ([#2166](https://github.com/ewels/MultiQC/pull/2166))
-- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/ewels/MultiQC/pull/2176))
-- Stricter config variable typing ([#2178](https://github.com/ewels/MultiQC/pull/2178))
-- Remove `position:absolute` CSS from table values ([#2169](https://github.com/ewels/MultiQC/pull/2169))
-- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/ewels/MultiQC/pull/2143))
-- Fix custom anchors for kraken ([#2170](https://github.com/ewels/MultiQC/pull/2170))
-- Fix logging spillover bug ([#2174](https://github.com/ewels/MultiQC/pull/2174))
+- Config can be set with environment variables, including env var interpolation ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
+- Try find config in `~/.config` or `$XDG_CONFIG_HOME` ([#2183](https://github.com/MultiQC/MultiQC/pull/2183))
+- Better sample name cleaning with pairs of input filenames ([#2181](https://github.com/MultiQC/MultiQC/pull/2181))
+- Software versions: allow any string as a version tag ([#2166](https://github.com/MultiQC/MultiQC/pull/2166))
+- Table columns with non-numeric values and now trigger a linting error if `scale` is set ([#2176](https://github.com/MultiQC/MultiQC/pull/2176))
+- Stricter config variable typing ([#2178](https://github.com/MultiQC/MultiQC/pull/2178))
+- Remove `position:absolute` CSS from table values ([#2169](https://github.com/MultiQC/MultiQC/pull/2169))
+- Fix column sorting in exported TSV files from a matplotlib linegraph plot ([#2143](https://github.com/MultiQC/MultiQC/pull/2143))
+- Fix custom anchors for kraken ([#2170](https://github.com/MultiQC/MultiQC/pull/2170))
+- Fix logging spillover bug ([#2174](https://github.com/MultiQC/MultiQC/pull/2174))
 
 ### New Modules
 
-- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/ewels/MultiQC/pull/2151))
+- [**Seqera Platform CLI**](https://github.com/seqeralabs/tower-cli) ([#2151](https://github.com/MultiQC/MultiQC/pull/2151))
   - Seqera Platform CLI reports statistics generated by the Seqera Platform CLI.
-- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/ewels/MultiQC/pull/1860))
+- [**Xenome**](https://github.com/data61/gossamer/blob/master/docs/xenome.md) ([#1860](https://github.com/MultiQC/MultiQC/pull/1860))
   - A tool for classifying reads from xenograft sources.
-- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/ewels/MultiQC/pull/2168))
+- [**xengsort**](https://gitlab.com/genomeinformatics/xengsort) ([#2168](https://github.com/MultiQC/MultiQC/pull/2168))
   - xengsort is a fast xenograft read sorter based on space-efficient k-mer hashing
 
 ### Module updates
 
-- **fastp**: add version parsing ([#2159](https://github.com/ewels/MultiQC/pull/2159))
-- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/ewels/MultiQC/pull/2139))
-- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/ewels/MultiQC/pull/2179))
-- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/ewels/MultiQC/pull/2155))
-- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/ewels/MultiQC/pull/2157))
-- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/ewels/MultiQC/pull/2110))
-- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/ewels/MultiQC/pull/2110))
+- **fastp**: add version parsing ([#2159](https://github.com/MultiQC/MultiQC/pull/2159))
+- **fastp**: correctly parse sample name from `--in1`/`--in2` in bash command. Prefer file name if not `fastp.json`; fallback to file name when error ([#2139](https://github.com/MultiQC/MultiQC/pull/2139))
+- **Kaiju**: fix `division by zero` error ([#2179](https://github.com/MultiQC/MultiQC/pull/2179))
+- **Nanostat**: account for both tab and spaces in `v1.41+` search pattern ([#2155](https://github.com/MultiQC/MultiQC/pull/2155))
+- **Pangolin**: update for v4: add QC Note , update tool versions columns ([#2157](https://github.com/MultiQC/MultiQC/pull/2157))
+- **Picard**: Generalize to directly support Sentieon and Parabricks outputs ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
+- **Sentieon**: Removed the module in favour of directly supporting parsing by the **Picard** module ([#2110](https://github.com/MultiQC/MultiQC/pull/2110))
   - Note that any code that relies on the module name needs to be updated, e.g. `-m sentieon` will no longer work
   - The exported plot and data files will be now be prefixed as `picard` instead of `sentieon`, etc.
   - Note that the Sentieon module used to fetch the sample names from the file names by default, and now it follows the Picard module's logic, and prioritizes the commands recorded in the logs. To override, use the `use_filename_as_sample_name` config flag
 
-## [MultiQC v1.17](https://github.com/ewels/MultiQC/releases/tag/v1.17) - 2023-10-17
+## [MultiQC v1.17](https://github.com/MultiQC/MultiQC/releases/tag/v1.17) - 2023-10-17
 
 ### The one with the new logo
 
@@ -122,45 +122,45 @@ Highlights:
 
 ### MultiQC updates
 
-- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/ewels/MultiQC/pull/2025), [#2102](https://github.com/ewels/MultiQC/pull/2102), [#2115](https://github.com/ewels/MultiQC/pull/2115))
-- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/ewels/MultiQC/pull/2082))
-- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/ewels/MultiQC/pull/2049))
-- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/ewels/MultiQC/pull/2081))
-- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/ewels/MultiQC/pull/2101))
-- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/ewels/MultiQC/pull/1632))
-- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/ewels/MultiQC/pull/2124))
-- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/ewels/MultiQC/pull/2109))
+- Add CI action [changelog.yml](.github%2Fworkflows%2Fchangelog.yml) to populate the changelog from PR titles, triggered by a comment `@multiqc-bot changelog` ([#2025](https://github.com/MultiQC/MultiQC/pull/2025), [#2102](https://github.com/MultiQC/MultiQC/pull/2102), [#2115](https://github.com/MultiQC/MultiQC/pull/2115))
+- Add GitHub Actions bot workflow to fix code linting from a PR comment ([#2082](https://github.com/MultiQC/MultiQC/pull/2082))
+- Use custom exception type instead of `UserWarning` when no samples are found. ([#2049](https://github.com/MultiQC/MultiQC/pull/2049))
+- Lint modules for missing `self.add_software_version` ([#2081](https://github.com/MultiQC/MultiQC/pull/2081))
+- Strict mode: rename `config.lint` to `config.strict`, crash early on module or template error. Add `MULTIQC_STRICT=1` ([#2101](https://github.com/MultiQC/MultiQC/pull/2101))
+- Matplotlib line plots now respect `xLog: True` and `yLog: True` in config ([#1632](https://github.com/MultiQC/MultiQC/pull/1632))
+- Fix matplotlib linegraph and bargraph for the case when `xmax` `<` `xmin` in config ([#2124](https://github.com/MultiQC/MultiQC/pull/2124))
+- Add `--require-logs` flag to error out if requested modules not used ([#2109](https://github.com/MultiQC/MultiQC/pull/2109))
 - Fixes for python 3.12
-  - Replace removed `distutils` ([#2113](https://github.com/ewels/MultiQC/pull/2113))
-  - Bundle lzstring ([#2119](https://github.com/ewels/MultiQC/pull/2119))
-- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/ewels/MultiQC/pull/2121))
-- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/ewels/MultiQC/pull/2074))
+  - Replace removed `distutils` ([#2113](https://github.com/MultiQC/MultiQC/pull/2113))
+  - Bundle lzstring ([#2119](https://github.com/MultiQC/MultiQC/pull/2119))
+- Drop Python 3.6 and 3.7 support, add 3.12 ([#2121](https://github.com/MultiQC/MultiQC/pull/2121))
+- Just run CI on the oldest + newest supported Python versions ([#2074](https://github.com/MultiQC/MultiQC/pull/2074))
 - <img src="./multiqc/templates/default/assets/img/favicon-16x16.png" alt="///" width="10px"/> New logo
-- Set name and anchor for the custom content "module" [#2131](https://github.com/ewels/MultiQC/pull/2131)
-- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/ewels/MultiQC/pull/2133))
+- Set name and anchor for the custom content "module" [#2131](https://github.com/MultiQC/MultiQC/pull/2131)
+- Fix use of `shutil.copytree` when overriding existing template files in `tmp_dir` ([#2133](https://github.com/MultiQC/MultiQC/pull/2133))
 
 ### New Modules
 
 - [**Bracken**](https://ccb.jhu.edu/software/bracken/)
   - A highly accurate statistical method that computes the abundance of species in DNA sequences from a metagenomics sample.
-- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/ewels/MultiQC/pull/1751))
+- [**Truvari**](https://github.com/ACEnglish/truvari) ([#1751](https://github.com/MultiQC/MultiQC/pull/1751))
   - Truvari is a toolkit for benchmarking, merging, and annotating structural variants
 
 ### Module updates
 
-- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/ewels/MultiQC/pull/2128))
-- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/ewels/MultiQC/pull/2118))
-- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/ewels/MultiQC/pull/2108))
-- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/ewels/MultiQC/pull/2075))
-- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/ewels/MultiQC/pull/2126))
-- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/ewels/MultiQC/pull/2129))
-- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/ewels/MultiQC/pull/2106))
-- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/ewels/MultiQC/pull/2127))
-- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/ewels/MultiQC/pull/2083), [#2094](https://github.com/ewels/MultiQC/pull/2094))
-- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/ewels/MultiQC/pull/2123))
-- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/ewels/MultiQC/pull/2095))
+- **Dragen**: make sure all inputs are recorded in multiqc_sources.txt ([#2128](https://github.com/MultiQC/MultiQC/pull/2128))
+- **Cellranger**: Count submodule updated to parse Antibody Capture summary ([#2118](https://github.com/MultiQC/MultiQC/pull/2118))
+- **fastp**: parse unescaped sample names with white spaces ([#2108](https://github.com/MultiQC/MultiQC/pull/2108))
+- **FastQC**: Add top overrepresented sequences table ([#2075](https://github.com/MultiQC/MultiQC/pull/2075))
+- **HiCPro**: Fix parsing scientific notation in hicpro-ashic. Thanks @Just-Roma ([#2126](https://github.com/MultiQC/MultiQC/pull/2126))
+- **HTSeq Count**: allow counts files with more than 2 columns ([#2129](https://github.com/MultiQC/MultiQC/pull/2129))
+- **mosdepth**: fix prioritizing region over global information ([#2106](https://github.com/MultiQC/MultiQC/pull/2106))
+- **Picard**: Adapt WgsMetrics to parabricks bammetrics outputs ([#2127](https://github.com/MultiQC/MultiQC/pull/2127))
+- **Picard**: MarkDuplicates: Fix parsing mixed strings/numbers, account for missing trailing `0` ([#2083](https://github.com/MultiQC/MultiQC/pull/2083), [#2094](https://github.com/MultiQC/MultiQC/pull/2094))
+- **Samtools**: Add MQ0 reads to the Percent Mapped barplot in Stats submodule ([#2123](https://github.com/MultiQC/MultiQC/pull/2123))
+- **WhatsHap**: Process truncated input with no ALL chromosome ([#2095](https://github.com/MultiQC/MultiQC/pull/2095))
 
-## [MultiQC v1.16](https://github.com/ewels/MultiQC/releases/tag/v1.16) - 2023-09-22
+## [MultiQC v1.16](https://github.com/MultiQC/MultiQC/releases/tag/v1.16) - 2023-09-22
 
 ### Highlight: Software versions
 
@@ -178,21 +178,21 @@ See the documentation for more ([writing modules](https://multiqc.info/docs/deve
 [supplying stand-alone](https://multiqc.info/docs/reports/customisation/#listing-software-versions))
 
 Huge thanks to [@pontushojer](https://https://github.com/pontushojer) for the
-contribution ([#1927](https://github.com/ewels/MultiQC/pull/1927)).
-This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/290), made in 2016!
+contribution ([#1927](https://github.com/MultiQC/MultiQC/pull/1927)).
+This idea goes way back to [issue #290](https://github.com/MultiQC/MultiQC/issues/290), made in 2016!
 
 ### MultiQC updates
 
-- Removed `simplejson` unused dependency ([#1973](https://github.com/ewels/MultiQC/pull/1973))
+- Removed `simplejson` unused dependency ([#1973](https://github.com/MultiQC/MultiQC/pull/1973))
 - Give config `custom_plot_config` priority over column-specific settings set by modules
-- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/ewels/MultiQC/pull/1976))
+- When exporting plots, make a more clear error message for unsupported FastQC dot plot ([#1976](https://github.com/MultiQC/MultiQC/pull/1976))
 - Fixed parsing of `plot_type: "html"` `data` in json custom content
 - Replace deprecated `pkg_resources`
-- [Fix](https://github.com/ewels/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/ewels/MultiQC/pull/2037)).
-- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/ewels/MultiQC/pull/2055)
-- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/ewels/MultiQC/pull/2058))
-- Fix table column color scaling then there are negative numbers ([1869](https://github.com/ewels/MultiQC/issues/1869))
-- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/ewels/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
+- [Fix](https://github.com/MultiQC/MultiQC/issues/2032) the module groups configuration for modules where the namespace is passed explicitly to `general_stats_addcols`. Namespace is now always appended to the module name in the general stats ([2037](https://github.com/MultiQC/MultiQC/pull/2037)).
+- Do not call `sys.exit()` in the `multiqc.run()` function, to avoid breaking interactive environments. [#2055](https://github.com/MultiQC/MultiQC/pull/2055)
+- Fixed the DOI exports in `multiqc_data` to include more than just the MultiQC paper ([#2058](https://github.com/MultiQC/MultiQC/pull/2058))
+- Fix table column color scaling then there are negative numbers ([1869](https://github.com/MultiQC/MultiQC/issues/1869))
+- Export plots as static images and data in a ZIP archive. Fixes the [issue](https://github.com/MultiQC/MultiQC/issues/1873) when only 10 plots maximum were downloaded due to the browser limitation.
 
 ### New Modules
 
@@ -206,36 +206,36 @@ This idea goes way back to [issue #290](https://github.com/ewels/MultiQC/issues/
 ### Module updates
 
 - **BcfTools**
-  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/ewels/MultiQC/issues/2052))
+  - Stats: fix parsing multi-sample logs ([#2052](https://github.com/MultiQC/MultiQC/issues/2052))
 - **Custom content**
-  - Don't convert sample IDs to floats ([#1883](https://github.com/ewels/MultiQC/issues/1883))
+  - Don't convert sample IDs to floats ([#1883](https://github.com/MultiQC/MultiQC/issues/1883))
 - **DRAGEN**
-  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/ewels/MultiQC/pull/1994))
+  - Make DRAGEN module use `fn_clean_exts` instead of hardcoded file names. Fixes working with arbitrary file names ([#1994](https://github.com/MultiQC/MultiQC/pull/1994))
 - **FastQC**:
-  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/ewels/MultiQC/issues/2024))
+  - fix `UnicodeDecodeError` when parsing `fastqc_data.txt`: try latin-1 or fail gracefully ([#2024](https://github.com/MultiQC/MultiQC/issues/2024))
 - **Kaiju**:
-  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/ewels/MultiQC/pull/2023))
+  - Fix `UnboundLocalError` on outputs when Kanju was run with the `-e` flag ([#2023](https://github.com/MultiQC/MultiQC/pull/2023))
 - **Kraken**
-  - Parametrize top-N through config ([#2060](https://github.com/ewels/MultiQC/pull/2060))
-  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/ewels/MultiQC/issues/1766)).
+  - Parametrize top-N through config ([#2060](https://github.com/MultiQC/MultiQC/pull/2060))
+  - Fix bug where ranks incorrectly assigned to tabs ([#1766](https://github.com/MultiQC/MultiQC/issues/1766)).
 - **Mosdepth**
-  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/ewels/MultiQC/issues/1978))
+  - Add X/Y relative coverage plot, analogous to the one in samtools-idxstats ([#1978](https://github.com/MultiQC/MultiQC/issues/1978))
   - Added the `perchrom_fraction_cutoff` option into the config to help avoid clutter in contig-level plots
   - Fix a bug happening when both `region` and `global` coverage histograms for a sample are available (i.e. when mosdepth was run with `--by`, see [mosdepth docs](https://github.com/brentp/mosdepth#usage)). In this case, data was effectively merged. Instead, summarise it separately and add a separate report section for the region-based coverage data.
-  - Do not fail when all input samples have no coverage ([#2005](https://github.com/ewels/MultiQC/pull/2005)).
+  - Do not fail when all input samples have no coverage ([#2005](https://github.com/MultiQC/MultiQC/pull/2005)).
 - **NanoStat**
-  - Support new format ([#1997](https://github.com/ewels/MultiQC/pull/1997)).
+  - Support new format ([#1997](https://github.com/MultiQC/MultiQC/pull/1997)).
 - **RSeQC**
-  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/ewels/MultiQC/issues/1985))
-  - Fix division by zero on all-zero input ([#2040](https://github.com/ewels/MultiQC/pull/2040))
+  - Fix `max() arg is an empty sequence` error ([#1985](https://github.com/MultiQC/MultiQC/issues/1985))
+  - Fix division by zero on all-zero input ([#2040](https://github.com/MultiQC/MultiQC/pull/2040))
 - **Samtools**
-  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/ewels/MultiQC/pull/1972))
+  - Stats: fix "Percent Mapped" plot when samtools was run with read filtering ([#1972](https://github.com/MultiQC/MultiQC/pull/1972))
 - **Qualimap**
-  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/ewels/MultiQC/issues/2019))
+  - BamQC: Include `% On Target` in General Stats table ([#2019](https://github.com/MultiQC/MultiQC/issues/2019))
 - **WhatsHap**
-  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/ewels/MultiQC/pull/1981))
+  - Bugfix: ensure that TSV is only split on tab character. Allows sample names with spaces ([#1981](https://github.com/MultiQC/MultiQC/pull/1981))
 
-## [MultiQC v1.15](https://github.com/ewels/MultiQC/releases/tag/v1.15) - 2023-08-04
+## [MultiQC v1.15](https://github.com/MultiQC/MultiQC/releases/tag/v1.15) - 2023-08-04
 
 #### Potential breaking change in some edge cases
 
@@ -252,13 +252,13 @@ for more information.
 
 ### MultiQC updates
 
-- Refactor file search for performance improvements ([#1904](https://github.com/ewels/MultiQC/pull/1904))
+- Refactor file search for performance improvements ([#1904](https://github.com/MultiQC/MultiQC/pull/1904))
 - Bump `log_filesize_limit` default (to skip large files in the search) from 10MB to 50MB.
-- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/ewels/MultiQC/issues/1739))
-- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/ewels/MultiQC/issues/1861))
+- Table code now tolerates lambda function calls with bad data ([#1739](https://github.com/MultiQC/MultiQC/issues/1739))
+- Beeswarm plot now saves data to `multiqc_data`, same as tables ([#1861](https://github.com/MultiQC/MultiQC/issues/1861))
 - Don't print DOI in module if it's set to an empty string.
-- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/ewels/MultiQC/pull/1891))
-- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/ewels/MultiQC/issues/1866))
+- Optimize parsing of 2D data dictionaries in multiqc.utils.utils_functions.write_data_file() ([#1891](https://github.com/MultiQC/MultiQC/pull/1891))
+- Don't sort table headers alphabetically if we don't have an `OrderedDict` - regular dicts are fine in Py3 ([#1866](https://github.com/MultiQC/MultiQC/issues/1866))
 - New back-end to preview + deploy the new website when the docs are edited.
 - Fixed a _lot_ of broken links in the documentation from the new website change in structure.
 
@@ -272,46 +272,46 @@ for more information.
 ### Module updates
 
 - **Conpair**
-  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/ewels/MultiQC/issues/1851))
+  - Bugfix: allow to find and proprely parse the `concordance` output of Conpair, which may output 2 kinds of format for `concordance` depending if it's ran with or without `--outfile` ([#1851](https://github.com/MultiQC/MultiQC/issues/1851))
 - **Cell Ranger**
-  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/ewels/MultiQC/issues/1853), [#1871](https://github.com/ewels/MultiQC/issues/1871))
+  - Bugfix: avoid multiple `KeyError` exceptions when parsing Cell Ranger 7.x `web_summary.html` ([#1853](https://github.com/MultiQC/MultiQC/issues/1853), [#1871](https://github.com/MultiQC/MultiQC/issues/1871))
 - **DRAGEN**
-  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/ewels/MultiQC/issues/1844))
-  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/ewels/MultiQC/pull/1958))
+  - Restored functionality to show target BED coverage metrics ([#1844](https://github.com/MultiQC/MultiQC/issues/1844))
+  - Update filename pattern in RNA quant metrics ([#1958](https://github.com/MultiQC/MultiQC/pull/1958))
 - **filtlong**
-  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/ewels/MultiQC/issues/1843))
+  - Handle reports from locales that use `.` as a thousands separator ([#1843](https://github.com/MultiQC/MultiQC/issues/1843))
 - **GATK**
   - Adds support for [AnalyzeSaturationMutagenesis submodule](https://gatk.broadinstitute.org/hc/en-us/articles/360037594771-AnalyzeSaturationMutagenesis-BETA-)
 - **HUMID**
-  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/ewels/MultiQC/issues/1856))
+  - Fix bug that prevent HUMID stats files from being parsed ([#1856](https://github.com/MultiQC/MultiQC/issues/1856))
 - **Mosdepth**
-  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Fill in missing values for general stats table ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/ewels/MultiQC/issues/1868))
-  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/ewels/MultiQC/issues/1960))
+  - Fix data not written to `mosdepth_cumcov_dist.txt` and `mosdepth_cov_dist.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Update documentation with new file `{prefix}.mosdepth.summary.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Fill in missing values for general stats table ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Include mosdepth/summary file paths in `multiqc_sources.txt` ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Enable log switch for Coverage per contig plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Fix y-axis scaling for Coverage distribution plot ([#1868](https://github.com/MultiQC/MultiQC/issues/1868))
+  - Handle case of intermediate missing coverage x-values in the `*_dist.txt` file causing a distorted Coverage distribution plot ([#1960](https://github.com/MultiQC/MultiQC/issues/1960))
 - **Picard**
-  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/ewels/MultiQC/issues/1888))
-  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/ewels/MultiQC/pull/1928))
+  - WgsMetrics: Fix wrong column label ([#1888](https://github.com/MultiQC/MultiQC/issues/1888))
+  - HsMetrics: Add missing field descriptions ([#1928](https://github.com/MultiQC/MultiQC/pull/1928))
 - **Porechop**
-  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/ewels/MultiQC/issues/1850))
+  - Don't render bar graphs if no samples had any adapters trimmed ([#1850](https://github.com/MultiQC/MultiQC/issues/1850))
   - Added report section listing samples that had no adapters trimmed
 - **RSeQC**
-  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/ewels/MultiQC/issues/1735))
+  - Fix `ZeroDivisionError` error for `bam_stat` results when there are 0 reads ([#1735](https://github.com/MultiQC/MultiQC/issues/1735))
 - **UMI-tools**
-  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/ewels/MultiQC/issues/1845))
+  - Fix bug that broke the module with paired-end data ([#1845](https://github.com/MultiQC/MultiQC/issues/1845))
 
-## [MultiQC v1.14](https://github.com/ewels/MultiQC/releases/tag/v1.14) - 2023-01-08
+## [MultiQC v1.14](https://github.com/MultiQC/MultiQC/releases/tag/v1.14) - 2023-01-08
 
 ### MultiQC new features
 
-- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/ewels/MultiQC/pull/1541), [#1541](https://github.com/ewels/MultiQC/pull/1541))
-- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/ewels/MultiQC/pull/1835))
-- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/ewels/MultiQC/issues/915))
+- Rewrote the `Dockerfile` to build multi-arch images (amd64 + arm), run through a non-privileged user and build tools for non precompiled python binaries ([#1541](https://github.com/MultiQC/MultiQC/pull/1541), [#1541](https://github.com/MultiQC/MultiQC/pull/1541))
+- Add a new lint test to check that colour scale names are valid ([#1835](https://github.com/MultiQC/MultiQC/pull/1835))
+- Update github actions to run tests on a single module if it is the only file affected by the PR ([#915](https://github.com/MultiQC/MultiQC/issues/915))
 - Add CI testing for Python 3.10 and 3.11
-- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/ewels/MultiQC/pull/1668))
+- Optimize line-graph generation to remove an n^2 loop ([#1668](https://github.com/MultiQC/MultiQC/pull/1668))
 - Parsing output file column headers is much faster.
 
 ### MultiQC code cleanup
@@ -323,12 +323,12 @@ for more information.
 
 ### MultiQC updates
 
-- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/ewels/MultiQC/issues/1722))
-- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/ewels/MultiQC/issues/1642))
-- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/ewels/MultiQC/issues/1638))
-- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/ewels/MultiQC/issues/1308))
+- Bugfix: Make `config.data_format` work again ([#1722](https://github.com/MultiQC/MultiQC/issues/1722))
+- Bump minimum version of Jinja2 to `>=3.0.0` ([#1642](https://github.com/MultiQC/MultiQC/issues/1642))
+- Disable search progress bar if running with `--quiet` or `--no-ansi` ([#1638](https://github.com/MultiQC/MultiQC/issues/1638))
+- Allow path filters without full paths by trying to prefix analysis dir when filtering ([#1308](https://github.com/MultiQC/MultiQC/issues/1308))
 - Fix sorting of table columns with text values
-- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/ewels/MultiQC/issues/1540))
+- Don't crash if a barplot is given an empty list of categories ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
 - New logos! MultiQC is now developed and maintained at [Seqera Labs](https://seqera.io/). Updated logos and email addresses accordingly.
 
 ### New Modules
@@ -368,63 +368,63 @@ for more information.
 ### Module updates
 
 - **Bcftools stats**
-  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/ewels/MultiQC/pull/1777))
-  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/ewels/MultiQC/issues/1832))
+  - Bugfix: Do not show empty bcftools stats variant depth plots ([#1777](https://github.com/MultiQC/MultiQC/pull/1777))
+  - Bugfix: Avoid exception when `PSC nMissing` column is not present ([#1832](https://github.com/MultiQC/MultiQC/issues/1832))
 - **BCL Convert**
-  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/ewels/MultiQC/issues/1697))
-  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/ewels/MultiQC/issues/1774))
+  - Handle single-end read data correctly when setting cluster length instead of always assuming paired-end reads ([#1697](https://github.com/MultiQC/MultiQC/issues/1697))
+  - Handle different R1 and R2 read-lengths correctly instead of assuming they are the same ([#1774](https://github.com/MultiQC/MultiQC/issues/1774))
   - Handle single-index paired-end data correctly
-  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/ewels/MultiQC/pull/1709))
+  - Added a config option to enable the creation of barplots with undetermined barcodes (`create_unknown_barcode_barplots` with `False` as default) ([#1709](https://github.com/MultiQC/MultiQC/pull/1709))
 - **BUSCO**
   - Update BUSCO pass/warning/fail scheme to be more clear for users
 - **Bustools**
   - Show median reads per barcode statistic
 - **Custom content**
   - Create a report even if there's only Custom Content General Stats there
-  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
-  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/ewels/MultiQC/issues/1242))
+  - Attempt to cooerce line / scatter x-axes into floats so as not to lose labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
+  - Multi-sample line-graph TSV files that have no sample name in row 1 column 1 now use row 1 as x-axis labels ([#1242](https://github.com/MultiQC/MultiQC/issues/1242))
 - **fastp**
-  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/ewels/MultiQC/issues/1744))
-  - Don't crash for invalid JSON files ([#1652](https://github.com/ewels/MultiQC/issues/1652))
+  - Add total read count (after filtering) to general stats table ([#1744](https://github.com/MultiQC/MultiQC/issues/1744))
+  - Don't crash for invalid JSON files ([#1652](https://github.com/MultiQC/MultiQC/issues/1652))
 - **FastQC**
-  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/ewels/MultiQC/pull/1745))
+  - Report median read-length for fastqc in addition to mean ([#1745](https://github.com/MultiQC/MultiQC/pull/1745))
 - **Kaiju**
-  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/ewels/MultiQC/issues/1540))
+  - Don't crash if we don't have any data for the top-5 barplot ([#1540](https://github.com/MultiQC/MultiQC/issues/1540))
 - **Kallisto**
-  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/ewels/MultiQC/issues/1746))
+  - Fix `ZeroDivisionError` when a sample has zero reads ([#1746](https://github.com/MultiQC/MultiQC/issues/1746))
 - **Kraken**
-  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/ewels/MultiQC/pull/1779))
+  - Fix duplicate heatmap to account for missing taxons ([#1779](https://github.com/MultiQC/MultiQC/pull/1779))
   - Make heatmap full width
-  - Handle empty kreports gracefully ([#1637](https://github.com/ewels/MultiQC/issues/1637))
-  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/ewels/MultiQC/pull/1639))
+  - Handle empty kreports gracefully ([#1637](https://github.com/MultiQC/MultiQC/issues/1637))
+  - Fix regex error with very large numbers of unclassified reads ([#1639](https://github.com/MultiQC/MultiQC/pull/1639))
 - **malt**
-  - Fixed division by 0 in malt module ([#1683](https://github.com/ewels/MultiQC/issues/1683))
+  - Fixed division by 0 in malt module ([#1683](https://github.com/MultiQC/MultiQC/issues/1683))
 - **miRTop**
-  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/ewels/MultiQC/issues/1778))
+  - Avoid `KeyError` - don't assume all fields present in logs ([#1778](https://github.com/MultiQC/MultiQC/issues/1778))
 - **Mosdepth**
-  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/ewels/MultiQC/pull/1810))
+  - Don't pad the General Stats table with zeros for missing data ([#1810](https://github.com/MultiQC/MultiQC/pull/1810))
 - **Picard**
   - HsMetrics: Allow custom columns in General Stats too, with `HsMetrics_genstats_table_cols` and `HsMetrics_genstats_table_cols_hidden`
 - **Qualimap**
-  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/ewels/MultiQC/pull/1798))
-  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/ewels/MultiQC/issues/1780))
+  - Added additional columns in general stats for BamQC results that displays region on-target stats if region bed has been supplied (hidden by default) ([#1798](https://github.com/MultiQC/MultiQC/pull/1798))
+  - Bugfix: Remove General Stats rows for filtered samples ([#1780](https://github.com/MultiQC/MultiQC/issues/1780))
 - **RSeQC**
-  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/ewels/MultiQC/pull/1792))
+  - Update `geneBody_coverage` to plot normalized coverages using a similar formula to that used by RSeQC itself ([#1792](https://github.com/MultiQC/MultiQC/pull/1792))
 - **Sambamba Markdup**
-  - Catch zero division in sambamba markdup ([#1654](https://github.com/ewels/MultiQC/issues/1654))
+  - Catch zero division in sambamba markdup ([#1654](https://github.com/MultiQC/MultiQC/issues/1654))
 - **Samtools**
-  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/ewels/MultiQC/issues/1733))
+  - Added additional column for `flagstat` that displays percentage of mapped reads in a bam (hidden by default) ([#1733](https://github.com/MultiQC/MultiQC/issues/1733))
 - **VEP**
-  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/ewels/MultiQC/issues/1681))
+  - Don't crash with `ValueError` if there are zero variants ([#1681](https://github.com/MultiQC/MultiQC/issues/1681))
 
-## [MultiQC v1.13](https://github.com/ewels/MultiQC/releases/tag/v1.13) - 2022-09-08
+## [MultiQC v1.13](https://github.com/MultiQC/MultiQC/releases/tag/v1.13) - 2022-09-08
 
 ### MultiQC updates
 
 - Major spruce of the command line help, using the new [rich-click](https://github.com/ewels/rich-click) package
 - Drop some of the Python 2k compatability code (eg. custom requirements)
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/ewels/MultiQC/issues/1643))
+  - Fixed bug raised when removing logging file handlers between calls that arose when configuring the root logger with dictConfig ([#1643](https://github.com/MultiQC/MultiQC/issues/1643))
 - Added new config option `custom_table_header_config` to override any config for any table header
 - Fixed edge-case bug in custom content where a `description` that doesn't terminate in `.` gave duplicate section descriptions.
 - Tidied the verbose log to remove some very noisy statements and add summaries for skipped files in the search
@@ -436,53 +436,53 @@ for more information.
 ### Module updates
 
 - **AdapterRemoval**
-  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/ewels/MultiQC/issues/1647))
+  - Finally merge a fix for counts of reads that are discarded/collapsed ([#1647](https://github.com/MultiQC/MultiQC/issues/1647))
 - **VEP**
-  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/ewels/MultiQC/pull/1656))
+  - Fixed bug when `General Statistics` have a value of `-` ([#1656](https://github.com/MultiQC/MultiQC/pull/1656))
 - **Custom content**
-  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/ewels/MultiQC/issues/1629))
-  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/ewels/MultiQC/issues/1686))
-  - Fix crash when `info` isn't set ([#1688](https://github.com/ewels/MultiQC/issues/1688))
+  - Only set id for custom content when id not set by metadata ([#1629](https://github.com/MultiQC/MultiQC/issues/1629))
+  - Fix bug where module wouldn't run if all content was within a MultiQC config file ([#1686](https://github.com/MultiQC/MultiQC/issues/1686))
+  - Fix crash when `info` isn't set ([#1688](https://github.com/MultiQC/MultiQC/issues/1688))
 - **Nanostat**
-  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/ewels/MultiQC/pull/1659))
-  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/ewels/MultiQC/issues/1717))
+  - Removed HTML escaping of special characters in the log to fix bug in jinja2 v3.10 removing `jinja2.escape()` ([#1659](https://github.com/MultiQC/MultiQC/pull/1659))
+  - Fix bug where module would crash if input does not contain quality scores ([#1717](https://github.com/MultiQC/MultiQC/issues/1717))
 - **Pangolin**
-  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/ewels/MultiQC/pull/1660))
+  - Updated module to handle outputs from Pangolin v4 ([#1660](https://github.com/MultiQC/MultiQC/pull/1660))
 - **Somalier**
-  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/ewels/MultiQC/pull/1670))
+  - Handle zero mean X depth in _Sex_ plot ([#1670](https://github.com/MultiQC/MultiQC/pull/1670))
 - **Fastp**
   - Include low complexity and too long reads in filtering bar chart
 - **miRTop**
-  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/ewels/MultiQC/issues/1712))
-  - Fix module crashing due to zero division ([#1719](https://github.com/ewels/MultiQC/issues/1719))
+  - Fix module crashing when `ref_miRNA_sum` is missing in file. ([#1712](https://github.com/MultiQC/MultiQC/issues/1712))
+  - Fix module crashing due to zero division ([#1719](https://github.com/MultiQC/MultiQC/issues/1719))
 - **FastQC**
-  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/ewels/MultiQC/pull/1725))
+  - Fixed error when parsing duplicate ratio when there is `nan` values in the report. ([#1725](https://github.com/MultiQC/MultiQC/pull/1725))
 
-## [MultiQC v1.12](https://github.com/ewels/MultiQC/releases/tag/v1.12) - 2022-02-08
+## [MultiQC v1.12](https://github.com/MultiQC/MultiQC/releases/tag/v1.12) - 2022-02-08
 
 ### MultiQC - new features
 
-- Added option to customise default plot height in plot config ([#1432](https://github.com/ewels/MultiQC/issues/1432))
-- Added `--no-report` flag to skip report generation ([#1462](https://github.com/ewels/MultiQC/issues/1462))
-- Added support for priting tool DOI in report sections ([#1177](https://github.com/ewels/MultiQC/issues/1177))
-- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/ewels/MultiQC/pull/1573))
-- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/ewels/MultiQC/pull/1576))
-- Added support for customising table column names ([#1255](https://github.com/ewels/MultiQC/issues/1255))
+- Added option to customise default plot height in plot config ([#1432](https://github.com/MultiQC/MultiQC/issues/1432))
+- Added `--no-report` flag to skip report generation ([#1462](https://github.com/MultiQC/MultiQC/issues/1462))
+- Added support for priting tool DOI in report sections ([#1177](https://github.com/MultiQC/MultiQC/issues/1177))
+- Added support for `--custom-css-file` / `config.custom_css_files` option to include custom CSS in the final report ([#1573](https://github.com/MultiQC/MultiQC/pull/1573))
+- New plot config option `labelSize` to customise font size for axis labels in flat MatPlotLib charts ([#1576](https://github.com/MultiQC/MultiQC/pull/1576))
+- Added support for customising table column names ([#1255](https://github.com/MultiQC/MultiQC/issues/1255))
 
 ### MultiQC - updates
 
-- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/ewels/MultiQC/issues/1463))
+- MultiQC now skips modules for which no files were found - gives a small performance boost ([#1463](https://github.com/MultiQC/MultiQC/issues/1463))
 - Improvements for running MultiQC in a Python environment, such as a Jupyter Notebook or script
-  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/ewels/MultiQC/issues/1141))
-  - Init/reset global state between runs ([#1596](https://github.com/ewels/MultiQC/pull/1596))
-- Added commonly missing functions to several modules ([#1468](https://github.com/ewels/MultiQC/issues/1468))
+  - Fixed logger bugs when calling `multiqc.run` multiple times by removing logging file handlers between calls ([#1141](https://github.com/MultiQC/MultiQC/issues/1141))
+  - Init/reset global state between runs ([#1596](https://github.com/MultiQC/MultiQC/pull/1596))
+- Added commonly missing functions to several modules ([#1468](https://github.com/MultiQC/MultiQC/issues/1468))
 - Wrote new script to check for the above function calls that should be in every module (`.github/workflows/code_checks.py`), runs on GitHub actions CI
-- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/ewels/MultiQC/issues/761))
-- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/ewels/MultiQC/pull/1579))
-- Fixed a problem with numeric filenames ([#1606](https://github.com/ewels/MultiQC/issues/1606))
-- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/ewels/MultiQC/issues/1568))
-- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/ewels/MultiQC/issues/1598))
-- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/ewels/MultiQC/issues/1539))
+- Make table _Conditional Formatting_ work at table level as well as column level. ([#761](https://github.com/MultiQC/MultiQC/issues/761))
+- CSS Improvements to make printed reports more attractive / readable ([#1579](https://github.com/MultiQC/MultiQC/pull/1579))
+- Fixed a problem with numeric filenames ([#1606](https://github.com/MultiQC/MultiQC/issues/1606))
+- Fixed nasty bug where line charts with a categorical x-axis would take categories from the last sample only ([#1568](https://github.com/MultiQC/MultiQC/issues/1568))
+- Ignore any files called `multiqc_data.json` ([#1598](https://github.com/MultiQC/MultiQC/issues/1598))
+- Check that the config `path_filters` is a list, convert to list if a string is supplied ([#1539](https://github.com/MultiQC/MultiQC/issues/1539))
 
 ### New Modules
 
@@ -496,75 +496,75 @@ for more information.
 ### Module feature additions
 
 - **BBMap**
-  - Added handling for `qchist` output ([#1021](https://github.com/ewels/MultiQC/issues/1021))
+  - Added handling for `qchist` output ([#1021](https://github.com/MultiQC/MultiQC/issues/1021))
 - **bcftools**
-  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/ewels/MultiQC/issues/1087))
+  - Added a plot with samplewise number of sites, Ts/Tv, number of singletons and sequencing depth ([#1087](https://github.com/MultiQC/MultiQC/issues/1087))
 - **Mosdepth**
-  - Added mean coverage [#1566](https://github.com/ewels/MultiQC/issues/1566)
+  - Added mean coverage [#1566](https://github.com/MultiQC/MultiQC/issues/1566)
 - **NanoStat**
-  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/ewels/MultiQC/issues/1547))
+  - Recognize FASTA and FastQ report flavors ([#1547](https://github.com/MultiQC/MultiQC/issues/1547))
 
 ### Module updates
 
 - **BBMap**
-  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/ewels/MultiQC/issues/1556))
+  - Correctly handle adapter stats files with additional columns ([#1556](https://github.com/MultiQC/MultiQC/issues/1556))
 - **BCL Convert**
-  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/ewels/MultiQC/issues/1563))
+  - Handle change in output format in v3.9.3 with new `Quality_Metrics.csv` file ([#1563](https://github.com/MultiQC/MultiQC/issues/1563))
 - **bowtie**
-  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/ewels/MultiQC/issues/1615))
+  - Minor update to handle new log wording in bowtie v1.3.0 ([#1615](https://github.com/MultiQC/MultiQC/issues/1615))
 - **CCS**
-  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/ewels/MultiQC/pull/1486))
-  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/ewels/MultiQC/issues/1583))
+  - Tolerate compound IDs generated by pbcromwell ccs in the general statistics ([#1486](https://github.com/MultiQC/MultiQC/pull/1486))
+  - Fix report parsing. Update test on attributes ids ([#1583](https://github.com/MultiQC/MultiQC/issues/1583))
 - **Custom content**
-  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/ewels/MultiQC/issues/1515))
-  - Use filename for section header in files with no headers ([#1550](https://github.com/ewels/MultiQC/issues/1550))
-  - Sort custom content bargraph data by default ([#1412](https://github.com/ewels/MultiQC/issues/1412))
-  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/ewels/MultiQC/issues/1194))
+  - Fixed module failing when writing data to file if there is a `/` in the section name ([#1515](https://github.com/MultiQC/MultiQC/issues/1515))
+  - Use filename for section header in files with no headers ([#1550](https://github.com/MultiQC/MultiQC/issues/1550))
+  - Sort custom content bargraph data by default ([#1412](https://github.com/MultiQC/MultiQC/issues/1412))
+  - Always save `custom content` data to file with a name reflecting the section name. ([#1194](https://github.com/MultiQC/MultiQC/issues/1194))
 - **DRAGEN**
-  - Fixed bug in sample name regular expression ([#1537](https://github.com/ewels/MultiQC/pull/1537))
+  - Fixed bug in sample name regular expression ([#1537](https://github.com/MultiQC/MultiQC/pull/1537))
 - **Fastp**
-  - Fixed % pass filter statistics ([#1574](https://github.com/ewels/MultiQC/issues/1574))
+  - Fixed % pass filter statistics ([#1574](https://github.com/MultiQC/MultiQC/issues/1574))
 - **FastQC**
-  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/ewels/MultiQC/issues/1488), [#1533](https://github.com/ewels/MultiQC/issues/1533))
+  - Fixed several bugs occuring when FastQC sections are skipped ([#1488](https://github.com/MultiQC/MultiQC/issues/1488), [#1533](https://github.com/MultiQC/MultiQC/issues/1533))
   - Clarify general statistics table header for length
 - **goleft/indexcov**
-  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/ewels/MultiQC/issues/1586))
+  - Fix `ZeroDivisionError` if no bins are found ([#1586](https://github.com/MultiQC/MultiQC/issues/1586))
 - **HiCPro**
-  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/ewels/MultiQC/issues/1366))
+  - Better handling of errors when expected data keys are not found ([#1366](https://github.com/MultiQC/MultiQC/issues/1366))
 - **Lima**
-  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/ewels/MultiQC/pull/1483))
+  - Move samples that have been renamed using `--replace-names` into the _General Statistics_ table ([#1483](https://github.com/MultiQC/MultiQC/pull/1483))
 - **miRTrace**
-  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/ewels/MultiQC/pull/1263))
+  - Replace hardcoded RGB colours with Hex to avoid errors with newer versions of matplotlib ([#1263](https://github.com/MultiQC/MultiQC/pull/1263))
 - **Mosdepth**
-  - Fixed issue [#1568](https://github.com/ewels/MultiQC/issues/1568)
+  - Fixed issue [#1568](https://github.com/MultiQC/MultiQC/issues/1568)
   - Fixed a bug when reporting per contig coverage
 - **Picard**
-  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/ewels/MultiQC/pull/1611))
+  - Update `ExtractIlluminaBarcodes` to recognise more log patterns in newer versions of Picard ([#1611](https://github.com/MultiQC/MultiQC/pull/1611))
 - **Qualimap**
-  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/ewels/MultiQC/issues/1492))
+  - Fix `ZeroDivisionError` in `QM_RNASeq` and skip genomic origins plot if no aligned reads are found ([#1492](https://github.com/MultiQC/MultiQC/issues/1492))
 - **QUAST**
   - Clarify general statistics table header for length
 - **RSeQC**
-  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/ewels/MultiQC/issues/1484))
-  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/ewels/MultiQC/issues/1582))
-  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/ewels/MultiQC/issues/1604))
-  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/ewels/MultiQC/issues/1571))
+  - Fixed minor bug in new TIN parsing where the sample name was not being correctly cleaned ([#1484](https://github.com/MultiQC/MultiQC/issues/1484))
+  - Fixed bug in the `junction_saturation` submodule ([#1582](https://github.com/MultiQC/MultiQC/issues/1582))
+  - Fixed bug where empty files caused `tin` submodule to crash ([#1604](https://github.com/MultiQC/MultiQC/issues/1604))
+  - Fix bug in `read_distribution` for samples with zero tags ([#1571](https://github.com/MultiQC/MultiQC/issues/1571))
 - **Sambamba**
-  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/ewels/MultiQC/issues/1617))
+  - Fixed issue with a change in the format of output from `sambamba markdup` 0.8.1 ([#1617](https://github.com/MultiQC/MultiQC/issues/1617))
 - **Skewer**
-  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/ewels/MultiQC/issues/1622))
+  - Fix `ZeroDivisionError` if no available reads are found ([#1622](https://github.com/MultiQC/MultiQC/issues/1622))
 - **Somalier**
-  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/ewels/MultiQC/issues/1546))
+  - Plot scaled X depth instead of mean for _Sex_ plot ([#1546](https://github.com/MultiQC/MultiQC/issues/1546))
 - **VEP**
-  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/ewels/MultiQC/issues/1597))
+  - Handle table cells containing `-` instead of numbers ([#1597](https://github.com/MultiQC/MultiQC/issues/1597))
 
-## [MultiQC v1.11](https://github.com/ewels/MultiQC/releases/tag/v1.11) - 2021-07-05
+## [MultiQC v1.11](https://github.com/MultiQC/MultiQC/releases/tag/v1.11) - 2021-07-05
 
 ### MultiQC new features
 
-- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/ewels/MultiQC/issues/1427))
+- New interactive slider controls for controlling heatmap colour scales ([#1427](https://github.com/MultiQC/MultiQC/issues/1427))
 - Added new `--replace-names` / config `sample_names_replace` option to replace sample names during report generation
-- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/ewels/MultiQC/issues/949), [#890](https://github.com/ewels/MultiQC/issues/890), [#864](https://github.com/ewels/MultiQC/issues/864), [#998](https://github.com/ewels/MultiQC/issues/998), [#1390](https://github.com/ewels/MultiQC/issues/1390))
+- Added `use_filename_as_sample_name` config option / `--fn_as_s_name` command line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949), [#890](https://github.com/MultiQC/MultiQC/issues/890), [#864](https://github.com/MultiQC/MultiQC/issues/864), [#998](https://github.com/MultiQC/MultiQC/issues/998), [#1390](https://github.com/MultiQC/MultiQC/issues/1390))
   - Forces modules to use the log filename for the sample identifier, even if the module usually takes this from the file contents
   - Required a change to the `clean_s_name()` function arguments. All core MultiQC modules updated to reflect this.
   - Should be backwards compatible for custom modules. To adopt new behaviour, supply `f` instead of `f["root"]` as the second argument.
@@ -575,9 +575,9 @@ for more information.
 - Make the module crash tracebacks much prettier using `rich`
 - Refine the cli log output a little (nicely formatted header line + drop the `[INFO]`)
 - Added docs describing tools for downstream analysis of MultiQC outputs.
-- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/ewels/MultiQC/issues/1413))
-- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/ewels/MultiQC/issues/1416))
-- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/ewels/MultiQC/issues/1254))
+- Added CI tests for Python 3.9, pinned `networkx` package to `>=2.5.1` ([#1413](https://github.com/MultiQC/MultiQC/issues/1413))
+- Added patterns to `config.fn_ignore_paths` to avoid error with parsing installation dir / singularity cache ([#1416](https://github.com/MultiQC/MultiQC/issues/1416))
+- Print a log message when flat-image plots are used due to sample size surpassing `plots_flat_numseries` config ([#1254](https://github.com/MultiQC/MultiQC/issues/1254))
 - Fix the `mqc_colours` util function to lighten colours even when passing categorical or single-length lists.
 - Bugfix for Custom Content, using YAML configuration (eg. section headers) for images should now work
 
@@ -605,22 +605,22 @@ for more information.
   - Rapid haploid variant calling and core genome alignment.
 - [**VEP**](https://www.ensembl.org/info/docs/tools/vep/index.html)
   - Added MultiQC module to add summary statistics of Ensembl VEP annotations.
-  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/ewels/MultiQC/issues/1446))
+  - Handle error from missing variants in VEP stats file. ([#1446](https://github.com/MultiQC/MultiQC/issues/1446))
 
 ### Module feature additions
 
 - **Cutadapt**
-  - Added support for linked adapters [#1329](https://github.com/ewels/MultiQC/issues/1329)]
+  - Added support for linked adapters [#1329](https://github.com/MultiQC/MultiQC/issues/1329)]
   - Parse whether trimming was 5' or 3' for _Lengths of Trimmed Sequences_ plot where possible
 - **Mosdepth**
   - Include or exclude contigs based on patterns for coverage-per-contig plots
 - **Picard**
-  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/ewels/MultiQC/pull/1336))
+  - Add support for `CollectIlluminaBasecallingMetrics`, `CollectIlluminaLaneMetrics`, `ExtractIlluminaBarcodes` and `MarkIlluminaAdapters` ([#1336](https://github.com/MultiQC/MultiQC/pull/1336))
   - New `insertsize_xmax` configuration option to limit the plotted maximum insert size for `InsertSizeMetrics`
 - **Qualimap**
-  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/ewels/MultiQC/issues/1258))
+  - Added new percentage coverage plot in `QM_RNASeq` ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
 - **RSeQC**
-  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/ewels/MultiQC/issues/737))
+  - Added a long-requested submodule to support showing the [**TIN**](http://rseqc.sourceforge.net/#tin-py) (Transcript Integrity Number) ([#737](https://github.com/MultiQC/MultiQC/issues/737))
 
 ### Module updates
 
@@ -631,68 +631,68 @@ for more information.
 - **bcl2fastq**
   - Added sample name cleaning so that prepending directories with the `-d` flag works properly.
 - **Cutadapt**
-  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/ewels/MultiQC/issues/1328))
-  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/ewels/MultiQC/issues/949))
+  - Plot filtered reads even when no filtering category is found ([#1328](https://github.com/MultiQC/MultiQC/issues/1328))
+  - Don't take the last command line string for the sample name if it looks like a command-line flag ([#949](https://github.com/MultiQC/MultiQC/issues/949))
 - **Dragen**
-  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/ewels/MultiQC/issues/1374))
+  - Handled MultiQC crashing when run on single-end output from Dragen ([#1374](https://github.com/MultiQC/MultiQC/issues/1374))
 - **fastp**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/ewels/MultiQC/issues/1444))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1444](https://github.com/MultiQC/MultiQC/issues/1444))
 - **FastQC**
-  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/ewels/MultiQC/issues/1444))
+  - Added check for if `overrepresented_sequences` is missing from reports ([#1281](https://github.com/MultiQC/MultiQC/issues/1444))
 - **Flexbar**
-  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/ewels/MultiQC/issues/1407))
+  - Fixed bug where reports with 0 reads would crash MultiQC ([#1407](https://github.com/MultiQC/MultiQC/issues/1407))
 - **Kraken**
-  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/ewels/MultiQC/issues/1440))
-  - Updated search patterns to handle edge case ([#1428](https://github.com/ewels/MultiQC/issues/1428))
+  - Handle a `ZeroDivisionError` if there are zero reads ([#1440](https://github.com/MultiQC/MultiQC/issues/1440))
+  - Updated search patterns to handle edge case ([#1428](https://github.com/MultiQC/MultiQC/issues/1428))
 - **Mosdepth**
   - Show barplot instead of line graph for coverage-per-contig plot if there is only one contig.
 - **Picard**
-  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/ewels/MultiQC/issues/1408))
-  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/ewels/MultiQC/issues/1414))
-  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/ewels/MultiQC/issues/1296))
+  - `RnaSeqMetrics` - fix assignment barplot labels to say bases instead of reads ([#1408](https://github.com/MultiQC/MultiQC/issues/1408))
+  - `CrosscheckFingerprints` - fix bug where LOD threshold was not detected when invoked with "new" picard cli style. fixed formatting bug ([#1414](https://github.com/MultiQC/MultiQC/issues/1414))
+  - Made checker for comma as decimal separator in `HsMetrics` more robust ([#1296](https://github.com/MultiQC/MultiQC/issues/1296))
 - **qc3C**
   - Updated module to not fail on older field names.
 - **Qualimap**
-  - Fixed wrong units in tool tip label ([#1258](https://github.com/ewels/MultiQC/issues/1258))
+  - Fixed wrong units in tool tip label ([#1258](https://github.com/MultiQC/MultiQC/issues/1258))
 - **QUAST**
-  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/ewels/MultiQC/issues/1442))
+  - Fixed typo causing wrong number of contigs being displayed ([#1442](https://github.com/MultiQC/MultiQC/issues/1442))
 - **Sentieon**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/ewels/MultiQC/issues/1420))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1420](https://github.com/MultiQC/MultiQC/issues/1420))
 - **RSEM**
-  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/ewels/MultiQC/issues/1040))
+  - Handled `ZeroDivisionError` when input files have zero reads ([#1040](https://github.com/MultiQC/MultiQC/issues/1040))
 - **RSeQC**
-  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/ewels/MultiQC/issues/1457))
+  - Fixed double counting of some categories in `read_distribution` bar graph. ([#1457](https://github.com/MultiQC/MultiQC/issues/1457))
 
-## [MultiQC v1.10.1](https://github.com/ewels/MultiQC/releases/tag/v1.10.1) - 2021-04-01
+## [MultiQC v1.10.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.10.1) - 2021-04-01
 
 ### MultiQC updates
 
 - Dropped the `Skipping search pattern` log message from a warning to debug
-- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/ewels/MultiQC/issues/1264))
-- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/ewels/MultiQC/issues/1257))
+- Moved directory prepending with `-d` back to before sample name cleaning (as it was before v1.7) ([#1264](https://github.com/MultiQC/MultiQC/issues/1264))
+- If linegraph plot data goes above `ymax`, only _discard_ the data if the line doesn't come back again ([#1257](https://github.com/MultiQC/MultiQC/issues/1257))
 - Allow scientific notation numbers in colour scheme generation
   - Fixed bug with very small minimum numbers that only revelead itself after a bugfix done in the v1.10 release
-- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/ewels/MultiQC/issues/1274))
-- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/ewels/MultiQC/issues/1393))
-- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/ewels/MultiQC/issues/1395))
+- Allow `top_modules` to be specified as empty dicts ([#1274](https://github.com/MultiQC/MultiQC/issues/1274))
+- Require at least `rich` version `9.4.0` to avoid `SpinnerColumn` `AttributeError` ([#1393](https://github.com/MultiQC/MultiQC/issues/1393))
+- Properly ignore `.snakemake` folders as intended ([#1395](https://github.com/MultiQC/MultiQC/issues/1395))
 
 #### Module updates
 
 - **bcftools**
-  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/ewels/MultiQC/issues/1400))
+  - Fixed bug where `QUAL` value `.` would crash MultiQC ([#1400](https://github.com/MultiQC/MultiQC/issues/1400))
 - **bowtie2**
-  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/ewels/MultiQC/issues/1230))
+  - Fix bug where HiSAT2 paired-end bar plots were missing unaligned reads ([#1230](https://github.com/MultiQC/MultiQC/issues/1230))
 - **Deeptools**
-  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/ewels/MultiQC/issues/1317))
-  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/ewels/MultiQC/issues/1275))
+  - Handle `plotProfile` data where no upstream / downstream regions have been calculated around genes ([#1317](https://github.com/MultiQC/MultiQC/issues/1317))
+  - Fix `IndexError` caused by mysterious `-1` in code.. ([#1275](https://github.com/MultiQC/MultiQC/issues/1275))
 - **FastQC**
-  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/ewels/MultiQC/issues/1246))
+  - Replace `NaN` with `0` in the _Per Base Sequence Content_ plot to avoid crashing the plot ([#1246](https://github.com/MultiQC/MultiQC/issues/1246))
 - **Picard**
-  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/ewels/MultiQC/issues/1397))
+  - Fixed bug in `ValidateSamFile` module where additional whitespace at the end of the file would cause MultiQC to crash ([#1397](https://github.com/MultiQC/MultiQC/issues/1397))
 - **Somalier**
-  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/ewels/MultiQC/issues/1234))
+  - Fixed bug where using sample name cleaning in a config would trigger a `KeyError` ([#1234](https://github.com/MultiQC/MultiQC/issues/1234))
 
-## [MultiQC v1.10](https://github.com/ewels/MultiQC/releases/tag/v1.10) - 2021-03-08
+## [MultiQC v1.10](https://github.com/MultiQC/MultiQC/releases/tag/v1.10) - 2021-03-08
 
 ### Update for developers: Code linting
 
@@ -727,7 +727,7 @@ For further information, please see the [documentation](https://multiqc.info/doc
     allowes module developers to format table cell values as labels.
 - New CI test looks for git merge markers in files
 - Beautiful new [progress bar](https://rich.readthedocs.io/en/stable/progress.html) from the amazing [willmcgugan/rich](https://github.com/willmcgugan/rich) package.
-- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/ewels/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
+- Added a bunch of new default sample name trimming suffixes ([see `8ac5c7b`](https://github.com/MultiQC/MultiQC/commit/8ac5c7b6e4ea6003ca2c9b681953ab3f22c5dd66))
 - Added `timeout-minutes: 10` to the CI test workflow to check that changes aren't negatively affecting run time too much.
 - New table header option `bars_zero_centrepoint` to treat `0` as zero width bars and plot bar length based on absolute values
 
@@ -755,29 +755,29 @@ For further information, please see the [documentation](https://multiqc.info/doc
 #### Module updates
 
 - **DRAGEN**
-  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/ewels/MultiQC/issues/1223))
-  - Added support for whole-exome / targetted data ([#1290](https://github.com/ewels/MultiQC/issues/1290))
+  - Fix issue where missing out fields could crash the module ([#1223](https://github.com/MultiQC/MultiQC/issues/1223))
+  - Added support for whole-exome / targetted data ([#1290](https://github.com/MultiQC/MultiQC/issues/1290))
 - **featureCounts**
-  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/ewels/MultiQC/issues/1022))
+  - Add support for output from [Rsubread](https://bioconductor.org/packages/release/bioc/html/Rsubread.html) ([#1022](https://github.com/MultiQC/MultiQC/issues/1022))
 - **fgbio**
-  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/ewels/MultiQC/pull/1251))
-  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/ewels/MultiQC/pull/1304))
+  - Fix `ErrorRateByReadPosition` to calculate `ymax` not just on the overall `error_rate`, but also specific base errors (ex. `a_to_c_error_rate`, `a_to_g_error_rate`, ...). ([#1215](https://github.com/MultiQC/MultiQC/pull/1251))
+  - Fix `ErrorRateByReadPosition` plotted line names to no longer concatenate multiple read identifiers and no longer have off-by-one read numbering (ex. `Sample1_R2_R3` -> `Sample1_R2`) ([#[1304](https://github.com/MultiQC/MultiQC/pull/1304))
 - **Fastp**
-  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/ewels/MultiQC/pull/1313))
+  - Fixed description for duplication rate (pre-filtering, not post) ([#[1313](https://github.com/MultiQC/MultiQC/pull/1313))
 - **GATK**
   - Add support for the creation of a "Reported vs Empirical Quality" graph to the Base Recalibration module.
 - **hap.py**
-  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/ewels/MultiQC/issues/1241))
+  - Updated module to plot both SNP and INDEL stats ([#1241](https://github.com/MultiQC/MultiQC/issues/1241))
 - **indexcov**
-  - Fixed bug when making the PED file plots ([#1265](https://github.com/ewels/MultiQC/issues/1265))
+  - Fixed bug when making the PED file plots ([#1265](https://github.com/MultiQC/MultiQC/issues/1265))
 - **interop**
   - Added the `% Occupied` metric to `Read Metrics per Lane` table which is reported for NovaSeq and iSeq platforms.
 - **Kaiju**
-  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/ewels/MultiQC/issues/1217))
-  - Rework barplot, add top 5 taxons ([#1219](https://github.com/ewels/MultiQC/issues/1219))
+  - Fixed bug affecting inputs with taxa levels other than Phylum ([#1217](https://github.com/MultiQC/MultiQC/issues/1217))
+  - Rework barplot, add top 5 taxons ([#1219](https://github.com/MultiQC/MultiQC/issues/1219))
 - **Kraken**
-  - Fix `ZeroDivisionError` ([#1276](https://github.com/ewels/MultiQC/issues/1276))
-  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/ewels/MultiQC/pull/1380))
+  - Fix `ZeroDivisionError` ([#1276](https://github.com/MultiQC/MultiQC/issues/1276))
+  - Add distinct minimizer heatmap for KrakenUniq style duplication information ([#1333](https://github.com/MultiQC/MultiQC/pull/1380))
 - **MALT**
   - Fix y-axis labelling in bargraphs
 - **MACS2**
@@ -786,21 +786,21 @@ For further information, please see the [documentation](https://multiqc.info/doc
   - Enable prepending of directory to sample names
   - Display contig names in _Coverage per contig_ plot tooltip
 - **Picard**
-  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/ewels/MultiQC/issues/1212))
-  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/ewels/MultiQC/issues/1310))
+  - Fix `HsMetrics` bait percentage columns ([#1212](https://github.com/MultiQC/MultiQC/issues/1212))
+  - Fix `ConvertSequencingArtifactToOxoG` files not being found ([#1310](https://github.com/MultiQC/MultiQC/issues/1310))
   - Make `WgsMetrics` histogram smoothed if more than 1000 data points (avoids huge plots that crash the browser)
   - Multiple new config options for `WgsMetrics` to customise coverage histogram and speed up MultiQC with very high coverage files.
-  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/ewels/MultiQC/issues/1293))
-  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/ewels/MultiQC/issues/1327))
+  - Add additional datasets to Picard Alignment Summary ([#1293](https://github.com/MultiQC/MultiQC/issues/1293))
+  - Add support for `CrosscheckFingerprints` ([#1327](https://github.com/MultiQC/MultiQC/issues/1327))
 - **PycoQC**
-  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/ewels/MultiQC/issues/1214))
+  - Log10 x-axis for _Read Length_ plot ([#1214](https://github.com/MultiQC/MultiQC/issues/1214))
 - **Rockhopper**
-  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/ewels/MultiQC/issues/1333))
+  - Fix issue with parsing genome names in Rockhopper summary files ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
   - Fix issue properly parsing multiple samples within a single Rockhopper summary file
 - **Salmon**
   - Only try to generate a plot for fragment length if the data was found.
 - **verifyBamID**
-  - Fix `CHIP` value detection ([#1316](https://github.com/ewels/MultiQC/pull/1316)).
+  - Fix `CHIP` value detection ([#1316](https://github.com/MultiQC/MultiQC/pull/1316)).
 
 #### New Custom Content features
 
@@ -811,12 +811,12 @@ For further information, please see the [documentation](https://multiqc.info/doc
 
 #### Bug Fixes
 
-- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/ewels/MultiQC/issues/1333))
+- Disable preservation of timestamps / modes when copying temp report files, to help issues with network shares ([#1333](https://github.com/MultiQC/MultiQC/issues/1333))
 - Fixed MatPlotLib warning: `FixedFormatter should only be used together with FixedLocator`
 - Fixed long-standing min/max bug with shared minimum values for table columns using `shared_key`
 - Made table colour schemes work with negative numbers (don't strip `-` from values when making scheme)
 
-## [MultiQC v1.9](https://github.com/ewels/MultiQC/releases/tag/v1.9) - 2020-05-30
+## [MultiQC v1.9](https://github.com/MultiQC/MultiQC/releases/tag/v1.9) - 2020-05-30
 
 #### Dropped official support for Python 2
 
@@ -848,8 +848,8 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Still testing on both Linux and Windows, with multiple versions of Python
   - CI tests should now run automatically for anyone who forks the MultiQC repository
 - Linting with `--lint` now checks line graphs as well as bar graphs
-- New `gathered` template with no tool name sections ([#1119](https://github.com/ewels/MultiQC/issues/1119))
-- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/ewels/MultiQC/issues/1125))
+- New `gathered` template with no tool name sections ([#1119](https://github.com/MultiQC/MultiQC/issues/1119))
+- Added `--sample-filters` option to add _show_/_hide_ buttons at the top of the report ([#1125](https://github.com/MultiQC/MultiQC/issues/1125))
   - Buttons control the report toolbox Show/Hide tool, filtering your samples
   - Allows reports to be pre-configured based on a supplied list of sample names at report-generation time.
 - Line graphs can now have `Log10` buttons (same functionality as bar graphs)
@@ -862,9 +862,9 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Should help to prevent duplicates requiring `-1` suffixes when running a module multiple times
 - New heatmap plot config options `xcats_samples` and `ycats_samples`
   - If set to `False`, the report toolbox options (_highlight_, _rename_, _show/hide_) do not affect that axis.
-  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/ewels/MultiQC/issues/1172))
+  - Means that the _Show only matching samples_ report toolbox option works on FastQC Status Checks, for example ([#1172](https://github.com/MultiQC/MultiQC/issues/1172))
 - Report header time and analysis paths can now be hidden
-  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/ewels/MultiQC/issues/1113))
+  - New config options `show_analysis_paths` and `show_analysis_time` ([#1113](https://github.com/MultiQC/MultiQC/issues/1113))
 - New search pattern key `skip: true` to skip specific searches when modules look for a lot of different files (eg. Picard).
 - New `--profile-runtime` command line option (`config.profile_runtime`) to give analysis of how long the report takes to be generated
   - Plots of the file search results and durations are added to the end of the MultiQC report as a special module called _Run Time_
@@ -873,7 +873,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Defaults to `true`, set to `false` to also show any data columns that are not defined as headers
   - Useful as allows table-wide defaults to be set with column-specific overrides
 - New `module` key allowed for `config.extra_fn_clean_exts` and `config.fn_clean_exts`
-  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/ewels/MultiQC/issues/905))
+  - Means you can limit the action of a sample name cleaning pattern to specific MultiQC modules ([#905](https://github.com/MultiQC/MultiQC/issues/905))
 
 #### New Custom Content features
 
@@ -881,10 +881,10 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Native handling of HTML snippets as files, no MultiQC config or YAML file required.
   - Also with embedded custom content configuration at the start of the file as a HTML comment.
 - Add ability to group custom-content files into report sections
-  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/ewels/MultiQC/issues/1008))
+  - Use the new `parent_id`, `parent_name` and `parent_description` config keys to group content together like a regular module ([#1008](https://github.com/MultiQC/MultiQC/issues/1008))
 - Custom Content files can now be configured using `custom_data`, without giving search patterns or data
-  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/ewels/MultiQC/issues/1026))
-  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/ewels/MultiQC/issues/1205))
+  - Allows you to set descriptions and nicer titles for images and other 'blunt' data types in reports ([#1026](https://github.com/MultiQC/MultiQC/issues/1026))
+  - Allows configuration of custom content separately from files themselves (`tsv`, `csv`, `txt` formats) ([#1205](https://github.com/MultiQC/MultiQC/issues/1205))
 
 #### New Modules
 
@@ -904,7 +904,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [**MultiVCFAnalyzer**](https://github.com/alexherbig/multivcfanalyzer)
   - Combining multiple VCF files into one coherent report and format for downstream analysis.
 - **Picard** - new submodules for `QualityByCycleMetrics`, `QualityScoreDistributionMetrics` & `QualityYieldMetrics`
-  - See [#1116](https://github.com/ewels/MultiQC/issues/1114)
+  - See [#1116](https://github.com/MultiQC/MultiQC/issues/1114)
 - [**Rockhopper**](https://cs.wellesley.edu/~btjaden/Rockhopper/)
   - RNA-seq tool for bacteria, includes bar plot showing where features map.
 - [**Sickle**](https://github.com/najoshi/sickle)
@@ -919,13 +919,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **BISCUIT**
   - Major rewrite to work with new BISCUIT QC script (BISCUIT `v0.3.16+`)
     - This change breaks backwards-compatability with previous BISCUIT versions. If you are unable to upgrade BISCUIT, please use MultiQC v1.8.
-  - Fixed error when missing data in log files ([#1101](https://github.com/ewels/MultiQC/issues/1101))
+  - Fixed error when missing data in log files ([#1101](https://github.com/MultiQC/MultiQC/issues/1101))
 - **bcl2fastq**
-  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/ewels/MultiQC/issues/1094))
+  - Samples with multiple library preps (i.e barcodes) will now be handled correctly ([#1094](https://github.com/MultiQC/MultiQC/issues/1094))
 - **BUSCO**
-  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/ewels/MultiQC/issues/1163))
+  - Updated log search pattern to match new format in v4 with auto-lineage detection option ([#1163](https://github.com/MultiQC/MultiQC/issues/1163))
 - **Cutadapt**
-  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/ewels/MultiQC/issues/1198))
+  - New bar plot showing the proportion of reads filtered out for different criteria (eg. _too short_, _too many Ns_) ([#1198](https://github.com/MultiQC/MultiQC/issues/1198))
 - **DamageProfiler**
   - Removes redundant typo in init name. This makes referring to the module's column consistent with other modules when customising general stats table.
 - **DeDup**
@@ -933,69 +933,69 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Fixes reporting errors - barplot total represents _mapped_ reads, not total reads in BAM file
   - New: Adds 'Post-DeDup Mapped Reads' column to general stats table.
 - **FastQC**
-  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/ewels/MultiQC/issues/1092))
-  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/ewels/MultiQC/issues/1129))
+  - Fixed tooltip text in _Sequence Duplication Levels_ plot ([#1092](https://github.com/MultiQC/MultiQC/issues/1092))
+  - Handle edge-case where a FastQC report was for an empty file with 0 reads ([#1129](https://github.com/MultiQC/MultiQC/issues/1129))
 - **FastQ Screen**
-  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
-  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/ewels/MultiQC/issues/1126))
+  - Don't skip plotting `% No Hits` even if it's `0%` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
+  - Refactor parsing code. Avoids error with `-0.00 %Unmapped` ([#1126](https://github.com/MultiQC/MultiQC/issues/1126))
   - New plot for _Bisulfite Reads_, if data is present
   - Categories in main plot are now sorted by the total read count and hidden if 0 across all samples
 - **fgbio**
   - New: Plot error rate by read position from `ErrorRateByReadPosition`
-  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/ewels/MultiQC/pull/1147))
+  - GroupReadsByUmi plot can now be toggled to show relative percents ([#1147](https://github.com/MultiQC/MultiQC/pull/1147))
 - **FLASh**
-  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/ewels/MultiQC/issues/1173))
+  - Logs not reporting innie and outine uncombined pairs now plot combined pairs instead ([#1173](https://github.com/MultiQC/MultiQC/issues/1173))
 - **GATK**
-  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/ewels/MultiQC/issues/1158))
+  - Made parsing for VariantEval more tolerant, so that it will work with output from the tool when run in different modes ([#1158](https://github.com/MultiQC/MultiQC/issues/1158))
 - **MTNucRatioCalculator**
   - Fixed misleading value suffix in general stats table
 - **Picard MarkDuplicates**
   - **Major change** - previously, if multiple libraries (read-groups) were found then only the first would be used and all others ignored. Now, values from all libraries are merged and `PERCENT_DUPLICATION` and `ESTIMATED_LIBRARY_SIZE` are recalculated. Libraries can be kept as separate samples with a new MultiQC configuration option - `picard_config: markdups_merge_multiple_libraries: False`
-  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/ewels/MultiQC/issues/1142))
+  - **Major change** - Updated `MarkDuplicates` bar plot to double the read-pair counts, so that the numbers stack correctly. ([#1142](https://github.com/MultiQC/MultiQC/issues/1142))
 - **Picard HsMetrics**
-  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/ewels/MultiQC/issues/831))
+  - Updated large table to use columns specified in the MultiQC config. See [docs](https://multiqc.info/docs/#hsmetrics). ([#831](https://github.com/MultiQC/MultiQC/issues/831))
 - **Picard WgsMetrics**
-  - Updated parsing code to recognise new java class string ([#1114](https://github.com/ewels/MultiQC/issues/1114))
+  - Updated parsing code to recognise new java class string ([#1114](https://github.com/MultiQC/MultiQC/issues/1114))
 - **QualiMap**
-  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/ewels/MultiQC/issues/1082), [#1077](https://github.com/ewels/MultiQC/issues/1082)
+  - Fixed QualiMap mean coverage calculation [#1082](https://github.com/MultiQC/MultiQC/issues/1082), [#1077](https://github.com/MultiQC/MultiQC/issues/1082)
 - **RSeqC**
-  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/ewels/MultiQC/issues/844))
-  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/ewels/MultiQC/issues/1133))
+  - Support added for output from `geneBodyCoverage2.py` script ([#844](https://github.com/MultiQC/MultiQC/issues/844))
+  - Single sample view in the _"Junction saturation"_ plot now works with the toolbox properly _(rename, hide, highlight)_ ([#1133](https://github.com/MultiQC/MultiQC/issues/1133))
 - **RNASeQC2**
   - Updated to handle the parsing metric files from the [newer rewrite of RNA-SeqQC](https://github.com/broadinstitute/rnaseqc).
 - **Samblaster**
-  - Improved parsing to handle variable whitespace ([#1176](https://github.com/ewels/MultiQC/issues/1176))
+  - Improved parsing to handle variable whitespace ([#1176](https://github.com/MultiQC/MultiQC/issues/1176))
 - **Samtools**
-  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/ewels/MultiQC/issues/1076](https://github.com/ewels/MultiQC/issues/1076)).
-  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/ewels/MultiQC/issues/1118))
+  - Removes hardcoding of general stats column names. This allows column names to indicate when a module has been run twice ([https://github.com/MultiQC/MultiQC/issues/1076](https://github.com/MultiQC/MultiQC/issues/1076)).
+  - Added an observed over expected read count plot for `idxstats` ([#1118](https://github.com/MultiQC/MultiQC/issues/1118))
   - Added additional (by default hidden) column for `flagstat` that displays number total number of reads in a bam
 - **sortmerna**
-  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/ewels/MultiQC/issues/1121))
+  - Fix the bug for the latest sortmerna version 4.2.0 ([#1121](https://github.com/MultiQC/MultiQC/issues/1121))
 - **sexdeterrmine**
   - Added a scatter plot of relative X- vs Y-coverage to the generated report.
 - **VerifyBAMID**
-  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/ewels/MultiQC/issues/1112))
+  - Allow files with column header `FREEMIX(alpha)` ([#1112](https://github.com/MultiQC/MultiQC/issues/1112))
 
 #### Bug Fixes
 
 - Added a new test to check that modules work correctly with `--ignore-samples`. A lot of them didn't:
   - `Mosdepth`, `conpair`, `Qualimap BamQC`, `RNA-SeQC`, `GATK BaseRecalibrator`, `SNPsplit`, `SeqyClean`, `Jellyfish`, `hap.py`, `HOMER`, `BBMap`, `DeepTools`, `HiCExplorer`, `pycoQC`, `interop`
   - These modules have now all been fixed and `--ignore-samples` should work as you expect for whatever data you have.
-- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/ewels/MultiQC/issues/1130))
+- Removed use of `shutil.copy` to avoid problems with working on multiple filesystems ([#1130](https://github.com/MultiQC/MultiQC/issues/1130))
 - Made folder naming behaviour of `multiqc_plots` consistent with `multiqc_data`
   - Incremental numeric suffixes now added if folder already exists
   - Plots folder properly renamed if using `-n`/`--filename`
-- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/ewels/MultiQC/issues/1136))
+- Heatmap plotting function is now compatible with MultiQC toolbox `hide` and `highlight` ([#1136](https://github.com/MultiQC/MultiQC/issues/1136))
 - Plot config `logswitch_active` now works as advertised
-- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/ewels/MultiQC/issues/1175))
+- When running MultiQC modules several times, multiple data files are now created instead of overwriting one another ([#1175](https://github.com/MultiQC/MultiQC/issues/1175))
 - Fixed minor bug where tables could report negative numbers of columns in their header text
-- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/ewels/MultiQC/issues/1091))
-- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/ewels/MultiQC/issues/1071))
+- Fixed bug where numeric custom content sample names could trigger a `TypeError` ([#1091](https://github.com/MultiQC/MultiQC/issues/1091))
+- Fixed custom content bug HTML data in a config file would trigger a `ValueError` ([#1071](https://github.com/MultiQC/MultiQC/issues/1071))
 - Replaced deprecated 'warn()' with 'warning()' of the logging module
 - Custom content now supports `section_extra` config key to add custom HTML after description.
 - Barplots with `ymax` set now ignore this when you click the _Percentages_ tab.
 
-## [MultiQC v1.8](https://github.com/ewels/MultiQC/releases/tag/v1.8) - 2019-11-20
+## [MultiQC v1.8](https://github.com/MultiQC/MultiQC/releases/tag/v1.8) - 2019-11-20
 
 #### New Modules
 
@@ -1027,16 +1027,16 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **damageprofiler**
   - Added writing metrics to data output file.
 - **DeepTools**
-  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/ewels/MultiQC/issues/1057))
-  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/ewels/MultiQC/issues/1011))
+  - Fixed Python3 bug with int() conversion ([#1057](https://github.com/MultiQC/MultiQC/issues/1057))
+  - Handle varied TES boundary labels in plotProfile ([#1011](https://github.com/MultiQC/MultiQC/issues/1011))
   - Fixed bug that prevented running on only plotProfile files when no other deepTools files found.
 - **fastp**
-  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/ewels/MultiQC/issues/936))
+  - Fix faulty column handling for the _after filtering_ Q30 rate ([#936](https://github.com/MultiQC/MultiQC/issues/936))
 - **FastQC**
   - When including a FastQC section multiple times in one report, the Per Base Sequence Content heatmaps now behave as you would expect.
   - Added heatmap showing FastQC status checks for every section report across all samples
-  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/ewels/MultiQC/issues/777))
-  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/ewels/MultiQC/issues/742))
+  - Made sequence content individual plots work after samples have been renamed ([#777](https://github.com/MultiQC/MultiQC/issues/777))
+  - Highlighting samples from status - respect chosen highlight colour in the toolbox ([#742](https://github.com/MultiQC/MultiQC/issues/742))
 - **FastQ Screen**
   - When including a FastQ Screen section multiple times in one report, the plots now behave as you would expect.
   - Fixed MultiQC linting errors
@@ -1050,18 +1050,18 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Updated the format of the report to fits the changes which have been applied to the QC report of hicexplorer v3.3
   - Updated code to save parsed results to `multiqc_data`
 - **HTSeq**
-  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/ewels/MultiQC/issues/1006))
+  - Fixed bug where module would crash if a sample had zero reads ([#1006](https://github.com/MultiQC/MultiQC/issues/1006))
 - **LongRanger**
   - Added support for the LongRanger Align pipeline.
 - **miRTrace**
-  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/ewels/MultiQC/issues/932))
+  - Fixed bug where a sample in some plots was missed. ([#932](https://github.com/MultiQC/MultiQC/issues/932))
 - **Peddy**
-  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/ewels/MultiQC/issues/1024))
+  - Fixed bug where sample name cleaning could lead to error. ([#1024](https://github.com/MultiQC/MultiQC/issues/1024))
   - All plots (including _Het Check_ and _Sex Check_) now hidden if no data
 - **Picard**
   - Modified `OxoGMetrics` so that it will find files created with GATK `CollectMultipleMetrics` and `ConvertSequencingArtifactToOxoG`.
 - **QoRTs**
-  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/ewels/MultiQC/issues/821))
+  - Fixed bug where `--dirs` broke certain input files. ([#821](https://github.com/MultiQC/MultiQC/issues/821))
 - **Qualimap**
   - Added in mean coverage computation for general statistics report
   - Creates now tables of collected data in `multiqc_data`
@@ -1070,13 +1070,13 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - **RSeQC**
   - Fixed bug where Junction Saturation plot when clicking a single sample was mislabelling the lines.
   - When including a RSeQC section multiple times in one report, clicking Junction Saturation plot now behaves as you would expect.
-  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/ewels/MultiQC/issues/1017))
+  - Fixed bug where exported data in `multiqc_rseqc_read_distribution.txt` files had incorrect values for `_kb` fields ([#1017](https://github.com/MultiQC/MultiQC/issues/1017))
 - **Samtools**
   - Utilize in-built `read_count_multiplier` functionality to plot `flagstat` results more nicely
 - **SnpEff**
   - Increased the default summary csv file-size limit from 1MB to 5MB.
 - **Stacks**
-  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/ewels/MultiQC/issues/906))
+  - Fixed bug where multi-population sum stats are parsed correctly ([#906](https://github.com/MultiQC/MultiQC/issues/906))
 - **TopHat**
   - Fixed bug where TopHat would try to run with files from Bowtie2 or HiSAT2 and crash
 - **VCFTools**
@@ -1101,22 +1101,22 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Windows support for base `multiqc` command
   - Support for running as a python module: `python -m multiqc .`
   - Support for running within a script: `import multiqc` and `multiqc.run('/path/to/files')`
-- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/ewels/MultiQC/issues/1044))
-- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/ewels/MultiQC/issues/541))
+- Config option `custom_plot_config` now works for bargraph category configs as well ([#1044](https://github.com/MultiQC/MultiQC/issues/1044))
+- Config `table_columns_visible` can now be given a module namespace and it will hide all columns from that module ([#541](https://github.com/MultiQC/MultiQC/issues/541))
 
 #### Bug Fixes
 
 - MultiQC now ignores all `.md5` files
 - Use `SafeLoader` for PyYaml load calls, avoiding recent warning messages.
 - Hide `multiqc_config_example.yaml` in the `test` directory to stop people from using it without modification.
-- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/ewels/MultiQC/issues))
-- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/ewels/MultiQC/issues/835))
+- Fixed matplotlib background colour issue (@epakarin - [#886](https://github.com/MultiQC/MultiQC/issues))
+- Table rows that are empty due to hidden columns are now properly hidden on page load ([#835](https://github.com/MultiQC/MultiQC/issues/835))
 - Sample name cleaning: All sample names are now truncated to their basename, without a path.
   - This includes for `regex` and `replace` (before was only the default `truncate`).
   - Only affects modules that take sample names from file contents, such as cutadapt.
-  - See [#897](https://github.com/ewels/MultiQC/issues/897) for discussion.
+  - See [#897](https://github.com/MultiQC/MultiQC/issues/897) for discussion.
 
-## [MultiQC v1.7](https://github.com/ewels/MultiQC/releases/tag/v1.7) - 2018-12-21
+## [MultiQC v1.7](https://github.com/MultiQC/MultiQC/releases/tag/v1.7) - 2018-12-21
 
 #### New Modules
 
@@ -1142,7 +1142,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 #### Module updates
 
 - **AdapterRemoval**
-  - Handle error when zero bases are trimmed. See [#838](https://github.com/ewels/MultiQC/issues/838).
+  - Handle error when zero bases are trimmed. See [#838](https://github.com/MultiQC/MultiQC/issues/838).
 - **Bcl2fastq**
   - New plot showing the top twenty of undetermined barcodes by lane.
   - Informations for R1/R2 are now separated in the General Statistics table.
@@ -1154,12 +1154,12 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - New sequence distribution profiles around genes, from the `plotProfile` function (written by [@chuan-wang](https://github.com/chuan-wang/))
   - Reordered sections
 - **Fastp**
-  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/ewels/MultiQC/issues/845).
+  - Fixed bug in parsing of empty histogram data. See [#845](https://github.com/MultiQC/MultiQC/issues/845).
 - **FastQC**
-  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/ewels/MultiQC/issues/812).
+  - Refactored _Per Base Sequence Content_ plots to show original underlying data, instead of calculating it from the page contents. Now shows original FastQC base-ranges and fixes 100% GC bug in final few pixels. See [#812](https://github.com/MultiQC/MultiQC/issues/812).
   - When including a FastQC section multiple times in one report, the summary progress bars now behave as you would expect.
 - **FastQ Screen**
-  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/ewels/MultiQC/issues/829).
+  - Don't hide genomes in the simple plot, even if they have zero unique hits. See [#829](https://github.com/MultiQC/MultiQC/issues/829).
 - **InterOp**
   - Fixed bug where read counts and base pair yields were not displaying in tables correctly.
   - Number formatting for these fields can now be customised in the same way as with other modules, as described [in the docs](http://multiqc.info/docs/#number-base-multiplier)
@@ -1172,14 +1172,14 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
   - Properly clean sample names
 - **Trimmomatic**
   - Updated Trimmomatic module documentation to be more helpful
-  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/ewels/MultiQC/issues/864).
+  - New option to use filenames instead of relying on the command line used. See [#864](https://github.com/MultiQC/MultiQC/issues/864).
 
 #### New MultiQC Features
 
 - Embed your custom images with a new Custom Content feature! Just add `_mqc` to the end of the filename for `.png`, `.jpg` or `.jpeg` files.
 - Documentation for Custom Content reordered to make it a little more sane
 - You can now add or override any config parameter for any MultiQC plot! See [the documentation](http://multiqc.info/docs/#customising-plots) for more info.
-- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/ewels/MultiQC/issues/841).
+- Allow `table_columns_placement` config to work with table IDs as well as column namespaces. See [#841](https://github.com/MultiQC/MultiQC/issues/841).
 - Improved visual spacing between grouped bar plots
 
 #### Bug Fixes
@@ -1189,7 +1189,7 @@ to break. If you haven't already, **you need to switch to Python 3 now**.
 - [Sample name directory prefixes](https://multiqc.info/docs/#sample-names-prefixed-with-directories) are now added _after_ cleanup.
 - If a module is run multiple times in one report, it's CSS and JS files will only be included once (`default` template)
 
-## [MultiQC v1.6](https://github.com/ewels/MultiQC/releases/tag/v1.6) - 2018-08-04
+## [MultiQC v1.6](https://github.com/MultiQC/MultiQC/releases/tag/v1.6) - 2018-08-04
 
 Some of these updates are thanks to the efforts of people who attended the [NASPM](https://twitter.com/NordicGenomics) 2018 MultiQC hackathon session. Thanks to everyone who attended!
 
@@ -1269,10 +1269,10 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Fix linegraph and scatter plots data conversion (sporadically the incorrect `ymax` was used to drop data points) ([@cpavanrun](https://github.com/cpavanrun))
 - Adjusted behavior of ceiling and floor axis limits
 - Adjusted multiple file search patterns to make them more specific
-  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/ewels/MultiQC/pull/727))
-- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/ewels/MultiQC/issues/801))
+  - Prevents the wrong module from accidentally slurping up output from a different tool. By [@cpavanrun](https://github.com/cpavanrun) (see [PR #727](https://github.com/MultiQC/MultiQC/pull/727))
+- Fixed broken report bar plots when `-p`/`--export-plots` was specified (see issue [#801](https://github.com/MultiQC/MultiQC/issues/801))
 
-## [MultiQC v1.5](https://github.com/ewels/MultiQC/releases/tag/v1.5) - 2018-03-15
+## [MultiQC v1.5](https://github.com/MultiQC/MultiQC/releases/tag/v1.5) - 2018-03-15
 
 #### New Modules
 
@@ -1332,7 +1332,7 @@ Some of these updates are thanks to the efforts of people who attended the [NASP
 - Locked the `matplotlib` version to `v2.1.0` and below
   - Due to [two](https://github.com/matplotlib/matplotlib/issues/10476) [bugs](https://github.com/matplotlib/matplotlib/issues/10784) that appeared in `v2.2.0` - will remove this constraint when there's a new release that works again.
 
-## [MultiQC v1.4](https://github.com/ewels/MultiQC/releases/tag/v1.4) - 2018-01-11
+## [MultiQC v1.4](https://github.com/MultiQC/MultiQC/releases/tag/v1.4) - 2018-01-11
 
 A slightly earlier-than-expected release due to a new problem with dependency packages that is breaking MultiQC installations since 2018-01-11.
 
@@ -1386,7 +1386,7 @@ A slightly earlier-than-expected release due to a new problem with dependency pa
 - Updated pandoc command used in `--pdf` to work with new releases of Pandoc
 - Made config `table_columns_visible` module name key matching case insensitive to make less frustrating
 
-## [MultiQC v1.3](https://github.com/ewels/MultiQC/releases/tag/v1.3) - 2017-11-03
+## [MultiQC v1.3](https://github.com/MultiQC/MultiQC/releases/tag/v1.3) - 2017-11-03
 
 #### Breaking changes - custom search patterns
 
@@ -1471,7 +1471,7 @@ string beginning with the name of your module, anything you like after the first
 - Don't prepend the directory separator (`|`) to sample names with `-d` when there are no subdirs
 - `yPlotLines` now works even if you don't set `width`
 
-## [MultiQC v1.2](https://github.com/ewels/MultiQC/releases/tag/v1.2) - 2017-08-16
+## [MultiQC v1.2](https://github.com/MultiQC/MultiQC/releases/tag/v1.2) - 2017-08-16
 
 #### CodeFest 2017 Contributions
 
@@ -1567,7 +1567,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.1](https://github.com/ewels/MultiQC/releases/tag/v1.1) - 2017-07-18
+## [MultiQC v1.1](https://github.com/MultiQC/MultiQC/releases/tag/v1.1) - 2017-07-18
 
 #### New Modules
 
@@ -1649,7 +1649,7 @@ Many thanks to those involved!
 
 ---
 
-## [MultiQC v1.0](https://github.com/ewels/MultiQC/releases/tag/v1.0) - 2017-05-17
+## [MultiQC v1.0](https://github.com/MultiQC/MultiQC/releases/tag/v1.0) - 2017-05-17
 
 Version 1.0! This release has been a long time coming and brings with it some fairly
 major improvements in speed, report filesize and report performance. There's also
@@ -1817,7 +1817,7 @@ To see what changes need to applied to your custom plugin code, please see the [
 
 ---
 
-## [MultiQC v0.9](https://github.com/ewels/MultiQC/releases/tag/v0.9) - 2016-12-21
+## [MultiQC v0.9](https://github.com/MultiQC/MultiQC/releases/tag/v0.9) - 2016-12-21
 
 A major new feature is released in v0.9 - support for _custom content_. This means
 that MultiQC can now easily include output from custom scripts within reports without
@@ -1910,7 +1910,7 @@ the need for a new module or plugin. For more information, please see the
 
 ---
 
-## [MultiQC v0.8](https://github.com/ewels/MultiQC/releases/tag/v0.8) - 2016-09-26
+## [MultiQC v0.8](https://github.com/MultiQC/MultiQC/releases/tag/v0.8) - 2016-09-26
 
 #### New Modules
 
@@ -1986,7 +1986,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.7](https://github.com/ewels/MultiQC/releases/tag/v0.7) - 2016-07-04
+## [MultiQC v0.7](https://github.com/MultiQC/MultiQC/releases/tag/v0.7) - 2016-07-04
 
 #### Module updates
 
@@ -2055,7 +2055,7 @@ who worked on MultiQC projects.
 
 ---
 
-## [MultiQC v0.6](https://github.com/ewels/MultiQC/releases/tag/v0.6) - 2016-04-29
+## [MultiQC v0.6](https://github.com/MultiQC/MultiQC/releases/tag/v0.6) - 2016-04-29
 
 #### Module updates
 
@@ -2095,7 +2095,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.5](https://github.com/ewels/MultiQC/releases/tag/v0.5) - 2016-03-29
+## [MultiQC v0.5](https://github.com/MultiQC/MultiQC/releases/tag/v0.5) - 2016-03-29
 
 #### Module updates
 
@@ -2128,7 +2128,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.4](https://github.com/ewels/MultiQC/releases/tag/v0.4) - 2016-02-16
+## [MultiQC v0.4](https://github.com/MultiQC/MultiQC/releases/tag/v0.4) - 2016-02-16
 
 - New `multiqc_sources.txt` which identifies the paths used to collect all report data for each sample
 - Export parsed data as tab-delimited text, `JSON` or `YAML` using the new `-k`/`--data-format` command line option
@@ -2148,7 +2148,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.2](https://github.com/ewels/MultiQC/releases/tag/v0.3.2) - 2016-02-08
+## [MultiQC v0.3.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.2) - 2016-02-08
 
 - All modules now load their log file search parameters from a config
   file, allowing you to overwrite them using your user config file
@@ -2194,7 +2194,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3.1](https://github.com/ewels/MultiQC/releases/tag/v0.3.1) - 2015-11-04
+## [MultiQC v0.3.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.3.1) - 2015-11-04
 
 - Hotfix patch to fix broken FastQC module (wasn't finding `.zip` files properly)
 - General Stats table colours now flat. Should improve browser speed.
@@ -2203,7 +2203,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.3](https://github.com/ewels/MultiQC/releases/tag/v0.3) - 2015-11-04
+## [MultiQC v0.3](https://github.com/MultiQC/MultiQC/releases/tag/v0.3) - 2015-11-04
 
 - Lots of lovely new documentation!
 - Child templates - easily customise specific parts of the default report template
@@ -2240,11 +2240,11 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.2](https://github.com/ewels/MultiQC/releases/tag/v0.2) - 2015-09-18
+## [MultiQC v0.2](https://github.com/MultiQC/MultiQC/releases/tag/v0.2) - 2015-09-18
 
 - Code restructuring for nearly all modules. Common base module
   functions now handle many more functions (plots, config, file import)
-  - See the [contributing notes](https://github.com/ewels/MultiQC/blob/master/CONTRIBUTING.md)
+  - See the [contributing notes](https://github.com/MultiQC/MultiQC/blob/master/CONTRIBUTING.md)
     for instructions on how to use these new helpers to make your own module
 - New report toolbox - sample highlighting, renaming, hiding
   - Config is autosaved by default, can also export to a file for sharing
@@ -2263,7 +2263,7 @@ Bugfixes:
 
 ---
 
-## [MultiQC v0.1](https://github.com/ewels/MultiQC/releases/tag/v0.1) - 2015-09-01
+## [MultiQC v0.1](https://github.com/MultiQC/MultiQC/releases/tag/v0.1) - 2015-09-01
 
 - The first public release of MultiQC, after a month of development. Basic
   structure in place and modules for FastQC, FastQ Screen, Cutadapt, Bismark,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ title: "MultiQC: summarize analysis results for multiple tools and samples in a 
 version: 1.12
 doi: 10.1093/bioinformatics/btw354
 date-released: 2022-02-08
-url: "https://github.com/ewels/MultiQC"
+url: "https://github.com/MultiQC/MultiQC"
 preferred-citation:
   type: article
   authors:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A very large number of Bioinformatics tools are supported by MultiQC. Please see
 MultiQC can also easily parse data from custom scripts, if correctly formatted / configured - a feature called [Custom Content](https://multiqc.info/docs/custom_content/).
 
 More modules are being written all of the time. Please suggest any ideas as a new
-[issue](https://github.com/ewels/MultiQC/issues) _(please include example log files)_.
+[issue](https://github.com/MultiQC/MultiQC/issues) _(please include example log files)_.
 
 ## Installation
 
@@ -46,7 +46,7 @@ conda install multiqc
 If you would like the development version from GitHub instead, you can install it with `pip`:
 
 ```bash
-pip install --upgrade --force-reinstall git+https://github.com/ewels/MultiQC.git
+pip install --upgrade --force-reinstall git+https://github.com/MultiQC/MultiQC.git
 ```
 
 MultiQC is also available via Docker and Singularity images, Galaxy wrappers, and
@@ -104,10 +104,10 @@ Please consider citing MultiQC if you use it in your analysis.
 ## Contributions & Support
 
 Contributions and suggestions for new features are welcome, as are bug reports!
-Please create a new [issue](https://github.com/ewels/MultiQC/issues) for any
+Please create a new [issue](https://github.com/MultiQC/MultiQC/issues) for any
 of these, including example reports where possible.
 Pull-requests for fixes and additions are very welcome.
-Please see the [contributing notes](https://github.com/ewels/MultiQC/blob/master/.github/CONTRIBUTING.md) for more information about how the process works.
+Please see the [contributing notes](https://github.com/MultiQC/MultiQC/blob/master/.github/CONTRIBUTING.md) for more information about how the process works.
 
 MultiQC has extensive [documentation](http://multiqc.info/docs/development/)
 describing how to write new modules, plugins and templates.
@@ -121,6 +121,6 @@ MultiQC is developed and maintained by Phil Ewels ([@ewels](https://github.com/e
 It was originally written at the [National Genomics Infrastructure](https://ngisweden.scilifelab.se/), part of [SciLifeLab](https://www.scilifelab.se/) in Sweden.
 
 A huge thank you to all code contributors - there are a lot of you!
-See the [Contributors Graph](https://github.com/ewels/MultiQC/graphs/contributors) for details.
+See the [Contributors Graph](https://github.com/MultiQC/MultiQC/graphs/contributors) for details.
 
 MultiQC is released under the GPL v3 or later licence.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Contributions and suggestions for new features are welcome, as are bug reports!
 Please create a new [issue](https://github.com/MultiQC/MultiQC/issues) for any
 of these, including example reports where possible.
 Pull-requests for fixes and additions are very welcome.
-Please see the [contributing notes](https://github.com/MultiQC/MultiQC/blob/master/.github/CONTRIBUTING.md) for more information about how the process works.
+Please see the [contributing notes](https://github.com/MultiQC/MultiQC/blob/main/.github/CONTRIBUTING.md) for more information about how the process works.
 
 MultiQC has extensive [documentation](http://multiqc.info/docs/development/)
 describing how to write new modules, plugins and templates.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,4 +19,4 @@ If you write a module which could be of use to others, it would be great to
 merge those changes back into the core MultiQC project.
 
 For instructions on how best to do this, please see the
-[contributing instructions](https://github.com/MultiQC/MultiQC/blob/master/.github/CONTRIBUTING.md).
+[contributing instructions](https://github.com/MultiQC/MultiQC/blob/main/.github/CONTRIBUTING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ of common tools.
 These docs can be read in any of three ways:
 
 - On the MultiQC Website: <http://multiqc.info>
-- On GitHub: <https://github.com/ewels/MultiQC/>
+- On GitHub: <https://github.com/MultiQC/MultiQC/>
 - As part of the distributed source code (in `/docs/`)
 
 If you're curious how the website works, check out the
@@ -19,4 +19,4 @@ If you write a module which could be of use to others, it would be great to
 merge those changes back into the core MultiQC project.
 
 For instructions on how best to do this, please see the
-[contributing instructions](https://github.com/ewels/MultiQC/blob/master/.github/CONTRIBUTING.md).
+[contributing instructions](https://github.com/MultiQC/MultiQC/blob/master/.github/CONTRIBUTING.md).

--- a/docs/core/custom_content/index.md
+++ b/docs/core/custom_content/index.md
@@ -257,7 +257,7 @@ custom_data:
   example_files:
     file_format: "tsv"
     section_name: "Coverage Decay"
-    description: "This plot comes from files acommpanied by a mutliqc_config.yaml file for configuration"
+    description: "This plot comes from files acommpanied by a multiqc_config.yaml file for configuration"
     plot_type: "linegraph"
     pconfig:
       id: "example_coverage_lineplot"

--- a/docs/core/custom_content/index.md
+++ b/docs/core/custom_content/index.md
@@ -16,7 +16,7 @@ Custom content parsing is a little more restricted than standard modules. Specif
 - Plot customisation is more limited
 
 All plot types can be generated using custom content - see the
-[test files](https://github.com/MultiQC/test-data/tree/master/data/custom_content)
+[test files](https://github.com/MultiQC/test-data/tree/main/data/custom_content)
 for examples of how data should be structured.
 
 :::note
@@ -147,7 +147,7 @@ description: 'This section is created using a custom HTML file'
 
 If no configuration is given, MultiQC will do its best to guess how to visualise your data appropriately.
 To see examples of typical file structures which are understood, see the
-[test data](https://github.com/MultiQC/test-data/tree/master/data/custom_content/no_config)
+[test data](https://github.com/MultiQC/test-data/tree/main/data/custom_content/no_config)
 used to develop this code. Something will be probably be shown, but it may produce unexpected results.
 
 :::note
@@ -294,7 +294,7 @@ custom_data:
 
 If no configuration is given, MultiQC will do its best to guess how to visualise
 your data appropriately. To see examples of typical file structures which are understood, see the
-[test data](https://github.com/MultiQC/test-data/tree/master/data/custom_content/no_config)
+[test data](https://github.com/MultiQC/test-data/tree/main/data/custom_content/no_config)
 used to develop this code.
 
 # Configuration
@@ -446,7 +446,7 @@ Probably the best way to get to grips with Custom Content is to see some example
 The MultiQC automated testing runs with a bunch of different files, and I try to add to
 these all the time.
 
-You can see these examples here: <https://github.com/MultiQC/test-data/tree/master/data/custom_content>
+You can see these examples here: <https://github.com/MultiQC/test-data/tree/main/data/custom_content>
 
 For example, to see a file which generates a table in a report by itself, you can
-have a look at `embedded_config/table_headers_mqc.txt` ([link](https://github.com/MultiQC/test-data/blob/master/data/custom_content/embedded_config/table_headers_mqc.txt)).
+have a look at `embedded_config/table_headers_mqc.txt` ([link](https://github.com/MultiQC/test-data/blob/main/data/custom_content/embedded_config/table_headers_mqc.txt)).

--- a/docs/core/custom_content/index.md
+++ b/docs/core/custom_content/index.md
@@ -16,7 +16,7 @@ Custom content parsing is a little more restricted than standard modules. Specif
 - Plot customisation is more limited
 
 All plot types can be generated using custom content - see the
-[test files](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content)
+[test files](https://github.com/MultiQC/test-data/tree/master/data/custom_content)
 for examples of how data should be structured.
 
 :::note
@@ -147,7 +147,7 @@ description: 'This section is created using a custom HTML file'
 
 If no configuration is given, MultiQC will do its best to guess how to visualise your data appropriately.
 To see examples of typical file structures which are understood, see the
-[test data](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content/no_config)
+[test data](https://github.com/MultiQC/test-data/tree/master/data/custom_content/no_config)
 used to develop this code. Something will be probably be shown, but it may produce unexpected results.
 
 :::note
@@ -294,7 +294,7 @@ custom_data:
 
 If no configuration is given, MultiQC will do its best to guess how to visualise
 your data appropriately. To see examples of typical file structures which are understood, see the
-[test data](https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content/no_config)
+[test data](https://github.com/MultiQC/test-data/tree/master/data/custom_content/no_config)
 used to develop this code.
 
 # Configuration
@@ -446,7 +446,7 @@ Probably the best way to get to grips with Custom Content is to see some example
 The MultiQC automated testing runs with a bunch of different files, and I try to add to
 these all the time.
 
-You can see these examples here: <https://github.com/ewels/MultiQC_TestData/tree/master/data/custom_content>
+You can see these examples here: <https://github.com/MultiQC/test-data/tree/master/data/custom_content>
 
 For example, to see a file which generates a table in a report by itself, you can
-have a look at `embedded_config/table_headers_mqc.txt` ([link](https://github.com/ewels/MultiQC_TestData/blob/master/data/custom_content/embedded_config/table_headers_mqc.txt)).
+have a look at `embedded_config/table_headers_mqc.txt` ([link](https://github.com/MultiQC/test-data/blob/master/data/custom_content/embedded_config/table_headers_mqc.txt)).

--- a/docs/core/development/plugins.md
+++ b/docs/core/development/plugins.md
@@ -55,7 +55,7 @@ to MultiQC:
 
 Any python program can create entry points with the same name, once installed
 MultiQC will find these and run them accordingly. For an example of this in
-action, see the [MultiQC_NGI](https://github.com/ewels/MultiQC_NGI/blob/master/setup.py)
+action, see the [MultiQC_NGI](https://github.com/MultiQC/MultiQC_NGI/blob/master/setup.py)
 setup file:
 
 ```python

--- a/docs/core/development/templates.md
+++ b/docs/core/development/templates.md
@@ -13,7 +13,7 @@ easy to create new report templates that fit your needs.
 
 If your template could be of use to others, it would be great if you
 could add it to the main MultiQC package. You can do this by creating a
-fork of the [MultiQC GitHub repository](https://github.com/ewels/MultiQC),
+fork of the [MultiQC GitHub repository](https://github.com/MultiQC/MultiQC),
 adding your template and then creating a pull request to merge your changes
 back to the main repository.
 

--- a/docs/core/getting_started/config.md
+++ b/docs/core/getting_started/config.md
@@ -259,7 +259,7 @@ they can be overwritten in `<installation_dir>/multiqc_config.yaml` or
 
 To see the default search patterns, check a given module in the MultiQC documentation.
 Each module has its search patterns listed beneath any free-text docs.
-Alternatively, see the [`search_patterns.yaml`](https://github.com/ewels/MultiQC/blob/master/multiqc/utils/search_patterns.yaml)
+Alternatively, see the [`search_patterns.yaml`](https://github.com/MultiQC/MultiQC/blob/master/multiqc/utils/search_patterns.yaml)
 file in the MultiQC source code. Copy the section for the program that you want to modify and paste this
 into your config file. Make sure you make it part of a dictionary called `sp`
 as follows:

--- a/docs/core/getting_started/config.md
+++ b/docs/core/getting_started/config.md
@@ -259,7 +259,7 @@ they can be overwritten in `<installation_dir>/multiqc_config.yaml` or
 
 To see the default search patterns, check a given module in the MultiQC documentation.
 Each module has its search patterns listed beneath any free-text docs.
-Alternatively, see the [`search_patterns.yaml`](https://github.com/MultiQC/MultiQC/blob/master/multiqc/utils/search_patterns.yaml)
+Alternatively, see the [`search_patterns.yaml`](https://github.com/MultiQC/MultiQC/blob/main/multiqc/utils/search_patterns.yaml)
 file in the MultiQC source code. Copy the section for the program that you want to modify and paste this
 into your config file. Make sure you make it part of a dictionary called `sp`
 as follows:

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -46,7 +46,7 @@ conda install multiqc
 <tr><td>Docker</td><td>
 
 ```bash
-docker run -t -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc .
+docker run -t -v `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc .
 ```
 
 </td></tr>
@@ -223,13 +223,13 @@ with required dependencies. To build MultiQC, run `nix build`.
 
 ### Docker
 
-A Docker container is provided on Docker Hub called `ewels/multiqc`.
+A Docker container is provided on Docker Hub called `multiqc/multiqc`.
 It's based on an `python-slim` base image to give the smallest image size possible.
 
 To use, call the `docker run` with your current working directory mounted as a volume and working directory. Then just specify the MultiQC command at the end as usual:
 
 ```bash
-docker run -t -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc .
+docker run -t -v `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc .
 ```
 
 - `-t`: Runs docker with a pseudo-tty, for nice terminal colours
@@ -239,12 +239,12 @@ docker run -t -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc .
 You can specify additional MultiQC parameters as normal at the end of the command:
 
 ```bash
-docker run -t -v `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc . --title "My amazing report" -b "This was made with docker"
+docker run -t -v `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc . --title "My amazing report" -b "This was made with docker"
 ```
 
 By default, docker will use the `:latest` tag. For MultiQC, this is set to be the most recent release.
-To use the most recent development code, use `ewels/multiqc:dev`.
-You can also specify specific versions, eg: `ewels/multiqc:1.14`.
+To use the most recent development code, use `multiqc/multiqc:dev`.
+You can also specify specific versions, eg: `multiqc/multiqc:1.20`.
 
 Note that all files on the command line (eg. config files) must also be mounted in the docker container to be accessible.
 For more help, look into [the Docker documentation](https://docs.docker.com/engine/reference/commandline/run/).
@@ -254,7 +254,7 @@ For more help, look into [the Docker documentation](https://docs.docker.com/engi
 The above base command is a little verbose, so if you are using this a lot it may be worth adding the following bash alias to your `~/.bashrc` file:
 
 ```bash
-alias multiqc="docker run -tv `pwd`:`pwd` -w `pwd` ewels/multiqc multiqc"
+alias multiqc="docker run -tv `pwd`:`pwd` -w `pwd` multiqc/multiqc multiqc"
 ```
 
 Once applied (first log out and in again) you can then just use the `multiqc` command instead:
@@ -267,16 +267,16 @@ multiqc .
 
 ### Singularity
 
-To build a singularity container image from the docker image, use the following command: _(change `1.14` to the current MultiQC version)_
+To build a singularity container image from the docker image, use the following command: _(change `1.20` to the current MultiQC version)_
 
 ```bash
-singularity build multiqc-1.14.sif docker://ewels/multiqc:1.14
+singularity build multiqc-1.20.sif docker://multiqc/multiqc:1.20
 ```
 
 Then, use `singularity run` to run the image with the normal MultiQC arguments:
 
 ```bash
-singularity run multiqc-1.14.sif my_results/ --title "Report made using Singularity"
+singularity run multiqc-1.20.sif my_results/ --title "Report made using Singularity"
 ```
 
 :::info{title="Import errors with Singularity"}

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -32,7 +32,7 @@ pip install multiqc
 <tr><td>Pip (dev version)</td><td>
 
 ```bash
-pip install --upgrade --force-reinstall git+https://github.com/ewels/MultiQC.git
+pip install --upgrade --force-reinstall git+https://github.com/MultiQC/MultiQC.git
 ```
 
 </td></tr>
@@ -151,7 +151,7 @@ Use the `--upgrade` flag to update to the latest version.
 If you would like the development version, the command is:
 
 ```bash
-pip install git+https://github.com/ewels/MultiQC.git
+pip install git+https://github.com/MultiQC/MultiQC.git
 ```
 
 To update the dev version between releases, use `--upgrade --force-reinstall`. This is needed as the version number isn't changing.
@@ -197,7 +197,7 @@ To report issues with a FreeBSD port, please submit a PR on the
 If you'd rather not use either of these tools, you can clone the code and install the code yourself:
 
 ```bash
-git clone https://github.com/ewels/MultiQC.git
+git clone https://github.com/MultiQC/MultiQC.git
 cd MultiQC
 pip install .
 ```
@@ -207,7 +207,7 @@ This will fetch the latest development code. To update to the latest changes, us
 `git` not installed? No problem - just download the flat files:
 
 ```bash
-curl -LOk https://github.com/ewels/MultiQC/archive/master.zip
+curl -LOk https://github.com/MultiQC/MultiQC/archive/master.zip
 unzip master.zip
 cd MultiQC-master
 pip install .
@@ -317,7 +317,7 @@ Currently you can't do a lot more than just running MultiQC.
 
 ### On the main Galaxy instance
 
-The easiest and fast manner to use MutliQC is to use the [usegalaxy.org](https://usegalaxy.org/) main Galaxy instance where you will find [MultiQC Galaxy tool](https://usegalaxy.org/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fengineson%2Fmultiqc%2Fmultiqc%2F1.0.0.0&version=1.0.0.0&__identifer=2sjdq8d9r3l) under the _NGS: QC and manipualtion_ tool panel section.
+The easiest and fast manner to use MultiQC is to use the [usegalaxy.org](https://usegalaxy.org/) main Galaxy instance where you will find [MultiQC Galaxy tool](https://usegalaxy.org/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fengineson%2Fmultiqc%2Fmultiqc%2F1.0.0.0&version=1.0.0.0&__identifer=2sjdq8d9r3l) under the _NGS: QC and manipualtion_ tool panel section.
 
 ### On your instance
 

--- a/docs/core/getting_started/installation.md
+++ b/docs/core/getting_started/installation.md
@@ -207,9 +207,9 @@ This will fetch the latest development code. To update to the latest changes, us
 `git` not installed? No problem - just download the flat files:
 
 ```bash
-curl -LOk https://github.com/MultiQC/MultiQC/archive/master.zip
-unzip master.zip
-cd MultiQC-master
+curl -LOk https://github.com/MultiQC/MultiQC/archive/main.zip
+unzip main.zip
+cd MultiQC-main
 pip install .
 ```
 

--- a/docs/core/getting_started/quick_start.md
+++ b/docs/core/getting_started/quick_start.md
@@ -47,7 +47,7 @@ multiqc --version
 ```
 
 ```txt
-multiqc, version 1.14
+multiqc, version 1.20
 ```
 
 ## Get some example data
@@ -81,7 +81,7 @@ multiqc .
 ```
 
 ```txt
-  /// MultiQC 🔍 | v1.14
+  /// MultiQC 🔍 | v1.20
 
 |           multiqc | Search path : /demo/data
 |         searching | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 121/121

--- a/docs/core/reports/reports.md
+++ b/docs/core/reports/reports.md
@@ -14,7 +14,7 @@ line, or double clicking the file in a file browser.
 
 MultiQC reports should work in any modern browser. They have been tested
 using OSX Chrome, Firefox and Safari. If you find any report bugs, please
-report them as a [GitHub issue](https://github.com/ewels/MultiQC/issues).
+report them as a [GitHub issue](https://github.com/MultiQC/MultiQC/issues).
 
 ## Report layout
 

--- a/docs/core/usage/troubleshooting.md
+++ b/docs/core/usage/troubleshooting.md
@@ -94,7 +94,7 @@ There are a couple of things you can check here:
    take a look and the raw files and make sure that there's something to see!
 3. Did you make sure that the logs you're trying to run MultiQC on are the ones
    expected by the module in question? Check the [module documentation](https://multiqc.info/modules/)
-   and have a look at the [example data](https://github.com/MultiQC/test-data/tree/master/data/modules) used for CI tests.
+   and have a look at the [example data](https://github.com/MultiQC/test-data/tree/main/data/modules) used for CI tests.
 
 If everything looks fine, then MultiQC probably needs extending to support
 your data. Tools have different versions, different parameters and different

--- a/docs/core/usage/troubleshooting.md
+++ b/docs/core/usage/troubleshooting.md
@@ -8,7 +8,7 @@ description: Troubleshooting difficulties
 Hopefully MultiQC will be easy to use and run without any hitches. If you have
 any problems, please do get in touch with the developer
 ([Phil Ewels](http://phil.ewels.co.uk)) by e-mail or by
-[submitting an issue](https://github.com/ewels/MultiQC/issues/new) on github.
+[submitting an issue](https://github.com/MultiQC/MultiQC/issues/new) on github.
 Before that, here are a few things previously encountered that may help...
 
 ## Not enough samples found
@@ -85,8 +85,8 @@ for the tool in question.
 There are a couple of things you can check here:
 
 1. Is the tool definitely
-   [supported by MultiQC](https://github.com/ewels/MultiQC)? If not, why
-   not [open an issue](https://github.com/ewels/MultiQC/issues/new) to
+   [supported by MultiQC](https://github.com/MultiQC/MultiQC)? If not, why
+   not [open an issue](https://github.com/MultiQC/MultiQC/issues/new) to
    request it!
 2. Did your bioinformatics tool definitely run properly? I've spent quite
    a bit of time debugging MultiQC modules only to realise that the output
@@ -99,7 +99,7 @@ There are a couple of things you can check here:
 If everything looks fine, then MultiQC probably needs extending to support
 your data. Tools have different versions, different parameters and different
 output formats that can confuse the parsing code.
-Please [open an issue](https://github.com/ewels/MultiQC/issues/new) with
+Please [open an issue](https://github.com/MultiQC/MultiQC/issues/new) with
 your log files and we can get it fixed.
 
 ## Error messages about mkl trial mode / licences

--- a/docs/core/usage/troubleshooting.md
+++ b/docs/core/usage/troubleshooting.md
@@ -94,7 +94,7 @@ There are a couple of things you can check here:
    take a look and the raw files and make sure that there's something to see!
 3. Did you make sure that the logs you're trying to run MultiQC on are the ones
    expected by the module in question? Check the [module documentation](https://multiqc.info/modules/)
-   and have a look at the [example data](https://github.com/ewels/MultiQC_TestData/tree/master/data/modules) used for CI tests.
+   and have a look at the [example data](https://github.com/MultiQC/test-data/tree/master/data/modules) used for CI tests.
 
 If everything looks fine, then MultiQC probably needs extending to support
 your data. Tools have different versions, different parameters and different

--- a/docs/modules/hisat2.md
+++ b/docs/modules/hisat2.md
@@ -19,7 +19,7 @@ Note that running HISAT2 without this option (and older versions)
 gives log output identical to Bowtie2. These logs are indistinguishable
 and summary statistics will appear in MultiQC reports labelled as Bowtie2.
 See GitHub issues on the [HISAT2 repository](https://github.com/infphilo/hisat2/issues/48)
-and the [MultiQC repository](https://github.com/ewels/MultiQC/issues/221)
+and the [MultiQC repository](https://github.com/MultiQC/MultiQC/issues/221)
 for more information.
 
 HISAT2 does not report the input file names in the log, so MultiQC

--- a/docs/modules/homer.md
+++ b/docs/modules/homer.md
@@ -12,7 +12,7 @@ of functional genomics sequencing data sets.
 
 The HOMER MultiQC module currently only parses output from the `findPeaks` tool.
 If you would like support to be added for other HOMER tools, please open a
-[new issue](https://github.com/ewels/MultiQC/issues/new) on the MultiQC GitHub page.
+[new issue](https://github.com/MultiQC/MultiQC/issues/new) on the MultiQC GitHub page.
 
 #### FindPeaks
 

--- a/docs/modules/stacks.md
+++ b/docs/modules/stacks.md
@@ -9,4 +9,4 @@ description: >
 
 This module will only work with Stacks version 2.1 or greater.
 Furthermore, this module is designed to only parse some of the output from the `denovo_map` pipeline.
-If you are missing some functionality, please submit an issue on the [MultiQC github page](https://github.com/ewels/MultiQC)
+If you are missing some functionality, please submit an issue on the [MultiQC github page](https://github.com/MultiQC/MultiQC)

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -187,7 +187,7 @@ class MultiqcModule(BaseMultiqcModule):
 
                 # HiSAT2 has PE data doesn't have the mate-specific stats.
                 # To avoid missing unaligned counts in the barplot, fake the "_halved" key.
-                # See https://github.com/ewels/MultiQC/issues/1230
+                # See https://github.com/MultiQC/MultiQC/issues/1230
                 if "paired_aligned_mate_none_halved" not in parsed_data and "paired_aligned_none" in parsed_data:
                     parsed_data["paired_aligned_mate_none_halved"] = parsed_data["paired_aligned_none"]
 

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -29,7 +29,7 @@ NAMESPACE = "Coverage"
 
 '''""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 The following code section provides a clean and simple tool for setting configurations:
-https://github.com/ewels/MultiQC/blob/master/docs/plots.md#creating-a-table
+https://github.com/MultiQC/MultiQC/blob/master/docs/plots.md#creating-a-table
 
 The SINGLE_HEADER is used to define the common settings for all coverage headers.
 '''

--- a/multiqc/modules/dragen/coverage_metrics.py
+++ b/multiqc/modules/dragen/coverage_metrics.py
@@ -29,7 +29,7 @@ NAMESPACE = "Coverage"
 
 '''""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 The following code section provides a clean and simple tool for setting configurations:
-https://github.com/MultiQC/MultiQC/blob/master/docs/plots.md#creating-a-table
+https://github.com/MultiQC/MultiQC/blob/main/docs/plots.md#creating-a-table
 
 The SINGLE_HEADER is used to define the common settings for all coverage headers.
 '''

--- a/multiqc/modules/dragen/utils.py
+++ b/multiqc/modules/dragen/utils.py
@@ -193,7 +193,7 @@ def order_headers(headers):
 
 
 # STD_TABLE_CONFIGS contains all standard table configurations from:
-# https://github.com/ewels/MultiQC/blob/master/docs/plots.md#creating-a-table
+# https://github.com/MultiQC/MultiQC/blob/master/docs/plots.md#creating-a-table
 STD_TABLE_CONFIGS = [
     "namespace",
     "title",

--- a/multiqc/modules/dragen/utils.py
+++ b/multiqc/modules/dragen/utils.py
@@ -193,7 +193,7 @@ def order_headers(headers):
 
 
 # STD_TABLE_CONFIGS contains all standard table configurations from:
-# https://github.com/MultiQC/MultiQC/blob/master/docs/plots.md#creating-a-table
+# https://github.com/MultiQC/MultiQC/blob/main/docs/plots.md#creating-a-table
 STD_TABLE_CONFIGS = [
     "namespace",
     "title",

--- a/multiqc/modules/filtlong/filtlong.py
+++ b/multiqc/modules/filtlong/filtlong.py
@@ -48,13 +48,13 @@ class MultiqcModule(BaseMultiqcModule):
                 if f["s_name"] in self.filtlong_data:
                     log.debug(f"Duplicate sample name found! Overwriting: {f['s_name']}")
                 target_bases = line.lstrip().split(" ")[1]
-                # Remove . thousand separators - see ewels/MultiQC#1843
+                # Remove . thousand separators - see MultiQC/MultiQC#1843
                 target_bases = float(target_bases.replace(".", ""))
                 self.filtlong_data[f["s_name"]] = {"Target bases": target_bases}
 
             elif "keeping" in line and f["s_name"] in self.filtlong_data:
                 bases_kept = line.lstrip().split(" ")[1]
-                # Remove . thousand separators - see ewels/MultiQC#1843
+                # Remove . thousand separators - see MultiQC/MultiQC#1843
                 bases_kept = float(bases_kept.replace(".", ""))
                 self.filtlong_data[f["s_name"]]["Bases kept"] = bases_kept
 

--- a/multiqc/modules/samtools/stats.py
+++ b/multiqc/modules/samtools/stats.py
@@ -17,7 +17,7 @@ HTSLIB_REGEX = r"\+htslib-([\d\.]+)"
 
 
 class StatsReportMixin:
-    """Mixin class, loaded by main samtools MuliqcModule class."""
+    """Mixin class, loaded by main samtools MultiqcModule class."""
 
     def parse_samtools_stats(self):
         """Find Samtools stats logs and parse their data"""
@@ -235,10 +235,10 @@ class StatsReportMixin:
             Low alignment rates could indicate contamination of samples (e.g. adapter sequences),
             low sequencing quality or other artefacts. These can be further investigated in the
             sequence level QC (e.g. from FastQC).
-            
-            Reads mapped with MQ0 often indicate that the reads are ambiguously mapped to multiple 
+
+            Reads mapped with MQ0 often indicate that the reads are ambiguously mapped to multiple
             locations in the reference sequence. This can be due to repetitive regions in the genome,
-            the presence of alternative contigs in the reference, or due to reads that are too short 
+            the presence of alternative contigs in the reference, or due to reads that are too short
             to be uniquely mapped. These reads are often filtered out in downstream analyses.
             """,
             plot=alignment_chart(bedgraph_data),

--- a/multiqc/multiqc.py
+++ b/multiqc/multiqc.py
@@ -785,11 +785,11 @@ def run(
             class CustomTraceback:
                 def __rich_console__(self, console: rich.console.Console, options: rich.console.ConsoleOptions):
                     sys_tb = sys.exc_info()
-                    issue_url = "https://github.com/ewels/MultiQC/issues/new?template=bug_report.md&title={}%20module%20-%20{}".format(
+                    issue_url = "https://github.com/MultiQC/MultiQC/issues/new?template=bug_report.md&title={}%20module%20-%20{}".format(
                         this_module, sys_tb[0].__name__
                     )
                     yield (
-                        "Please copy this log and report it at [bright_blue][link={}]https://github.com/ewels/MultiQC/issues[/link][/] \n"
+                        "Please copy this log and report it at [bright_blue][link={}]https://github.com/MultiQC/MultiQC/issues[/link][/] \n"
                         "[bold underline]Please attach a file that triggers the error.[/] The last file found was: [green]{}[/]\n".format(
                             issue_url, report.last_found_file
                         )

--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -140,7 +140,7 @@ def plot(data, cats=None, pconfig=None):
         hc_samples = list(d.keys())
         if isinstance(d, OrderedDict):
             # Legacy: users assumed that passing an OrderedDict indicates that we
-            # want to keep the sample order https://github.com/ewels/MultiQC/issues/2204
+            # want to keep the sample order https://github.com/MultiQC/MultiQC/issues/2204
             pass
         elif pconfig.get("sort_samples", True):
             hc_samples = sorted(list(d.keys()))

--- a/multiqc/templates/default/footer.html
+++ b/multiqc/templates/default/footer.html
@@ -14,7 +14,7 @@ Content for the report footer.
         <a href="http://multiqc.info" target="_blank">MultiQC v{{ config.version }}</a>
     </strong>
     - Written by <a href="http://phil.ewels.co.uk" target="_blank">Phil Ewels</a>,
-    available on <a href="https://github.com/ewels/MultiQC" target="_blank">GitHub</a>.
+    available on <a href="https://github.com/MultiQC/MultiQC" target="_blank">GitHub</a>.
 </p>
 <p>
     This report uses <a href="http://www.highcharts.com/" target="_blank">HighCharts</a>,

--- a/multiqc/templates/default/toolbox.html
+++ b/multiqc/templates/default/toolbox.html
@@ -263,7 +263,7 @@ of the report.
       <p>For more information about MultiQC, including other videos and
         extensive documentation, please visit <a href="http://multiqc.info/?ref=mqc_report" target="_blank">http://multiqc.info</a></p>
       <p>You can report bugs, suggest improvements and find the source code for MultiQC on GitHub:
-        <a href="https://github.com/ewels/MultiQC" target="_blank">https://github.com/ewels/MultiQC</a></p>
+        <a href="https://github.com/MultiQC/MultiQC" target="_blank">https://github.com/MultiQC/MultiQC</a></p>
       <p>MultiQC is published in Bioinformatics:</p>
       <blockquote>
         <strong>MultiQC: Summarize analysis results for multiple tools and samples in a single report</strong><br>

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ MultiQC was written by Phil Ewels (http://phil.ewels.co.uk) at Seqera Labs (http
 from setuptools import find_packages, setup
 
 version = "1.20dev"
-dl_version = "master" if "dev" in version else f"v{version}"
+dl_version = "main" if "dev" in version else f"v{version}"
 
 print(
     f"""-----------------------------------

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description=__doc__,
     keywords=["bioinformatics", "biology", "sequencing", "NGS", "next generation sequencing", "quality control"],
     url="http://multiqc.info",
-    download_url=f"https://github.com/ewels/MultiQC/tarball/{dl_version}",
+    download_url=f"https://github.com/MultiQC/MultiQC/tarball/{dl_version}",
     license="GPLv3",
     packages=find_packages(),
     include_package_data=True,

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -2,7 +2,7 @@
 
 # Test runner for MultiQC.
 if [ -z "${MULTIQC_TEST_ROOT:-}" ] ; then
-    MULTIQC_TEST_ROOT="$(dirname $0)"/../../MultiQC_TestData
+    MULTIQC_TEST_ROOT="$(dirname $0)"/../../test-data
 fi
 
 # Canonicalize it
@@ -19,7 +19,7 @@ Error: $MULTIQC_TEST_ROOT was not found or does not contain a
        unit_tests/ subdirectory.
 
 To reduce bloat of the main GIT repository, the tests and test data are kept
-in the MultiQC_TestData repository, which you need to check out from GitHub.
+in the test-data repository, which you need to check out from GitHub.
 
 If the test data is somewhere other than the path above, set \$MULTIQC_TEST_ROOT
 to the correct directory and retry.


### PR DESCRIPTION
Move to the MultiQC GitHub org. See https://github.com/ewels/MultiQC/issues/1785

Let's hope this doesn't break too many things 🤞🏻 

GitHub should automatically redirect links, so hopefully we'll be ok.