### PR TITLE
SNPsplit: Fix module datetime serialization error

### DIFF
--- a/multiqc/modules/snpsplit/snpsplit.py
+++ b/multiqc/modules/snpsplit/snpsplit.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import date, datetime
 
 import yaml
 
@@ -74,7 +75,11 @@ class MultiqcModule(BaseMultiqcModule):
                     if sk.startswith(prefix):
                         key = sk[len(prefix) :]
                 flat_key = f"{k.lower()}_{key}"
-                flat_data[flat_key] = data[k][sk]
+                value = data[k][sk]
+                # Convert datetime objects to ISO format strings for JSON serialization
+                if isinstance(value, (datetime, date)):
+                    value = value.isoformat()
+                flat_data[flat_key] = value
         input_fn = data["Meta"]["infile"]
         flat_data["version"] = data["Meta"]["version"]
         return [input_fn, flat_data]


### PR DESCRIPTION
The YAML SafeLoader parses ISO 8601 datetime strings into Python datetime objects, which cannot be serialized by the JSON encoder.

This caused the SNPsplit module to crash when processing paired-end reports containing a date_run field.

Convert datetime objects to ISO format strings during YAML parsing to ensure proper JSON serialization.

Fixes #3441