### PR TITLE
Fix incorrect plot title in umicollapse module

### DIFF
--- a/multiqc/modules/umicollapse/umicollapse.py
+++ b/multiqc/modules/umicollapse/umicollapse.py
@@ -155,7 +155,7 @@ class MultiqcModule(BaseMultiqcModule):
                 keys,
                 {
                     "id": "umicollapse_deduplication_barplot",
-                    "title": "UMI-tools: Deduplication Counts",
+                    "title": "UMICollapse: Deduplication Counts",
                     "ylab": "# Reads",
                     "cpswitch_counts_label": "Number of Reads",
                 },


### PR DESCRIPTION
## Summary

The bar plot title in the umicollapse module incorrectly said "UMI-tools: Deduplication Counts" instead of "UMICollapse: Deduplication Counts". This was likely a copy-paste error from when the module was created based on the umitools module.

## Changes

- Fixed the plot title from "UMI-tools: Deduplication Counts" to "UMICollapse: Deduplication Counts"

🤖 Generated with [Claude Code](https://claude.com/claude-code)