### PR TITLE
CheckM2 column spelling fix

### DIFF
--- a/multiqc/modules/checkm2/checkm2.py
+++ b/multiqc/modules/checkm2/checkm2.py
@@ -74,7 +74,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "scale": "YlOrRd",
             },
             "Completeness_Model_Used": {
-                "title": "Completness Model Used",
+                "title": "Completeness Model Used",
                 "description": "Which ML model was used to predict completeness.",
                 "hidden": True,
             },


### PR DESCRIPTION
I just noticed there is a spelling error, so this fixes it.

- [ x] This comment contains a description of changes (with reason)
