### PR TITLE
fastp: Add limits, update color scale of % PF/% Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Glimpse: Add more decimal to general table stats ([#3423](https://github.com/MultiQC/MultiQC/pull/3423))
 - Refactor BISCUIT module for better consistency with current MultiQC codebase ([#3345](https://github.com/MultiQC/MultiQC/pull/3345), [#3426](https://github.com/MultiQC/MultiQC/pull/3426))
 - Add version fetching for HiCUP, QoRTs, QualiMap, RNA-SeQC ([#3420](https://github.com/MultiQC/MultiQC/pull/3420))
+- fastp: add limits to `% PF` and `% Adapter` columns. Change color scale of `% PF` column.
 
 ### Fixes
 

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -440,13 +440,17 @@ class MultiqcModule(BaseMultiqcModule):
                     "title": "% PF",
                     "description": "Percent reads passing filter",
                     "suffix": "%",
-                    "scale": "BuGn",
+                    "scale": "RdYlGn",
+                    "min": 0,
+                    "max": 100,
                 },
                 "pct_adapter": {
                     "title": "% Adapter",
                     "description": "Percentage adapter-trimmed reads",
                     "suffix": "%",
                     "scale": "RdYlGn-rev",
+                    "min": 0,
+                    "max": 100,
                 },
                 "before_filtering_read1_mean_length": {
                     "title": "Mean R1 Length",


### PR DESCRIPTION
Most reads should pass preprocessing. If all samples have 0% reads pass, that's bad and currently gets hidden in the fastp module stats. This update sets min/max on some columns and changes the color to reflect that reads not passing filter = bad.