### PR TITLE
adding fgbio/CollectDuplexSeqMetrics.py

### DIFF
--- a/multiqc/modules/fgbio/CollectDuplexSeqMetrics.py
+++ b/multiqc/modules/fgbio/CollectDuplexSeqMetrics.py
@@ -1,0 +1,55 @@
+import os
+import pandas as pd
+from multiqc.utils import report
+from multiqc.utils.config import config
+from multiqc.modules.base_module import BaseMultiqcModule
+
+
+def parse_reports(self):
+    yield_files = self.find_log_files(
+        fn_match=r'_collapsed_grouped\.duplex_yield_metrics\.txt$',
+        contents_match='fraction',
+        filecontents_res=[r"fraction"]
+    )
+
+    if not yield_files:
+        self.log.warning("❌ No yield metric files matched.")
+        return 0
+    else:
+        self.log.info(f"✅ Found {len(yield_files)} yield metric files.")
+
+    parsed_data = {}
+
+    for f in yield_files:
+        self.log.debug(f"📄 Matched file: {f['fn']} at path: {f['f']}")
+
+        with open(f['f'], 'r') as fh:
+            lines = fh.readlines()
+
+        self.log.debug(f"🧪 First line: {lines[0].strip()}")
+        if len(lines) > 1:
+            self.log.debug(f"🧪 Second line: {lines[1].strip()}")
+
+        df = pd.read_csv(f['f'], sep="\t")
+        total_yield_fraction = df["fraction"].sum()
+
+        sample_name = self.clean_s_name(f["s_name"])
+        parsed_data[sample_name] = {"Total Yield Fraction": total_yield_fraction}
+
+    # Add data table section
+    self.add_section(
+        name="Fgbio Duplex Yield Metrics",
+        anchor="collapsed_duplex_metrics",
+        description="Summed yield fractions from fgbio CollectDuplexSeqMetrics files.",
+        plot_type="table",
+        data=parsed_data,
+        headers={
+            "Total Yield Fraction": {
+                "title": "Total Yield Fraction",
+                "description": "Sum of 'fraction' column from the duplex_yield_metrics file",
+                "format": "{:,.4f}"
+            }
+        }
+    )
+
+    return len(parsed_data)

--- a/multiqc/modules/fgbio/fgbio.py
+++ b/multiqc/modules/fgbio/fgbio.py
@@ -5,6 +5,7 @@ from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 from multiqc.modules.fgbio.error_rate_by_read_position import error_rate_by_read_position
 from multiqc.modules.fgbio.group_reads_by_umi import run_group_reads_by_umi
 
+
 log = logging.getLogger(__name__)
 
 
@@ -17,6 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
+        from . import CollectDuplexSeqMetrics
         super(MultiqcModule, self).__init__(
             name="fgbio",
             anchor="fgbio",
@@ -36,6 +38,11 @@ class MultiqcModule(BaseMultiqcModule):
         n["errorratebyreadposition"] = error_rate_by_read_position(self)
         if n["errorratebyreadposition"] > 0:
             log.info(f"Found {n['errorratebyreadposition']} errorratebyreadposition reports")
+
+        # CollectDuplexSeqMetrics
+        n["collectduplexseqmetrics"] = CollectDuplexSeqMetrics.parse_reports(self)
+        if n["collectduplexseqmetrics"] > 0:
+            log.info("Found {} collectduplexseqmetrics reports".format(n["collectduplexseqmetrics"]))
 
         # Exit if we didn't find anything
         if sum(n.values()) == 0:


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [ ] This Is regarding the issue raised [here ](https://github.com/MultiQC/MultiQC/issues/3152). This update adds a new parser in the fgbio module for CollectDuplexSeqMetrics

The parser will:

Parse and visualize simplex and duplex family size distributions
Parse and visualize duplex yield metrics across downsampling fractions
Add three interactive plots to the MultiQC report:
Duplex family size distribution
Simplex family size distribution
Duplex yield metrics across downsampling fractions
Write two output data files for further analysis:
multiqc_fgbio_CollectDuplexSeqMetrics_family_sizes
multiqc_fgbio_CollectDuplexSeqMetrics_duplex_yield_metrics

- [ ] There is example tool output for tool here  (https://github.com/MultiQC/test-data/pull/350).
- [ ] Code is tested and works locally (including with `--strict` flag)
- [ ] Everything that can be represented with a plot instead of a table is a plot
- [ ] There aren't any huge tables with > 6 columns (explain reasoning if so)
- [ ] Module does not do any significant computational work

