### PR TITLE
Haplocheck: Don't overwrite prior results, allow multiple samples

### DIFF
--- a/multiqc/modules/haplocheck/haplocheck.py
+++ b/multiqc/modules/haplocheck/haplocheck.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
         haplocheck_data: Dict = dict()
 
         for f in self.find_log_files("haplocheck"):
-            haplocheck_data = self.parse_logs(f)
+            haplocheck_data.update(self.parse_logs(f))
 
         haplocheck_data = self.ignore_samples(haplocheck_data)
 


### PR DESCRIPTION
This corrects a bug in the Haplocheck module whereby currently each found report is overwrites prior objects, and only the last found report/sample is returned. This single line change now updates `haplocheck_data` such that all found reports/samples are returned.

- [x] This comment contains a description of changes (with reason)

Fixes #3511