### PR TITLE
Enable code review workflow to post comments on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -51,6 +51,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_non_write_users: "*"
           show_full_output: true
           prompt: |
             Please review pull request #${{ steps.pr-info.outputs.pr_number }} and provide feedback on:


### PR DESCRIPTION
## Description

This PR updates the Claude code review GitHub Actions workflow to enable posting review comments on pull requests.

### Changes Made

- [ ] This comment contains a description of changes (with reason)

**Workflow Permission Update:**
- Changed `pull-requests` permission from `read` to `write` to allow the workflow to post review comments

**Workflow Configuration Update:**
- Added `allowed_non_write_users: "*"` parameter to the code review action to permit all users to trigger reviews

### Reason

These changes enable the automated code review workflow to post feedback directly as comments on pull requests, improving the review experience by making feedback visible in the PR conversation thread rather than only in workflow logs.

### Test Plan

The workflow will be tested on the next pull request created in the repository. The code review action should successfully post comments on the PR with the new permissions in place.

https://claude.ai/code/session_01JKmBxggyJKLMhu8y1rQ8hZ