### PR TITLE
CrosscheckFingerprints: Fix bug due to overwriting `row_number` variable

### DIFF
--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -60,7 +60,7 @@ def parse_reports(module):
         if not lines:
             continue
         found_reports.append(f["s_name"])
-        for row_number, row in lines:
+        for row_number_in_lines, row in lines:
             # Clean the sample names
             row["LEFT_SAMPLE"] = module.clean_s_name(row["LEFT_SAMPLE"], f)
             row["LEFT_GROUP_VALUE"] = module.clean_s_name(row["LEFT_GROUP_VALUE"], f)
@@ -72,7 +72,7 @@ def parse_reports(module):
             # Set the cli options of interest for this file
             row["LOD_THRESHOLD"] = lod_threshold
             row["TUMOR_AWARENESS"] = tumor_awareness
-            row_by_number[row_number] = row
+            row_by_number[row_number_in_lines] = row
 
             try:
                 row["LOD_SCORE"] = float(row["LOD_SCORE"])


### PR DESCRIPTION
This PR fixes a new bug related to issue #2449. Although the solution from PR #2454 enabled reading multiple files in the crosscheckfingerprints module, the last row of each file (except the final file) was still being dropped.

Cause: The variable `row_number` was reused inside a nested loop, overwriting the iterator of the outer loop. As a result, when processing subsequent result files, the last row of the previous file was overwritten.


- [x] This comment contains a description of changes (with reason)

