### PR TITLE
Dragen: Fix incorrect average GC% in fastqc for all samples except first in batch

### DIFF
--- a/multiqc/modules/dragen_fastqc/gc_metrics.py
+++ b/multiqc/modules/dragen_fastqc/gc_metrics.py
@@ -170,6 +170,8 @@ class DragenFastqcGcMetrics(BaseMultiqcModule):
                     reads_by_gc_sum += (1.0 * pct / 100) * num_reads
                     total_reads_sum += num_reads
 
+            data.clear()
+
             avg_gc_content_data[s_name] = {"avg_gc_content_percent": (reads_by_gc_sum * 100) / total_reads_sum}
 
         # Add Avg. GC Content to header


### PR DESCRIPTION
Fixed incorrect average GC% calculated from Dragen fastqc reports for every sample in the multiqc batch except the very first in order

Explanation: The 'data' dict gets populated with [GC%, read_count] pairs for R1 and R2 of a sample. Then average GC% is calculated for the sample from these pairs. But all these tuples remain in the dict when moving to calculate the average for the next sample. As a result, every subsequent sample has its average GC% calculated from its own data appended to that of all preceding samples, resulting in an incorrect value. The final sample's reported average GC% is actually the average GC% of all the samples combined.

Changes:  Clearing the 'data' dict after each iteration.

<!--
Many thanks to contributing to MultiQC!
Please fill in the appropriate checklist below (delete whatever is not relevant).
-->

- [X] This comment contains a description of changes (with reason)