### PR TITLE
Fix: import rich.panel explicitly in module-broke exception handler

### DIFF
--- a/multiqc/core/exec_modules.py
+++ b/multiqc/core/exec_modules.py
@@ -7,6 +7,7 @@ from typing import Callable, Dict, List, Union
 
 import rich
 from importlib_metadata import EntryPoint
+from rich.panel import Panel
 from rich.syntax import Syntax
 
 from multiqc import config, report
@@ -154,7 +155,7 @@ def exec_modules(mod_dicts_in_order: List[Dict[str, Dict]]) -> None:
             from multiqc.core.log_and_rich import rich_console_print
 
             rich_console_print(
-                rich.panel.Panel(
+                Panel(
                     CustomTraceback(),
                     title=f"Oops! The '[underline]{this_module}[/]' MultiQC module broke...",
                     expand=False,


### PR DESCRIPTION
## Summary

Closes #3536.

`multiqc/core/exec_modules.py:157` used `rich.panel.Panel(...)` with only `import rich` at the top of the file. This worked by luck while rich's `console.py` eagerly imported `rich.scope` (which imported `rich.panel`) at module scope. That import became lazy in rich 14.3, so from then on the handler crashed with

```
AttributeError: module 'rich' has no attribute 'panel'. Did you mean: 'pager'?
```

whenever any MultiQC module raised. The real module error was masked by the handler's own crash, making it hard to diagnose which module had failed.

This PR adds an explicit `from rich.panel import Panel` (matching the existing `from rich.syntax import Syntax` pattern one line above) and uses `Panel` at the call site.

## Test plan

Reproduction uses the same input as #3488 (`rotavirus.stats.txt`) which independently trips a module-broke path.

Before:

```
$ micromamba create -n mqc -c conda-forge -c bioconda bioconda::multiqc=1.34 -y
$ micromamba activate mqc
$ multiqc rotavirus.stats.txt
...
  File ".../multiqc/core/exec_modules.py", line 157, in exec_modules
    rich.panel.Panel(
    ^^^^^^^^^^
AttributeError: module 'rich' has no attribute 'panel'. Did you mean: 'pager'?
```

After (with this branch pip-installed over the env):

```
╭──────────────── Oops! The 'bcftools' MultiQC module broke... ────────────────╮
│ Please copy this log and report it at https://github.com/MultiQC/MultiQC/issues │
│ ...                                                                          │
│   raise ValueError("No datasets to plot")                                    │
│ ValueError: No datasets to plot                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
           multiqc | No analysis results found. Cleaning up…
```

The real underlying error (the `bcftools (stats)` parser producing an empty bar plot, tracked in #3488) is now visible to the user, and the handler exits cleanly with code 1 as before. Also verified against an unrelated module break (corrupt FastQC input → `Oops! The 'fastqc' module broke...` renders correctly), and against a clean run with no broken modules (exit 0, no panel, no regression).

- [x] Manually reproduced with rich 15.0.0 + Python 3.14 + MultiQC 1.34 (fails before, passes after)
- [x] Confirmed no regression on clean / no-broken-module runs