### PR TITLE
do not require importlib_metadata backport on recent Python

### DIFF
--- a/multiqc/__main__.py
+++ b/multiqc/__main__.py
@@ -7,9 +7,11 @@ $ multiqc .
 $ python -m multiqc .
 """
 
-try:
+import sys
+
+if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
-except ImportError:
+else:
     from importlib.metadata import entry_points
 
 from . import multiqc

--- a/multiqc/__main__.py
+++ b/multiqc/__main__.py
@@ -9,10 +9,10 @@ $ python -m multiqc .
 
 import sys
 
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
-else:
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 from . import multiqc
 

--- a/multiqc/__main__.py
+++ b/multiqc/__main__.py
@@ -7,7 +7,10 @@ $ multiqc .
 $ python -m multiqc .
 """
 
-from importlib_metadata import entry_points
+try:
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 from . import multiqc
 

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -14,10 +14,13 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
-import importlib_metadata
 import yaml
-from importlib_metadata import EntryPoint
 from jsonschema import validate as validate_json_schema
+
+try:
+    from importlib_metadata import EntryPoint, entry_points, version
+except ImportError:
+    from importlib.metadata import EntryPoint, entry_points, version
 
 from multiqc.types import Anchor, ModuleId, SectionId
 from multiqc.utils import pyaml_env
@@ -28,7 +31,7 @@ from multiqc.utils.util_functions import strtobool, update_dict
 logger = logging.getLogger(__name__)
 
 # Get the MultiQC version
-version = importlib_metadata.version("multiqc")
+version = version("multiqc")
 short_version = version
 git_hash = None
 git_hash_short = None
@@ -300,7 +303,7 @@ def load_defaults():
     # Modules must be listed in pyproject.toml under entry_points['multiqc.modules.v1']
     # Get all modules, including those from other extension packages
     avail_modules = dict()
-    for entry_point in importlib_metadata.entry_points(group="multiqc.modules.v1"):
+    for entry_point in entry_points(group="multiqc.modules.v1"):
         nice_name = entry_point.name
         avail_modules[nice_name] = entry_point
 
@@ -309,7 +312,7 @@ def load_defaults():
     # Templates must be listed in pyproject.toml under entry_points['multiqc.templates.v1']
     # Get all templates, including those from other extension packages
     avail_templates = {}
-    for entry_point in importlib_metadata.entry_points(group="multiqc.templates.v1"):
+    for entry_point in entry_points(group="multiqc.templates.v1"):
         nice_name = entry_point.name
         avail_templates[nice_name] = entry_point
 

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -18,9 +18,9 @@ import yaml
 from jsonschema import validate as validate_json_schema
 
 if sys.version_info >= (3, 10):
-    from importlib.metadata import EntryPoint, entry_points, version
+    from importlib.metadata import EntryPoint, entry_points, version as version_
 else:
-    from importlib_metadata import EntryPoint, entry_points, version
+    from importlib_metadata import EntryPoint, entry_points, version as version_
 
 from multiqc.types import Anchor, ModuleId, SectionId
 from multiqc.utils import pyaml_env
@@ -31,7 +31,7 @@ from multiqc.utils.util_functions import strtobool, update_dict
 logger = logging.getLogger(__name__)
 
 # Get the MultiQC version
-version = version("multiqc")
+version = version_("multiqc")
 short_version = version
 git_hash = None
 git_hash_short = None

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -17,10 +17,10 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 import yaml
 from jsonschema import validate as validate_json_schema
 
-if sys.version_info < (3, 10):
-    from importlib_metadata import EntryPoint, entry_points, version
-else:
+if sys.version_info >= (3, 10):
     from importlib.metadata import EntryPoint, entry_points, version
+else:
+    from importlib_metadata import EntryPoint, entry_points, version
 
 from multiqc.types import Anchor, ModuleId, SectionId
 from multiqc.utils import pyaml_env

--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -17,9 +17,9 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 import yaml
 from jsonschema import validate as validate_json_schema
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import EntryPoint, entry_points, version
-except ImportError:
+else:
     from importlib.metadata import EntryPoint, entry_points, version
 
 from multiqc.types import Anchor, ModuleId, SectionId

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -6,8 +6,12 @@ import tracemalloc
 from typing import Callable, Dict, List, Union
 
 import rich
-from importlib_metadata import EntryPoint
 from rich.syntax import Syntax
+
+try:
+    from importlib_metadata import EntryPoint
+except ImportError:
+    from importlib.metadata import EntryPoint
 
 from multiqc import config, report
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -8,10 +8,10 @@ from typing import Callable, Dict, List, Union
 import rich
 from rich.syntax import Syntax
 
-if sys.version_info < (3, 10):
-    from importlib_metadata import EntryPoint
-else:
+if sys.version_info >= (3, 10):
     from importlib.metadata import EntryPoint
+else:
+    from importlib_metadata import EntryPoint
 
 from multiqc import config, report
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound

--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -8,9 +8,9 @@ from typing import Callable, Dict, List, Union
 import rich
 from rich.syntax import Syntax
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import EntryPoint
-except ImportError:
+else:
     from importlib.metadata import EntryPoint
 
 from multiqc import config, report

--- a/multiqc/core/plugin_hooks.py
+++ b/multiqc/core/plugin_hooks.py
@@ -2,11 +2,12 @@
 to run their own custom subroutines at predefined
 trigger points during MultiQC execution."""
 
+import sys
 from typing import Dict, List
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
-except ImportError:
+else:
     from importlib.metadata import entry_points
 
 # Load the hooks

--- a/multiqc/core/plugin_hooks.py
+++ b/multiqc/core/plugin_hooks.py
@@ -5,10 +5,10 @@ trigger points during MultiQC execution."""
 import sys
 from typing import Dict, List
 
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
-else:
+if sys.version_info >= (3, 10):
     from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 # Load the hooks
 hook_functions: Dict[str, List] = {}

--- a/multiqc/core/plugin_hooks.py
+++ b/multiqc/core/plugin_hooks.py
@@ -4,7 +4,10 @@ trigger points during MultiQC execution."""
 
 from typing import Dict, List
 
-from importlib_metadata import entry_points
+try:
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 # Load the hooks
 hook_functions: Dict[str, List] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "boto3",              # for aws bedrock ai support
     "click",
     "humanize",
-    "importlib_metadata",
+    "importlib_metadata; python_version < '3.10'",
     "jinja2>=3.0.0",
     "kaleido==0.2.1",     # for flat plot export
     "markdown",

--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -7,7 +7,10 @@ from typing import Dict, Set, Union
 
 import pytest
 import yaml
-from importlib_metadata import EntryPoint
+try:
+    from importlib_metadata import EntryPoint
+except ImportError:
+    from importlib.metadata import EntryPoint
 
 from multiqc import config, report
 from multiqc.core.exceptions import RunError

--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -9,10 +9,10 @@ from typing import Dict, Set, Union
 import pytest
 import yaml
 
-if sys.version_info < (3, 10):
-    from importlib_metadata import EntryPoint
-else:
+if sys.version_info >= (3, 10):
     from importlib.metadata import EntryPoint
+else:
+    from importlib_metadata import EntryPoint
 
 from multiqc import config, report
 from multiqc.core.exceptions import RunError

--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -7,6 +7,7 @@ from typing import Dict, Set, Union
 
 import pytest
 import yaml
+
 try:
     from importlib_metadata import EntryPoint
 except ImportError:

--- a/tests/test_search_files.py
+++ b/tests/test_search_files.py
@@ -2,15 +2,16 @@
 Tests for discovering and excluding files
 """
 
+import sys
 from pathlib import Path
 from typing import Dict, Set, Union
 
 import pytest
 import yaml
 
-try:
+if sys.version_info < (3, 10):
     from importlib_metadata import EntryPoint
-except ImportError:
+else:
     from importlib.metadata import EntryPoint
 
 from multiqc import config, report


### PR DESCRIPTION
subsidiary question ... what would be the baseline ? I picked 3.10 

This is an hybridized version of the much more straightforward Debian patch:

https://salsa.debian.org/med-team/multiqc/-/commit/ff07d319e381b38ff75bca50f4455a952c51b724

