### PR TITLE
enable defaultsort to include col1 header

### DIFF
--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -1355,7 +1355,7 @@ def _get_sortlist_js(dt: DataTable) -> str:
                 logger.warning(
                     "Tried to sort by column '%s', but column was not found. Available columns: %s",
                     d["column"],
-                    [col1_header]+[k for (_, k, _) in headers],
+                    [col1_header] + [k for (_, k, _) in headers],
                 )
                 return ""
         direction = 0 if d.get("direction", "").startswith("asc") else 1

--- a/multiqc/plots/table_object.py
+++ b/multiqc/plots/table_object.py
@@ -1338,23 +1338,26 @@ def _get_sortlist_js(dt: DataTable) -> str:
     sortlist: List[Tuple[int, int]] = []
 
     # defaultsort is a list of {column, direction} objects
+    col1_header = dt.pconfig.col1_header
     for d in defaultsort:
-        try:
-            # The first element of the triple is not actually unique, it's a bucket index,
-            # so we must re-enumerate ourselves here
-            idx = next(
-                idx
-                for idx, (_, k, header) in enumerate(headers)
-                if d["column"].lower() in [k.lower(), header.title.lower()]
-            )
-        except StopIteration:
-            logger.warning(
-                "Tried to sort by column '%s', but column was not found. Available columns: %s",
-                d["column"],
-                [k for (_, k, _) in headers],
-            )
-            return ""
-        idx += 1  # to account for col1_header
+        idx = 0
+        if d["column"] != col1_header:
+            try:
+                # The first element of the triple is not actually unique, it's a bucket index,
+                # so we must re-enumerate ourselves here.
+                # We start at 1 to account for col1_header.
+                idx = next(
+                    idx
+                    for idx, (_, k, header) in enumerate(headers, start=1)
+                    if d["column"].lower() in [k.lower(), header.title.lower()]
+                )
+            except StopIteration:
+                logger.warning(
+                    "Tried to sort by column '%s', but column was not found. Available columns: %s",
+                    d["column"],
+                    [col1_header]+[k for (_, k, _) in headers],
+                )
+                return ""
         direction = 0 if d.get("direction", "").startswith("asc") else 1
         sortlist.append((idx, direction))
 


### PR DESCRIPTION
Currently trying to apply a default sort including the col1 header fails as it's not technically a column. This fixes.

<img width="1601" height="194" alt="2026-03-28_20-30" src="https://github.com/user-attachments/assets/ac3ea9e4-8fb1-4eac-bdab-2ea48a397bcb" />
