### PR TITLE
Lima: split delimiter is a tab, not any whitespace.

### DIFF
--- a/multiqc/modules/lima/lima.py
+++ b/multiqc/modules/lima/lima.py
@@ -129,7 +129,7 @@ class MultiqcModule(BaseMultiqcModule):
         # A dictionary to store the results
         lima_counts = dict()
         for line in file_content:
-            spline = line.strip().split('\t')
+            spline = line.strip().split("\t")
             data = {field: value for field, value in zip(header, spline)}
 
             first_barcode = data["IdxFirstNamed"]


### PR DESCRIPTION
The file format is given as:

```yaml
lima/counts:
  contents: "IdxFirst\tIdxCombined\tIdxFirstNamed\tIdxCombinedNamed\tCounts\tMeanScore"
```

Thus, tabs are indeed expected. We had a couple samples returned with "Not barcoded" as the sample ID. `.split()` of course is happy to split on that whitespace, and thus an invalid value was parsed for the counts. It must be split on a tab.