### PR TITLE
add spacing between ai summary and general stats

### DIFF
--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -196,7 +196,7 @@ was generated and the button that launches the welcome tour.
 
 <div
   id="global_ai_summary_wrapper"
-  class="ai-summary bg-body-tertiary border rounded p-2"
+  class="ai-summary bg-body-tertiary border rounded p-2 mb-4"
   style="display: {% if report.ai_global_summary | length > 0 %}block{% else %}none{% endif %};"
 >
   <h5 class="ai-summary-header">Report AI Summary</h5>


### PR DESCRIPTION
<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [x] This comment contains a description of changes (with reason)

Before:

<img width="502" height="269" alt="2026-01-14_20-07_1" src="https://github.com/user-attachments/assets/c14de038-f219-427f-b074-df2f81fb181b" />

After:

<img width="618" height="297" alt="2026-01-14_20-07" src="https://github.com/user-attachments/assets/d6cb2fa5-385d-43e5-b0d5-60291d788868" />

I picked `mb-4` to align with other sections. However, note that in other places we use `mb-3`: https://github.com/MultiQC/MultiQC/blob/a1afb2ea2f48edfd3a2a1de983777914b1a32569/multiqc/templates/default/general_stats.html#L18

I don't really understand the difference between `default` vs. `original`, `general_stats.html` vs. `header.html`. All I know is this fixed the visual issue for me. We might want to modify the other templates too.