### PR TITLE
Porechop: Fix bug with "End Trimmed Percent" denominator

### DIFF
--- a/multiqc/modules/porechop/porechop.py
+++ b/multiqc/modules/porechop/porechop.py
@@ -123,7 +123,7 @@ class MultiqcModule(BaseMultiqcModule):
                     try:
                         self.porechop_data[s_name]["End Trimmed Percent"] = (
                             self.porechop_data[s_name]["End Trimmed"]
-                            / self.porechop_data[s_name]["Start Trimmed Total"]
+                            / self.porechop_data[s_name]["End Trimmed Total"]
                             * 100
                         )
                     except ZeroDivisionError:


### PR DESCRIPTION
The End Trimmed Percent was incorrectly using "Start Trimmed Total" as the denominator instead of "End Trimmed Total". This was a copy-paste error from the Start Trimmed Percent calculation.

Fixes #3436
