### PR TITLE
Fix sample name cleaning in CheckM and CheckM2 modules

### DIFF
--- a/multiqc/modules/checkm/checkm.py
+++ b/multiqc/modules/checkm/checkm.py
@@ -147,7 +147,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         for line in lines[1:]:
             row = re.split(r"\t| {3,}", line.rstrip("\n"))
-            sname = row[0]
+            sname = self.clean_s_name(row[0], f)
             if sname in data_by_sample:
                 log.debug(f"Duplicate sample name found! Overwriting: {sname}")
             data_by_sample[sname] = {k: v for k, v in zip(column_names[1:], row[1:]) if v is not None}

--- a/multiqc/modules/checkm2/checkm2.py
+++ b/multiqc/modules/checkm2/checkm2.py
@@ -76,7 +76,7 @@ class MultiqcModule(BaseMultiqcModule):
         """Parse the quality_report.tsv output."""
         reader = csv.DictReader(StringIO(f["f"]), delimiter="\t")
         for row in reader:
-            sname = row.pop("Name")  # Remove and get the Name column
+            sname = self.clean_s_name(row.pop("Name"), f)  # Remove and get the Name column
             if sname in data_by_sample:
                 log.debug(f"Duplicate sample name found! Overwriting: {sname}")
             data_by_sample[sname] = {k: v for k, v in row.items() if v != "None"}


### PR DESCRIPTION
## Summary
- Both CheckM and CheckM2 modules were not calling `clean_s_name()` on sample names extracted from file content
- This meant config options like `extra_fn_clean_exts` had no effect on sample names in these modules
- Added the missing `self.clean_s_name()` calls to properly clean sample names

## Test plan
- [ ] Run MultiQC with CheckM/CheckM2 output files
- [ ] Verify that `extra_fn_clean_exts` config option now works correctly for these modules
- [ ] Confirm sample names are properly cleaned according to configured patterns

Fixes https://community.seqera.io/t/replace-names/2502/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)