### PR TITLE
Add Claude PostToolUse hook for code formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pre-commit run --files \"$CLAUDE_FILE_PATH\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a Claude Code hook that runs ruff-check, ruff-format, and prettier via pre-commit after Write or Edit operations to ensure consistent code formatting across Python, JS, JSON, YAML, and Jinja templates.

Based on this now-famous [X thread](https://x.com/bcherny/status/2007179832300581177).