### PR TITLE
Bump minimum Python to 3.9

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.14.0"] # Oldest and newest supported Python versions (3.14.1 has upstream bug)
+        python-version: ["3.9", "3.14.0"] # Oldest and newest supported Python versions (3.14.1 has upstream bug)
     timeout-minutes: 10
 
     steps:

--- a/multiqc/__init__.py
+++ b/multiqc/__init__.py
@@ -12,7 +12,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning)
 
-OLDEST_SUPPORTED_PYTHON_VERSION = "3.8"
+OLDEST_SUPPORTED_PYTHON_VERSION = "3.9"
 
 if sys.version_info < tuple(map(int, OLDEST_SUPPORTED_PYTHON_VERSION.split("."))):
     raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pyarrow",            # for parquet support
 ]
 # Avoid cPython bug in 3.14.1 - https://github.com/python/cpython/issues/142214
-requires-python = ">=3.8, !=3.14.1"
+requires-python = ">=3.9, !=3.14.1"
 authors = [
     { name = "Phil Ewels", email = "phil.ewels@seqera.io" },
     { name = "Vlad Savelyev", email = "vladislav.sav@gmail.com" },


### PR DESCRIPTION
Drop support for Python 3.8 (reached end of life on 2024-10-07). Minimum supported version is now Python 3.9.

There was already a mix in the codebase where it was sort of partially dropped, so I just finished the job here.