### PR TITLE
Add support for optical pooled screening output from cells2stats

### DIFF
--- a/multiqc/modules/cells2stats/cells2stats.py
+++ b/multiqc/modules/cells2stats/cells2stats.py
@@ -8,8 +8,12 @@ from multiqc.modules.cells2stats.cells2stats_bar_plots import (
     plot_barcoding,
     plot_cell_assignment,
     plot_controls,
+    plot_target_polony_assignment,
+    plot_target_cell_assignment,
 )
-from multiqc.modules.cells2stats.cells2stats_tables import tabulate_wells, tabulate_batches
+
+from multiqc.modules.cells2stats.utils import summarize_target_site_names
+from multiqc.modules.cells2stats.cells2stats_tables import tabulate_wells, tabulate_batches, tabulate_target_wells
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +24,7 @@ class MultiqcModule(BaseMultiqcModule):
             name="cells2stats",
             anchor="cells2stats",
             href="https://docs.elembio.io/docs/cells2stats/introduction/",
-            info="Generate output files and statistics from Element Biosciences Teton Assay",
+            info="Generate output files and statistics from Element Biosciences Teton cytoprofiling assays",
             doi="",
         )
 
@@ -68,3 +72,22 @@ class MultiqcModule(BaseMultiqcModule):
                 description=description,
             )
             self.write_data_file(plot_content, anchor)
+
+        for target_site_name in summarize_target_site_names(self.c2s_run_data):
+            log.info(f"Found {target_site_name} target group")
+            for plotting_function in [
+                tabulate_target_wells,
+                plot_target_polony_assignment,
+                plot_target_cell_assignment,
+            ]:
+                plot_html, plot_name, anchor, description, helptext, plot_content = plotting_function(
+                    self.c2s_run_data, target_site_name
+                )
+                self.add_section(
+                    anchor=anchor,
+                    name=plot_name,
+                    helptext=helptext,
+                    plot=plot_html,
+                    description=description,
+                )
+                self.write_data_file(plot_content, anchor)

--- a/multiqc/modules/cells2stats/cells2stats_bar_plots.py
+++ b/multiqc/modules/cells2stats/cells2stats_bar_plots.py
@@ -5,6 +5,7 @@ from .utils import summarize_batch_names, is_nan, find_entry, json_decode_float
 from .queries import (
     get_batch_counts,
     get_batch_density,
+    get_batch_extracellularratio,
     get_cell_count,
     get_median_cell_diameter,
     get_percent_confluency,
@@ -13,11 +14,15 @@ from .queries import (
     get_percent_mismatch,
     get_total_counts,
     get_total_density,
+    get_percent_assigned_target_polony,
+    get_percent_mismatch_target_polony,
+    get_target_cell_assignment_status,
+    get_target_cell_metric_by_key,
 )
 
 
 def plot_barcoding(c2s_run_data):
-    """ "
+    """
     Generate plots related to barcoding performance metrics from the cells2stats report
     """
 
@@ -51,15 +56,15 @@ def plot_barcoding(c2s_run_data):
     anchor = "well_barcoding_plot"
     description = "Bar plots of barcoding metrics"
     helptext = (
-        """PLot percent of assigned reads and percent of reads assigned with mismatch for each well in the run."""
+        """Plot percent of assigned reads and percent of reads assigned with mismatch for each well in the run."""
     )
 
     return plot_html, plot_name, anchor, description, helptext, plot_content
 
 
 def plot_cell_assignment(c2s_run_data):
-    """ "
-    Generate plots related to cell assignment performance metrics from the cells2stats report
+    """
+    Generate plots related to barcoding cell assignment performance metrics from the cells2stats report
     """
 
     batch_names = summarize_batch_names(c2s_run_data)
@@ -68,6 +73,7 @@ def plot_cell_assignment(c2s_run_data):
         get_batch_density(c2s_run_data),
         get_total_counts(c2s_run_data),
         get_batch_counts(c2s_run_data),
+        get_batch_extracellularratio(c2s_run_data),
     ]
     pconfig = {
         "data_labels": [
@@ -75,6 +81,7 @@ def plot_cell_assignment(c2s_run_data):
             {"name": "Batch Density", "ylab": "Assigned Counts K / mm2"},
             {"name": "Total Counts", "ylab": "Average Assigned Counts / Cell"},
             {"name": "Batch Counts", "ylab": "Average Assigned Counts / Cell"},
+            {"name": "Extracellular Ratio", "ylab": "Extracellular Ratio"},
         ],
         "cpswitch": False,
         "id": "cell_assignment_bar",
@@ -89,19 +96,19 @@ def plot_cell_assignment(c2s_run_data):
     for i, batch_name in enumerate(batch_names):
         cat[batch_name] = {"name": batch_name, "color": scale.get_colour(i, lighten=1)}
 
-    cats = [{"total_density": {"name": "Total Density"}}, cat, {"total_count": {"name": "Total Counts"}}, cat]
+    cats = [{"total_density": {"name": "Total Density"}}, cat, {"total_count": {"name": "Total Counts"}}, cat, cat]
 
-    plot_name = "Cell Assignment Metrics"
+    plot_name = "Barcoding Cell Assignment Metrics"
     plot_html = bargraph.plot(plot_content, cats, pconfig=pconfig)
     anchor = "well_assignment_plot"
-    description = "Bar plots of cell assignment metrics"
-    helptext = """Plot density and absolute of assigned counts per batch and across all batches."""
+    description = "Bar plots of barcoding cell assignment metrics"
+    helptext = """Plot density and absolute of assigned counts per batch and across all barcoding batches."""
 
     return plot_html, plot_name, anchor, description, helptext, plot_content
 
 
 def plot_cell_segmentation(c2s_run_data):
-    """ "
+    """
     Generate plots related to cell segmentation metrics from the cells2stats report
     """
     plot_content = []
@@ -140,7 +147,7 @@ def plot_cell_segmentation(c2s_run_data):
 
 
 def plot_controls(c2s_run_data):
-    """ "
+    """
     Generate plots related to control metrics from the cells2stats report
     """
 
@@ -172,7 +179,9 @@ def plot_controls(c2s_run_data):
                         control_data = find_entry(batch_data.get("ControlTargets", []), "ControlType", control, {})
                         val = json_decode_float(control_data.get("AssignedCountPerMM2", float("nan")))
                         if not is_nan(val):
-                            control_content.setdefault(f"{run_name} {well_location}", {})[batch_name] = val
+                            control_content.setdefault(f"{run_name} {well_location}", {})[batch_name] = (
+                                val / 1000.0
+                            )  # Convert to K/mm2
         plot_content.append(control_content)
 
     pconfig = {
@@ -194,10 +203,106 @@ def plot_controls(c2s_run_data):
         cat,
     ] * len(plot_content)
 
-    plot_name = "Control Targets"
+    plot_name = "Barcoding Control Targets"
     plot_html = bargraph.plot(plot_content, cats, pconfig=pconfig)
     anchor = "well_control_plot"
-    description = "Bar plots of control targets"
-    helptext = """Plot density of assigned counts per batch for controls."""
+    description = "Bar plots of bardoding control targets"
+    helptext = """Plot density of assigned counts per barcoding batch for controls."""
+
+    return plot_html, plot_name, anchor, description, helptext, plot_content
+
+
+def plot_target_polony_assignment(c2s_run_data, target_site_name):
+    """
+    Generate plots related to target assignment performance metrics from the cells2stats report
+    """
+
+    plot_content = []
+    plot_content.append(get_percent_assigned_target_polony(c2s_run_data, target_site_name))
+    plot_content.append(get_percent_mismatch_target_polony(c2s_run_data, target_site_name))
+
+    pconfig = {
+        "data_labels": [
+            {"name": "Percent Assigned", "ylab": "Percent Assigned"},
+            {"name": "Percent Mismatch", "ylab": "Percent Mismatch"},
+        ],
+        "cpswitch": False,
+        "id": f"{target_site_name}_target_polony_bar",
+        "title": f"cells2stats: {target_site_name} target polony QC metrics plot",
+        "ylab": "QC",
+        "ymax": 100,
+    }
+
+    cats = [{"percent_assigned": {"name": "Percent Assigned"}}, {"percent_mismatch": {"name": "Percent Mismatch"}}]
+
+    plot_name = f"{target_site_name} Metrics"
+    plot = bargraph.plot(plot_content, cats, pconfig=pconfig)
+    anchor = f"{target_site_name}_target_polony_plot"
+    description = f"Bar plots of {target_site_name} polony assignment metrics"
+    helptext = """Plot percent assigned and percent mismatch for assignment of polonies to targets."""
+
+    return plot, plot_name, anchor, description, helptext, plot_content
+
+
+def plot_target_cell_assignment(c2s_run_data, target_site_name):
+    """
+    Generate plots related to target cell assignment performance metrics from the cells2stats report
+    """
+
+    plot_content = [
+        get_target_cell_assignment_status(c2s_run_data, target_site_name),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "AssignedCountsPerMM2", 1000),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "MeanAssignedCountPerCell"),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "MedianAbundantTargetCount"),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "MeanUniqueTargetsPerCell"),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "ExtraCellularRatio"),
+        get_target_cell_metric_by_key(c2s_run_data, target_site_name, "PercentTargetDropout"),
+    ]
+    pconfig = {
+        "data_labels": [
+            {"name": "Cell Assignment Status", "ylab": "Percent Cells"},
+            {"name": "Assigned Density", "ylab": "Assigned Counts K / mm2"},
+            {"name": "Mean Assigned Count", "ylab": "Mean Assigned Counts / Cell"},
+            {"name": "Median Abundant Target Count", "ylab": "Median Abundant Target Count"},
+            {"name": "Mean Unique Targets", "ylab": "Mean Unique Targets / Cell"},
+            {"name": "Extra Cellular Ratio", "ylab": "Extra Cellular Ratio"},
+            {"name": "Percent Target Dropout", "ylab": "Percent Target Dropout"},
+        ],
+        "cpswitch": False,
+        "id": f"{target_site_name}_cell_target_assignment_bar",
+        "stacking": "normal",
+        "title": "cells2stats: Target cell assignment metrics plot",
+        "ylab": "QC",
+    }
+
+    scale = mqc_colour.mqc_colour_scale("GnBu", 0, 4)
+
+    cat = {}
+    cat["PercentAssignedPureCells"] = {"name": "Percent Assigned Pure Cells", "color": scale.get_colour(0, lighten=1)}
+    cat["PercentAssignedMixedCells"] = {"name": "Percent Assigned Mixed Cells", "color": scale.get_colour(1, lighten=1)}
+    cat["PercentUnassignedMixedCells"] = {
+        "name": "Percent Unassigned Mixed Cells",
+        "color": scale.get_colour(2, lighten=1),
+    }
+    cat["PercentUnassignedLowCountCells"] = {
+        "name": "Percent Unassigned Low Count Cells",
+        "color": scale.get_colour(3, lighten=1),
+    }
+
+    cats = [
+        cat,
+    ]
+    cats.append({"AssignedCountsPerMM2": {"name": "Assigned Density"}})
+    cats.append({"MeanAssignedCountPerCell": {"name": "Mean Assigned Count"}})
+    cats.append({"MedianAbundantTargetCount": {"name": "Median Abundant Target Count"}})
+    cats.append({"MeanUniqueTargetsPerCell": {"name": "Mean Unique Targets"}})
+    cats.append({"ExtraCellularRatio": {"name": "Extra Cellular Ratio"}})
+    cats.append({"PercentTargetDropout": {"name": "Percent Target Dropout"}})
+
+    plot_name = f"{target_site_name} Target Cell Assignment Metrics"
+    plot_html = bargraph.plot(plot_content, cats, pconfig=pconfig)
+    anchor = f"{target_site_name}_target_cell_assignment_plot"
+    description = "Bar plots of target cell assignment metrics"
+    helptext = """Plot statistics related to assignment of targets to cells."""
 
     return plot_html, plot_name, anchor, description, helptext, plot_content

--- a/multiqc/modules/cells2stats/queries.py
+++ b/multiqc/modules/cells2stats/queries.py
@@ -1,5 +1,7 @@
 from .utils import json_decode_int, json_decode_float, is_nan, summarize_batch_names, find_entry
 
+small_value = 0.00000001
+
 
 def get_cell_count(c2s_run_data):
     """
@@ -130,6 +132,25 @@ def get_batch_counts(c2s_run_data):
     return result
 
 
+def get_batch_extracellularratio(c2s_run_data):
+    """
+    Get the extra-cellular ratio for each batch in each well in the run
+    """
+    batch_names = summarize_batch_names(c2s_run_data)
+    result = {}
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for well_data in run_data.get("CytoStats", {}).get("Wells", []):
+            well_location = well_data.get("WellLocation", "")
+            if well_location != "":
+                for batch_name in batch_names:
+                    batch_data = find_entry(well_data.get("Batches", []), "BatchName", batch_name, {})
+                    val = json_decode_float(batch_data.get("ExtraCellularRatio", float("nan")))
+                    if not is_nan(val):
+                        result.setdefault(f"{run_name} {well_location}", {})[batch_name] = val
+    return result
+
+
 def get_percent_assigned(c2s_run_data):
     """
     Get the percent assigned reads for each batch in each well in the run
@@ -165,4 +186,102 @@ def get_percent_mismatch(c2s_run_data):
                     val = json_decode_float(well_data.get("PercentMismatch", float("nan")))
                     if not is_nan(val):
                         result.setdefault(f"{run_name} {well_location}", {})[batch_name] = val
+    return result
+
+
+def get_percent_assigned_target_polony(c2s_run_data, target_site_name):
+    """
+    Get the percent assigned for each well in the run for a target site
+    """
+
+    result = {}
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for batch_data in run_data.get("TargetStats", {}).get("Batches", []):
+            for well_data in batch_data.get("Wells", []):
+                for target_site_data in well_data.get("TargetSites", []):
+                    if target_site_data.get("TargetSiteName", "") == target_site_name:
+                        value = json_decode_float(
+                            target_site_data.get("PolonyAssignmentStats", {}).get("PercentAssigned", float("nan"))
+                        )
+                        if not is_nan(value) and value > 0:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})["percent_assigned"] = value
+                        else:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})["percent_assigned"] = (
+                                small_value
+                            )
+    return result
+
+
+def get_percent_mismatch_target_polony(c2s_run_data, target_site_name):
+    """
+    Get the percent mismatch for each well in the run for a target site
+    """
+
+    result = {}
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for batch_data in run_data.get("TargetStats", {}).get("Batches", []):
+            for well_data in batch_data.get("Wells", []):
+                for target_site_data in well_data.get("TargetSites", []):
+                    if target_site_data.get("TargetSiteName", "") == target_site_name:
+                        value = json_decode_float(
+                            target_site_data.get("PolonyAssignmentStats", {}).get("PercentMismatch", float("nan"))
+                        )
+                        if not is_nan(value) and value > 0:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})["percent_mismatch"] = value
+                        else:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})["percent_mismatch"] = (
+                                small_value
+                            )
+
+    return result
+
+
+def get_target_cell_assignment_status(c2s_run_data, target_site_name):
+    """
+    Get the target cell assignment metrics for each well in the run for a target site
+    """
+
+    result = {}
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for batch_data in run_data.get("TargetStats", {}).get("Batches", []):
+            for well_data in batch_data.get("Wells", []):
+                for target_site_data in well_data.get("TargetSites", []):
+                    if target_site_data.get("TargetSiteName", "") == target_site_name:
+                        cell_assignment_data = target_site_data.get("CellAssignmentStats", {})
+                        for key in [
+                            "PercentAssignedPureCells",
+                            "PercentAssignedMixedCells",
+                            "PercentUnassignedMixedCells",
+                            "PercentUnassignedLowCountCells",
+                        ]:
+                            val = json_decode_float(cell_assignment_data.get(key, float("nan")))
+                            if not is_nan(val) and val > 0:
+                                result.setdefault(f"{run_name} {well_data['WellLocation']}", {})[key] = val
+                            else:
+                                result.setdefault(f"{run_name} {well_data['WellLocation']}", {})[key] = small_value
+    return result
+
+
+def get_target_cell_metric_by_key(c2s_run_data, target_site_name, key, factor=1.0):
+    """
+    Get the named metric for each well in the run for a target site
+    """
+
+    result = {}
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for batch_data in run_data.get("TargetStats", {}).get("Batches", []):
+            for well_data in batch_data.get("Wells", []):
+                for target_site_data in well_data.get("TargetSites", []):
+                    if target_site_data.get("TargetSiteName", "") == target_site_name:
+                        value = json_decode_float(
+                            target_site_data.get("CellAssignmentStats", {}).get(key, float("nan"))
+                        )
+                        if not is_nan(value) and value > 0:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})[key] = value / factor
+                        else:
+                            result.setdefault(f"{run_name} {well_data['WellLocation']}", {})[key] = small_value
     return result

--- a/multiqc/modules/cells2stats/utils.py
+++ b/multiqc/modules/cells2stats/utils.py
@@ -49,3 +49,18 @@ def summarize_batch_names(c2s_run_data):
                     batch_names.add(batch_data["BatchName"])
 
     return sorted(batch_names)
+
+
+def summarize_target_site_names(c2s_run_data):
+    """
+    Generate a list of target site names from the cells2stats report
+    """
+    target_site_names = set()
+    for run_name in c2s_run_data:
+        run_data = c2s_run_data[run_name]
+        for batch_data in run_data.get("TargetStats", {}).get("Batches", []):
+            for target_site_data in batch_data.get("TargetSites", []):
+                target_site_name = target_site_data.get("TargetSiteName", "")
+                if target_site_name != "":
+                    target_site_names.add(target_site_name)
+    return sorted(target_site_names)

--- a/multiqc/search_patterns.yaml
+++ b/multiqc/search_patterns.yaml
@@ -231,7 +231,7 @@ cellranger_arc:
     num_lines: 250
 cells2stats/run:
   fn: "RunStats.json"
-  contents: "DemuxStats"
+  contents: '"AnalysisID": "c2s.'
   num_lines: 100
 checkm:
   - contents_re: ".*Bin Id(?:\t| {3,})Marker lineage(?:\t| {3,})# genomes(?:\t| {3,})# markers(?:\t| {3,})# marker sets.*"


### PR DESCRIPTION
Contains updates for cells2stats module

- Handle "violin" error reported due to formatting string of cell counts
- Add report table for extra-cellular ratio
- Update string used to identify cells2stats input (uses "AnalysisID" field)
- Add plots for upcoming optical pooled screening output from cells2stats