### PR TITLE
better header k/v spacing

### DIFF
--- a/multiqc/templates/default/header.html
+++ b/multiqc/templates/default/header.html
@@ -55,8 +55,8 @@ was generated and the button that launches the welcome tour.
   <div class="card card-body bg-body-tertiary mb-2">
     <dl class="row" style="margin-bottom:0;">
       {% for d in config.report_header_info %}{% for k, v in d.items() %}
-        <dt class="col-sm-3">{{ k }}</dt>
-        <dd class="col-sm-9">{{ v }}</dd>
+        <dt class="col-sm-6 col-md-4">{{ k }}</dt>
+        <dd class="col-sm-6 col-md-8">{{ v }}</dd>
       {% endfor %}{% endfor %}
     </dl>
   </div>


### PR DESCRIPTION

- [x] This comment contains a description of changes (with reason)

Improves spacing of header text. Obviously this is subjective and hard to get right on all screen sizes. I think this is a slight improvement.

<img width="555" height="295" alt="2026-01-14_20-39_1" src="https://github.com/user-attachments/assets/347a64f0-17b2-45f4-b5b0-2cb83973c5a8" />
<img width="1400" height="258" alt="2026-01-14_20-39" src="https://github.com/user-attachments/assets/c28ed2b5-d2e5-4704-ad73-c0a7988ca832" />
<img width="2250" height="262" alt="2026-01-14_20-38_1" src="https://github.com/user-attachments/assets/53943e13-7527-4a11-8993-dd081718f200" />
<img width="4813" height="259" alt="2026-01-14_20-38" src="https://github.com/user-attachments/assets/6130edcc-4aaa-45c0-8b91-30832cd1ce22" />
