### PR TITLE
Drop Python 2-era idioms and lint for them

### DIFF
--- a/.claude/skills/implementing-new-modules/code-patterns.md
+++ b/.claude/skills/implementing-new-modules/code-patterns.md
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ToolName",
             anchor="toolname",
             href="https://example.com/toolname",
@@ -73,7 +73,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ToolName",
             anchor="toolname",
             href="https://example.com/toolname",

--- a/.claude/skills/implementing-new-modules/module-structure.md
+++ b/.claude/skills/implementing-new-modules/module-structure.md
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ToolName",
             anchor="toolname",
             href="https://example.com/toolname",
@@ -173,7 +173,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ToolName",
             anchor="toolname",
             href="https://example.com/toolname",

--- a/.github/workflows/code_checks.py
+++ b/.github/workflows/code_checks.py
@@ -8,6 +8,7 @@ from rich import print
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 MODULES_DIR = os.path.join(BASE_DIR, "multiqc", "modules")
+PACKAGE_DIR = os.path.join(BASE_DIR, "multiqc")
 num_errors = 0
 
 SUPER_INIT_TERMS = ("super(MultiqcModule, self).__init__(", "super().__init__(")
@@ -22,6 +23,22 @@ must_be_present_after = [
 must_be_avoided_after = [
     ('f["contents_lines"]', "self.find_log_files", "Use 'f[\"f\"].splitlines()' instead"),
     ("super(MultiqcModule", "class MultiqcModule", "Use 'super().__init__()' instead"),
+]
+
+# Patterns that must never appear anywhere in the multiqc/ package. Each entry is
+# (forbidden_substring, suggestion, exempt_relpaths). Files in exempt_relpaths are
+# allowed to contain the pattern (e.g. legacy compatibility shims).
+must_be_avoided_globally = [
+    (
+        "from __future__",
+        "Drop __future__ imports — MultiQC is Python 3 only",
+        (),
+    ),
+    (
+        "OrderedDict",
+        "Use a regular dict — Python 3.7+ preserves insertion order",
+        ("plots/bargraph.py", "plots/box.py"),
+    ),
 ]
 
 
@@ -57,6 +74,26 @@ for must_be_avoided, search_term, suggestion in must_be_avoided_after:
             if matches_search_term(contents, search_term) and must_be_avoided in contents:
                 relpath = os.path.relpath(fn, MODULES_DIR)
                 message = f"Found '{must_be_avoided}' in /{relpath}"
+                if suggestion:
+                    message += f" ({suggestion})"
+                found_files.append((relpath, message))
+                num_errors += 1
+
+    for file in sorted(found_files, key=lambda x: x[0]):
+        print(file[1])
+    print("\n\n")
+
+for forbidden, suggestion, exempt in must_be_avoided_globally:
+    print(f"[bold black on yellow]  Checking that '{forbidden}' is not found anywhere in multiqc/  [/]")
+    found_files = []
+    for fn in glob.glob(os.path.join(PACKAGE_DIR, "**", "*.py"), recursive=True):
+        relpath = os.path.relpath(fn, PACKAGE_DIR)
+        if relpath in exempt:
+            continue
+        with open(fn, "r") as fh:
+            contents = fh.read()
+            if forbidden in contents:
+                message = f"Found '{forbidden}' in /{relpath}"
                 if suggestion:
                     message += f" ({suggestion})"
                 found_files.append((relpath, message))

--- a/.github/workflows/code_checks.py
+++ b/.github/workflows/code_checks.py
@@ -10,16 +10,26 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 MODULES_DIR = os.path.join(BASE_DIR, "multiqc", "modules")
 num_errors = 0
 
+SUPER_INIT_TERMS = ("super(MultiqcModule, self).__init__(", "super().__init__(")
+
 must_be_present_after = [
     ("self.add_data_source", "self.find_log_files"),
     ("self.write_data_file", "self.find_log_files"),
-    ("doi=", "super(MultiqcModule, self).__init__("),
+    ("doi=", SUPER_INIT_TERMS),
     ("self.add_software_version", "self.find_log_files"),
 ]
 
 must_be_avoided_after = [
     ('f["contents_lines"]', "self.find_log_files", "Use 'f[\"f\"].splitlines()' instead"),
 ]
+
+
+def matches_search_term(contents, search_term):
+    """Return True if any of the search term variants appears in contents."""
+    if isinstance(search_term, tuple):
+        return any(term in contents for term in search_term)
+    return search_term in contents
+
 
 # Check that add_data_source() is called for each module
 for must_be_present, search_term in must_be_present_after:
@@ -28,7 +38,7 @@ for must_be_present, search_term in must_be_present_after:
     for fn in glob.glob(os.path.join(MODULES_DIR, "*", "*.py")):
         with open(fn, "r") as fh:
             contents = fh.read()
-            if search_term in contents and must_be_present not in contents:
+            if matches_search_term(contents, search_term) and must_be_present not in contents:
                 relpath = os.path.relpath(fn, MODULES_DIR)
                 missing_files.append((relpath, f"Can't find '{must_be_present}' in /{relpath}"))
                 num_errors += 1
@@ -43,7 +53,7 @@ for must_be_avoided, search_term, suggestion in must_be_avoided_after:
     for fn in glob.glob(os.path.join(MODULES_DIR, "*", "*.py")):
         with open(fn, "r") as fh:
             contents = fh.read()
-            if search_term in contents and must_be_avoided in contents:
+            if matches_search_term(contents, search_term) and must_be_avoided in contents:
                 relpath = os.path.relpath(fn, MODULES_DIR)
                 message = f"Found '{must_be_avoided}' in /{relpath}"
                 if suggestion:

--- a/.github/workflows/code_checks.py
+++ b/.github/workflows/code_checks.py
@@ -21,6 +21,7 @@ must_be_present_after = [
 
 must_be_avoided_after = [
     ('f["contents_lines"]', "self.find_log_files", "Use 'f[\"f\"].splitlines()' instead"),
+    ("super(MultiqcModule", "class MultiqcModule", "Use 'super().__init__()' instead"),
 ]
 
 

--- a/docs/markdown/development/modules.md
+++ b/docs/markdown/development/modules.md
@@ -316,7 +316,7 @@ from multiqc.base_module import BaseMultiqcModule
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
           name="My Module",
           anchor="mymodule",
           href="https://www.awesome_bioinfo.com/mymodule",
@@ -333,7 +333,7 @@ analysis module credits and description in the report.
 The `info` parameter supports rich markdown formatting. For example:
 
 `````python
-super(MultiqcModule, self).__init__(
+super().__init__(
     name="My Advanced Module",
     anchor="myadvancedmodule",
     href="https://www.awesome_bioinfo.com/myadvancedmodule",
@@ -408,7 +408,7 @@ class MultiqcModule(BaseMultiqcModule):
     Version 1.1.0 of the tool is tested.
     """
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             ...
         )
         ...
@@ -1374,7 +1374,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Qualalyser",
             anchor="qualalyser",
             href="https://github.com/bioinformatics-centre/qualalyser/",

--- a/multiqc/base_module.py
+++ b/multiqc/base_module.py
@@ -347,12 +347,12 @@ class BaseMultiqcModule:
                     # Custom content module can now handle image files
                     (ftype, _) = mimetypes.guess_type(os.path.join(f["root"], f["fn"]))
                     if ftype is not None and ftype.startswith("image"):
-                        with io.open(os.path.join(f["root"], f["fn"]), "rb") as fh:
+                        with open(os.path.join(f["root"], f["fn"]), "rb") as fh:
                             # always return file handles
                             yield {**f, "s_name": s_name, "f": fh}
                     else:
                         # Everything else - should be all text files
-                        with io.open(os.path.join(f["root"], f["fn"]), "r", encoding="utf-8") as fh:
+                        with open(os.path.join(f["root"], f["fn"]), "r", encoding="utf-8") as fh:
                             if filehandles:
                                 yield {**f, "s_name": s_name, "f": fh}
                             elif filecontents:
@@ -364,7 +364,7 @@ class BaseMultiqcModule:
                                         f"characters\n{e}"
                                     )
                                     try:
-                                        with io.open(
+                                        with open(
                                             os.path.join(f["root"], f["fn"]),
                                             "r",
                                             encoding="utf-8",

--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -434,7 +434,7 @@ class MultiqcModule(BaseMultiqcModule):
             assert isinstance(cc_dict.config["section_name"], str)
             modname = cc_dict.config["section_name"]
 
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name=modname,
             anchor=anchor,
             href=cc_dict.config.get("section_href"),

--- a/multiqc/core/special_case_modules/profile_runtime.py
+++ b/multiqc/core/special_case_modules/profile_runtime.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
             developers optimise how they run MultiQC, to get the most efficient
             and fastest configuration possible. For more information, see the
             <a href="https://docs.seqera.io/multiqc/#optimising-run-time" target="_blank">MultiQC documentation</a>"""
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Run time " + ("and memory " if config.profile_memory else "") + "profiling",
             anchor=Anchor("multiqc_runtime"),
             info=info,

--- a/multiqc/core/special_case_modules/software_versions.py
+++ b/multiqc/core/special_case_modules/software_versions.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Software Versions",
             anchor=Anchor("multiqc_software_versions"),
             info="lists versions of software tools extracted from file contents.",

--- a/multiqc/core/write_results.py
+++ b/multiqc/core/write_results.py
@@ -556,10 +556,10 @@ def _write_html_report(to_stdout: bool, report_path: Optional[Path], return_html
                     return f'</style><link rel="stylesheet" href="{name}">'
 
             if b64:
-                with io.open(_path, "rb") as f:
+                with open(_path, "rb") as f:
                     return base64.b64encode(f.read()).decode("utf-8")
             else:
-                with io.open(_path, "r", encoding="utf-8") as f:
+                with open(_path, "r", encoding="utf-8") as f:
                     return f.read()
         except (OSError, IOError) as e:
             logger.error(f"Could not include file '{name}': {e}")
@@ -603,7 +603,7 @@ def _write_html_report(to_stdout: bool, report_path: Optional[Path], return_html
     else:
         assert report_path is not None
         try:
-            with io.open(report_path, "w", encoding="utf-8") as f:
+            with open(report_path, "w", encoding="utf-8") as f:
                 print(report_output, file=f)
         except IOError as e:
             raise IOError(f"Could not print report to '{config.output_fn}' - {IOError(e)}")

--- a/multiqc/modules/adapterremoval/adapterremoval.py
+++ b/multiqc/modules/adapterremoval/adapterremoval.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Adapter Removal",
             anchor="adapterremoval",
             href="https://github.com/mikkelschubert/adapterremoval",

--- a/multiqc/modules/afterqc/afterqc.py
+++ b/multiqc/modules/afterqc/afterqc.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="AfterQC",
             anchor="afterqc",
             href="https://github.com/OpenGene/AfterQC",

--- a/multiqc/modules/anglerfish/anglerfish.py
+++ b/multiqc/modules/anglerfish/anglerfish.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Anglerfish",
             anchor="Anglerfish",
             href="https://github.com/remiolsen/anglerfish",

--- a/multiqc/modules/ataqv/ataqv.py
+++ b/multiqc/modules/ataqv/ataqv.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ATAQV",
             anchor="ataqv",
             href="https://github.com/ParkerLab/ataqv/",

--- a/multiqc/modules/bakta/bakta.py
+++ b/multiqc/modules/bakta/bakta.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bakta",
             anchor="bakta",
             href="https://github.com/oschwengers/bakta",

--- a/multiqc/modules/bamdst/bamdst.py
+++ b/multiqc/modules/bamdst/bamdst.py
@@ -126,7 +126,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bamdst",
             anchor="bamdst",
             href="https://https://github.com/shiquan/bamdst",

--- a/multiqc/modules/bamtools/bamtools.py
+++ b/multiqc/modules/bamtools/bamtools.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bamtools",
             anchor="bamtools",
             href="https://github.com/pezmaster31/bamtools",

--- a/multiqc/modules/bases2fastq/bases2fastq.py
+++ b/multiqc/modules/bases2fastq/bases2fastq.py
@@ -150,7 +150,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bases2Fastq",
             anchor="bases2fastq",
             href=ELEMBIO_DOCS_URL,

--- a/multiqc/modules/bbduk/bbduk.py
+++ b/multiqc/modules/bbduk/bbduk.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BBDuk",
             anchor="bbduk",
             href="https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/bbduk-guide/",

--- a/multiqc/modules/bbmap/bbmap.py
+++ b/multiqc/modules/bbmap/bbmap.py
@@ -57,7 +57,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BBTools",
             anchor="bbmap",
             href="http://jgi.doe.gov/data-and-tools/bbtools/",

--- a/multiqc/modules/bcftools/bcftools.py
+++ b/multiqc/modules/bcftools/bcftools.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bcftools",
             anchor="bcftools",
             target="Bcftools",

--- a/multiqc/modules/bcl2fastq/bcl2fastq.py
+++ b/multiqc/modules/bcl2fastq/bcl2fastq.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="bcl2fastq",
             anchor="bcl2fastq",
             href="https://support.illumina.com/sequencing/sequencing_software/bcl2fastq-conversion-software.html",

--- a/multiqc/modules/bclconvert/bclconvert.py
+++ b/multiqc/modules/bclconvert/bclconvert.py
@@ -127,7 +127,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BCL Convert",
             anchor="bclconvert",
             href="https://support.illumina.com/sequencing/sequencing_software/bcl-convert.html",

--- a/multiqc/modules/biobambam2/biobambam2.py
+++ b/multiqc/modules/biobambam2/biobambam2.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="biobambam2",
             anchor="biobambam2",
             href="https://gitlab.com/german.tischler/biobambam2",

--- a/multiqc/modules/biobloomtools/biobloomtools.py
+++ b/multiqc/modules/biobloomtools/biobloomtools.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BioBloom Tools",
             anchor="biobloomtools",
             href="https://github.com/bcgsc/biobloom/",

--- a/multiqc/modules/biscuit/biscuit.py
+++ b/multiqc/modules/biscuit/biscuit.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BISCUIT",
             anchor="biscuit",
             href="https://github.com/huishenlab/biscuit",

--- a/multiqc/modules/bismark/bismark.py
+++ b/multiqc/modules/bismark/bismark.py
@@ -57,7 +57,7 @@ regexes = {
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bismark",
             anchor="bismark",
             href="http://www.bioinformatics.babraham.ac.uk/projects/bismark/",

--- a/multiqc/modules/bowtie1/bowtie1.py
+++ b/multiqc/modules/bowtie1/bowtie1.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bowtie 1",
             anchor="bowtie1",
             target="Bowtie 1",

--- a/multiqc/modules/bowtie2/bowtie2.py
+++ b/multiqc/modules/bowtie2/bowtie2.py
@@ -44,7 +44,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bowtie 2 / HiSAT2",
             anchor="bowtie2",
             href=["http://bowtie-bio.sourceforge.net/bowtie2/", "https://ccb.jhu.edu/software/hisat2/"],

--- a/multiqc/modules/busco/busco.py
+++ b/multiqc/modules/busco/busco.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="BUSCO",
             anchor="busco",
             href="http://busco.ezlab.org/",

--- a/multiqc/modules/bustools/bustools.py
+++ b/multiqc/modules/bustools/bustools.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Bustools",
             anchor="bustools",
             href="https://bustools.github.io/",

--- a/multiqc/modules/ccs/ccs.py
+++ b/multiqc/modules/ccs/ccs.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="CCS",
             anchor="ccs",
             href="https://github.com/PacificBiosciences/ccs",

--- a/multiqc/modules/cellranger/cellranger.py
+++ b/multiqc/modules/cellranger/cellranger.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Cell Ranger",
             anchor="cellranger",
             href="https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/what-is-cell-ranger",

--- a/multiqc/modules/cellranger_arc/cellranger_arc.py
+++ b/multiqc/modules/cellranger_arc/cellranger_arc.py
@@ -37,7 +37,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Cell Ranger ARC",
             anchor="cellranger-arc",
             href="https://www.10xgenomics.com/support/software/cell-ranger-arc/latest",

--- a/multiqc/modules/cells2stats/cells2stats.py
+++ b/multiqc/modules/cells2stats/cells2stats.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="cells2stats",
             anchor="cells2stats",
             href="https://docs.elembio.io/docs/cells2stats/introduction/",

--- a/multiqc/modules/checkm/checkm.py
+++ b/multiqc/modules/checkm/checkm.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="CheckM",
             anchor="checkm",
             href="https://github.com/Ecogenomics/CheckM",

--- a/multiqc/modules/checkm2/checkm2.py
+++ b/multiqc/modules/checkm2/checkm2.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="CheckM2",
             anchor="checkm2",
             href="https://github.com/chklovski/CheckM2",

--- a/multiqc/modules/checkqc/checkqc.py
+++ b/multiqc/modules/checkqc/checkqc.py
@@ -24,7 +24,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="CheckQC",
             anchor="checkqc",
             href="https://github.com/Molmed/checkQC",

--- a/multiqc/modules/clipandmerge/clipandmerge.py
+++ b/multiqc/modules/clipandmerge/clipandmerge.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ClipAndMerge",
             anchor="clipandmerge",
             href="http://www.github.com/apeltzer/ClipAndMerge",

--- a/multiqc/modules/clusterflow/clusterflow.py
+++ b/multiqc/modules/clusterflow/clusterflow.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Cluster Flow",
             anchor="clusterflow",
             href="http://clusterflow.io",

--- a/multiqc/modules/conpair/conpair.py
+++ b/multiqc/modules/conpair/conpair.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Conpair",
             anchor="conpair",
             href="https://github.com/nygenome/Conpair",

--- a/multiqc/modules/cutadapt/cutadapt.py
+++ b/multiqc/modules/cutadapt/cutadapt.py
@@ -37,7 +37,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Cutadapt",
             anchor=Anchor("cutadapt"),
             href="https://cutadapt.readthedocs.io/",

--- a/multiqc/modules/damageprofiler/damageprofiler.py
+++ b/multiqc/modules/damageprofiler/damageprofiler.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="DamageProfiler",
             anchor="damageprofiler",
             href="https://github.com/Integrative-Transcriptomics/DamageProfiler",

--- a/multiqc/modules/dedup/dedup.py
+++ b/multiqc/modules/dedup/dedup.py
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="DeDup",
             anchor="dedup",
             href="http://www.github.com/apeltzer/DeDup",

--- a/multiqc/modules/deeptools/deeptools.py
+++ b/multiqc/modules/deeptools/deeptools.py
@@ -47,7 +47,7 @@ class MultiqcModule(
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="deepTools",
             anchor="deepTools",
             target="deepTools",

--- a/multiqc/modules/diamond/diamond.py
+++ b/multiqc/modules/diamond/diamond.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="DIAMOND",
             anchor="diamond",
             href="https://github.com/bbuchfink/diamond",

--- a/multiqc/modules/disambiguate/disambiguate.py
+++ b/multiqc/modules/disambiguate/disambiguate.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Disambiguate",
             anchor="disambiguate",
             href="https://github.com/AstraZeneca-NGS/disambiguate",

--- a/multiqc/modules/dragen/dragen.py
+++ b/multiqc/modules/dragen/dragen.py
@@ -86,7 +86,7 @@ class MultiqcModule(
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="DRAGEN",
             anchor="DRAGEN",
             href="https://www.illumina.com/products/by-type/informatics-products/dragen-bio-it-platform.html",

--- a/multiqc/modules/dragen_fastqc/dragen_fastqc.py
+++ b/multiqc/modules/dragen_fastqc/dragen_fastqc.py
@@ -51,7 +51,7 @@ class MultiqcModule(DragenBaseMetrics, DragenReadMetrics, DragenFastqcGcMetrics,
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="DRAGEN-FastQC",
             anchor="dragen-fastqc",
             href="https://www.illumina.com/products/by-type/informatics-products/dragen-bio-it-platform.html",

--- a/multiqc/modules/eigenstratdatabasetools/eigenstratdatabasetools.py
+++ b/multiqc/modules/eigenstratdatabasetools/eigenstratdatabasetools.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="eigenstratdatabasetools",
             anchor="eigenstrat",
             href="https://github.com/TCLamnidis/EigenStratDatabaseTools",

--- a/multiqc/modules/fastp/fastp.py
+++ b/multiqc/modules/fastp/fastp.py
@@ -34,7 +34,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="fastp",
             anchor="fastp",
             href="https://github.com/OpenGene/fastp",

--- a/multiqc/modules/fastq_screen/fastq_screen.py
+++ b/multiqc/modules/fastq_screen/fastq_screen.py
@@ -25,7 +25,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="FastQ Screen",
             anchor="fastq_screen",
             href="http://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/",

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -5,7 +5,6 @@
 #### Have a look at Kallisto for a simpler example.     ####
 ############################################################
 import dataclasses
-import io
 import json
 import logging
 import math
@@ -888,7 +887,7 @@ class MultiqcModule(BaseMultiqcModule):
                 if not os.path.isfile(tgc_path):
                     tgc_path = tgc
                 try:
-                    with io.open(tgc_path, "r", encoding="utf-8") as f:
+                    with open(tgc_path, "r", encoding="utf-8") as f:
                         theoretical_gc_raw = f.read()
                 except IOError:
                     log.warning(f"Couldn't open FastQC Theoretical GC Content file {tgc_path}")

--- a/multiqc/modules/fastqc/fastqc.py
+++ b/multiqc/modules/fastqc/fastqc.py
@@ -193,7 +193,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="FastQC",
             anchor=Anchor("fastqc"),
             href="http://www.bioinformatics.babraham.ac.uk/projects/fastqc/",

--- a/multiqc/modules/fastqe/fastqe.py
+++ b/multiqc/modules/fastqe/fastqe.py
@@ -34,6 +34,7 @@ class MultiqcModule(BaseMultiqcModule):
             anchor="fastqe",
             href="https://github.com/fastqe/fastqe",
             info="Uses emoji to represent FASTQ sequence quality scores.",
+            # doi="",  # No DOI
         )
 
         fastqe_data: Dict[str, Dict[str, str]] = {}

--- a/multiqc/modules/featurecounts/featurecounts.py
+++ b/multiqc/modules/featurecounts/featurecounts.py
@@ -44,7 +44,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="featureCounts",
             anchor="featurecounts",
             target="Subread featureCounts",

--- a/multiqc/modules/fgbio/fgbio.py
+++ b/multiqc/modules/fgbio/fgbio.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="fgbio",
             anchor="fgbio",
             target="fgbio",

--- a/multiqc/modules/filtlong/filtlong.py
+++ b/multiqc/modules/filtlong/filtlong.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Filtlong",
             anchor="filtlong",
             href="https://github.com/rrwick/Filtlong",

--- a/multiqc/modules/flash/flash.py
+++ b/multiqc/modules/flash/flash.py
@@ -47,7 +47,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="FLASh",
             anchor="flash",
             href="https://ccb.jhu.edu/software/FLASH/",

--- a/multiqc/modules/flexbar/flexbar.py
+++ b/multiqc/modules/flexbar/flexbar.py
@@ -11,7 +11,7 @@ VERSION_REGEX = r"Flexbar - flexible barcode and adapter removal, version ([\d\.
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Flexbar",
             anchor="flexbar",
             href="https://github.com/seqan/flexbar",

--- a/multiqc/modules/freyja/freyja.py
+++ b/multiqc/modules/freyja/freyja.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Freyja",
             anchor="freyja",
             href="https://github.com/andersen-lab/Freyja",

--- a/multiqc/modules/ganon/ganon.py
+++ b/multiqc/modules/ganon/ganon.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Ganon",
             anchor="ganon",
             href="https://pirovc.github.io/ganon/",

--- a/multiqc/modules/gatk/gatk.py
+++ b/multiqc/modules/gatk/gatk.py
@@ -40,7 +40,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="GATK",
             anchor="gatk",
             target="GATK",

--- a/multiqc/modules/gffcompare/gffcompare.py
+++ b/multiqc/modules/gffcompare/gffcompare.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="GffCompare",
             anchor="gffcompare",
             href="https://ccb.jhu.edu/software/stringtie/gffcompare.shtml",

--- a/multiqc/modules/glimpse/glimpse.py
+++ b/multiqc/modules/glimpse/glimpse.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="GLIMPSE",
             anchor="glimpse",
             target="GLIMPSE",

--- a/multiqc/modules/goleft_indexcov/goleft_indexcov.py
+++ b/multiqc/modules/goleft_indexcov/goleft_indexcov.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="goleft indexcov",
             anchor="goleft_indexcov",
             href="https://github.com/brentp/goleft/tree/master/indexcov",

--- a/multiqc/modules/gopeaks/gopeaks.py
+++ b/multiqc/modules/gopeaks/gopeaks.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="GoPeaks",
             anchor="gopeaks",
             href="https://github.com/maxsonBraunLab/gopeaks",

--- a/multiqc/modules/gtdbtk/gtdbtk.py
+++ b/multiqc/modules/gtdbtk/gtdbtk.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="GTDB-Tk",
             anchor="gtdbtk",
             href="https://ecogenomics.github.io/GTDBTk/index.html",

--- a/multiqc/modules/haplocheck/haplocheck.py
+++ b/multiqc/modules/haplocheck/haplocheck.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Haplocheck",
             anchor="haplocheck",
             href="https://github.com/genepi/haplocheck/",

--- a/multiqc/modules/happy/happy.py
+++ b/multiqc/modules/happy/happy.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         """MultiQC module for processing hap.py output logs"""
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="hap.py",
             anchor="happy",
             href="https://github.com/Illumina/hap.py",

--- a/multiqc/modules/hicexplorer/hicexplorer.py
+++ b/multiqc/modules/hicexplorer/hicexplorer.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HiCExplorer",
             anchor="hicexplorer",
             href="https://hicexplorer.readthedocs.io",

--- a/multiqc/modules/hicpro/hicpro.py
+++ b/multiqc/modules/hicpro/hicpro.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """HiC-Pro module, parses log and stats files saved by HiC-Pro."""
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HiC-Pro",
             anchor="hicpro",
             href="https://github.com/nservant/HiC-Pro",

--- a/multiqc/modules/hicup/hicup.py
+++ b/multiqc/modules/hicup/hicup.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HiCUP",
             anchor="hicup",
             href="http://www.bioinformatics.babraham.ac.uk/projects/hicup/",

--- a/multiqc/modules/hifiasm/hifiasm.py
+++ b/multiqc/modules/hifiasm/hifiasm.py
@@ -11,7 +11,7 @@ VERSION_REGEX = r"\[M::main\] Version: ([\d\.r\-]+)"
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HiFiasm",
             anchor="hifiasm",
             href="https://github.com/chhylp123/hifiasm",

--- a/multiqc/modules/hisat2/hisat2.py
+++ b/multiqc/modules/hisat2/hisat2.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HISAT2",
             anchor="hisat2",
             href="https://ccb.jhu.edu/software/hisat2/",

--- a/multiqc/modules/homer/homer.py
+++ b/multiqc/modules/homer/homer.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule, FindPeaksReportMixin, TagDirReportMixin):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HOMER",
             anchor="homer",
             href="http://homer.ucsd.edu/homer/",

--- a/multiqc/modules/hops/hops.py
+++ b/multiqc/modules/hops/hops.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HOPS",
             anchor="hops",
             href="https://github.com/rhuebler/HOPS/",

--- a/multiqc/modules/hostile/hostile.py
+++ b/multiqc/modules/hostile/hostile.py
@@ -50,7 +50,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Hostile",
             anchor="hostile",
             href="https://github.com/bede/hostile",

--- a/multiqc/modules/htseq/htseq.py
+++ b/multiqc/modules/htseq/htseq.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HTSeq Count",
             anchor="htseq",
             target="HTSeq Count",

--- a/multiqc/modules/humid/humid.py
+++ b/multiqc/modules/humid/humid.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="HUMID",
             anchor="humid",
             href="https://github.com/jfjlaros/HUMID",

--- a/multiqc/modules/interop/interop.py
+++ b/multiqc/modules/interop/interop.py
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Illumina InterOp Statistics",
             anchor="interop",
             href="http://illumina.github.io/interop/index.html",

--- a/multiqc/modules/isoseq/isoseq.py
+++ b/multiqc/modules/isoseq/isoseq.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Iso-Seq",
             anchor="isoseq",
             href="https://github.com/PacificBiosciences/IsoSeq",

--- a/multiqc/modules/ivar/ivar.py
+++ b/multiqc/modules/ivar/ivar.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="iVar",
             anchor="iVar",
             href="https://github.com/andersen-lab/ivar",

--- a/multiqc/modules/jcvi/jcvi.py
+++ b/multiqc/modules/jcvi/jcvi.py
@@ -41,7 +41,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="JCVI Genome Annotation",
             anchor="jcvi",
             href="https://pypi.org/project/jcvi/",

--- a/multiqc/modules/jellyfish/jellyfish.py
+++ b/multiqc/modules/jellyfish/jellyfish.py
@@ -21,7 +21,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Jellyfish",
             anchor="jellyfish",
             href="https://github.com/gmarcais/Jellyfish",

--- a/multiqc/modules/kaiju/kaiju.py
+++ b/multiqc/modules/kaiju/kaiju.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Kaiju",
             anchor="kaiju",
             href="http://kaiju.binf.ku.dk/",

--- a/multiqc/modules/kallisto/kallisto.py
+++ b/multiqc/modules/kallisto/kallisto.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Kallisto",
             anchor="kallisto",
             href="http://pachterlab.github.io/kallisto/",

--- a/multiqc/modules/kat/kat.py
+++ b/multiqc/modules/kat/kat.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="K-mer Analysis Toolkit",
             anchor="kat",
             href="https://github.com/TGAC/KAT",

--- a/multiqc/modules/kraken/kraken.py
+++ b/multiqc/modules/kraken/kraken.py
@@ -62,7 +62,7 @@ class MultiqcModule(BaseMultiqcModule):
         doi: str = "10.1186/gb-2014-15-3-r46",
         sp_key: str = "kraken",
     ):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name=name,
             anchor=anchor,
             href=href,

--- a/multiqc/modules/leehom/leehom.py
+++ b/multiqc/modules/leehom/leehom.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="leeHom",
             anchor="leehom",
             href="https://github.com/grenaud/leeHom",

--- a/multiqc/modules/librarian/librarian.py
+++ b/multiqc/modules/librarian/librarian.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialse the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Librarian",
             anchor="librarian",
             href="https://github.com/DesmondWillowbrook/Librarian",

--- a/multiqc/modules/lima/lima.py
+++ b/multiqc/modules/lima/lima.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialse the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Lima",
             anchor="lima",
             href="https://github.com/PacificBiosciences/barcoding",

--- a/multiqc/modules/longranger/longranger.py
+++ b/multiqc/modules/longranger/longranger.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Long Ranger",
             anchor="longranger",
             href="https://support.10xgenomics.com/genome-exome/software/pipelines/latest/what-is-long-ranger",

--- a/multiqc/modules/macs2/macs2.py
+++ b/multiqc/modules/macs2/macs2.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MACS2",
             anchor="macs",
             href="https://macs3-project.github.io/MACS/",

--- a/multiqc/modules/malt/malt.py
+++ b/multiqc/modules/malt/malt.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MALT",
             anchor="malt",
             href="http://ab.inf.uni-tuebingen.de/software/malt/",

--- a/multiqc/modules/mapdamage/mapdamage.py
+++ b/multiqc/modules/mapdamage/mapdamage.py
@@ -13,7 +13,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="mapDamage",
             anchor="mapdamage",
             href="https://github.com/ginolhac/mapDamage",

--- a/multiqc/modules/megahit/megahit.py
+++ b/multiqc/modules/megahit/megahit.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MEGAHIT",
             anchor="megahit",
             href="https://github.com/voutcn/megahit",

--- a/multiqc/modules/metaphlan/metaphlan.py
+++ b/multiqc/modules/metaphlan/metaphlan.py
@@ -40,7 +40,7 @@ class MultiqcModule(BaseMultiqcModule):
         info="Profiles the composition of microbial communities from metagenomic shotgun sequencing data.",
         doi="10.1038/s41587-023-01688-w",
     ):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name=name,
             anchor=anchor,
             href=href,

--- a/multiqc/modules/methurator/methurator.py
+++ b/multiqc/modules/methurator/methurator.py
@@ -32,7 +32,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Methurator",
             anchor="methurator",
             href="https://github.com/VIBTOBIlab/methurator",

--- a/multiqc/modules/methylqa/methylqa.py
+++ b/multiqc/modules/methylqa/methylqa.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="methylQA",
             anchor="methylqa",
             target="methylqa",

--- a/multiqc/modules/mgikit/mgikit.py
+++ b/multiqc/modules/mgikit/mgikit.py
@@ -34,7 +34,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="mgikit",
             anchor="mgikit",
             href="https://github.com/sagc-bioinformatics/mgikit",

--- a/multiqc/modules/minionqc/minionqc.py
+++ b/multiqc/modules/minionqc/minionqc.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MinIONQC",
             anchor="minionqc",
             href="https://github.com/roblanf/minion_qc",

--- a/multiqc/modules/mirtop/mirtop.py
+++ b/multiqc/modules/mirtop/mirtop.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="mirtop",
             anchor="mirtop",
             href="https://github.com/miRTop/mirtop/",

--- a/multiqc/modules/mirtrace/mirtrace.py
+++ b/multiqc/modules/mirtrace/mirtrace.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="miRTrace",
             anchor="mirtrace",
             href="https://github.com/friedlanderlab/mirtrace",

--- a/multiqc/modules/mosaicatcher/mosaicatcher.py
+++ b/multiqc/modules/mosaicatcher/mosaicatcher.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MosaiCatcher",
             anchor="mosaicatcher",
             href="https://github.com/friendsofstrandseq/mosaicatcher",

--- a/multiqc/modules/mosdepth/mosdepth.py
+++ b/multiqc/modules/mosdepth/mosdepth.py
@@ -175,7 +175,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Mosdepth",
             anchor="mosdepth",
             href="https://github.com/brentp/mosdepth",

--- a/multiqc/modules/motus/motus.py
+++ b/multiqc/modules/motus/motus.py
@@ -13,7 +13,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Motus",
             anchor="motus",
             href="https://motu-tool.org/",

--- a/multiqc/modules/mtnucratio/mtnucratio.py
+++ b/multiqc/modules/mtnucratio/mtnucratio.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="mtnucratio",
             anchor="mtnucratio",
             href="http://www.github.com/apeltzer/MTNucRatioCalculator",

--- a/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
+++ b/multiqc/modules/multivcfanalyzer/multivcfanalyzer.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="MultiVCFAnalyzer",
             anchor="multivcfanalyzer",
             href="https://github.com/alexherbig/MultiVCFAnalyzer",

--- a/multiqc/modules/nanoq/nanoq.py
+++ b/multiqc/modules/nanoq/nanoq.py
@@ -17,7 +17,7 @@ class MultiqcModule(BaseMultiqcModule):
     _stat_types = ("summary", "quality")
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="nanoq",
             anchor="nanoq",
             href="https://github.com/nerdna/nanoq/",

--- a/multiqc/modules/nanostat/nanostat.py
+++ b/multiqc/modules/nanostat/nanostat.py
@@ -86,7 +86,7 @@ class MultiqcModule(BaseMultiqcModule):
     _stat_types = ("aligned", "seq summary", "fastq", "fasta", "unrecognized")
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="NanoStat",
             anchor="nanostat",
             href=["https://github.com/wdecoster/nanostat/", "https://github.com/wdecoster/nanoplot/"],

--- a/multiqc/modules/nextclade/nextclade.py
+++ b/multiqc/modules/nextclade/nextclade.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Nextclade",
             anchor="nextclade",
             href="https://github.com/nextstrain/nextclade",

--- a/multiqc/modules/ngsbits/ngsbits.py
+++ b/multiqc/modules/ngsbits/ngsbits.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
 
     def __init__(self):
         # Initialise the parent object
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ngs-bits",
             anchor="ngsbits",
             href="https://github.com/imgag/ngs-bits",

--- a/multiqc/modules/ngsderive/ngsderive.py
+++ b/multiqc/modules/ngsderive/ngsderive.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ngsderive",
             anchor="ngsderive",
             href="https://github.com/stjudecloud/ngsderive",

--- a/multiqc/modules/nonpareil/nonpareil.py
+++ b/multiqc/modules/nonpareil/nonpareil.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Nonpareil",
             anchor="nonpareil",
             href="https://github.com/lmrodriguezr/nonpareil",

--- a/multiqc/modules/odgi/odgi.py
+++ b/multiqc/modules/odgi/odgi.py
@@ -77,7 +77,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="ODGI",
             anchor="odgi",
             href="https://github.com/pangenome/odgi",

--- a/multiqc/modules/optitype/optitype.py
+++ b/multiqc/modules/optitype/optitype.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="OptiType",
             anchor="optitype",
             href="https://github.com/FRED-2/OptiType",

--- a/multiqc/modules/pairtools/pairtools.py
+++ b/multiqc/modules/pairtools/pairtools.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="pairtools",
             anchor="pairtools",
             href="https://github.com/mirnylab/pairtools",

--- a/multiqc/modules/pbmarkdup/pbmarkdup.py
+++ b/multiqc/modules/pbmarkdup/pbmarkdup.py
@@ -13,7 +13,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="pbmarkdup",
             anchor="pbmarkdup",
             href="https://github.com/PacificBiosciences/pbmarkdup",

--- a/multiqc/modules/peddy/peddy.py
+++ b/multiqc/modules/peddy/peddy.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Peddy",
             anchor="peddy",
             href="https://github.com/brentp/peddy",

--- a/multiqc/modules/percolator/percolator.py
+++ b/multiqc/modules/percolator/percolator.py
@@ -31,7 +31,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Percolator",
             anchor="percolator",
             href="https://github.com/percolator/percolator",

--- a/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
+++ b/multiqc/modules/phantompeakqualtools/phantompeakqualtools.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="phantompeakqualtools",
             anchor="phantompeakqualtools",
             href="https://www.encodeproject.org/software/phantompeakqualtools",

--- a/multiqc/modules/picard/AlignmentSummaryMetrics.py
+++ b/multiqc/modules/picard/AlignmentSummaryMetrics.py
@@ -3,7 +3,6 @@ MultiQC submodule to parse output from Picard AlignmentSummaryMetrics
 """
 
 import logging
-from collections import OrderedDict
 from typing import Dict
 
 from multiqc.modules.picard import util
@@ -106,7 +105,7 @@ def parse_reports(module):
             pdata[s_name]["aligned_reads"] = data_by_sample[s_name]["PF_READS_ALIGNED"]
         pdata[s_name]["unaligned_reads"] = pdata[s_name]["total_reads"] - pdata[s_name]["aligned_reads"]
 
-    keys = [OrderedDict(), OrderedDict()]
+    keys = [{}, {}]
     keys[0]["aligned_reads"] = {"name": "Aligned Reads"}
     keys[0]["unaligned_reads"] = {"name": "Unaligned Reads"}
     keys[1]["PF_ALIGNED_BASES"] = {"name": "Aligned Bases"}

--- a/multiqc/modules/picard/CrosscheckFingerprints.py
+++ b/multiqc/modules/picard/CrosscheckFingerprints.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from csv import DictReader
 from itertools import chain, groupby
 
@@ -331,7 +331,7 @@ def _get_table_headers(data_by_sample):
             "RIGHT_GROUP_VALUE",
         ] + table_cols
 
-    headers = OrderedDict()
+    headers = {}
     for h in FIELD_DESCRIPTIONS:
         # Skip anything not set to visible
         if h not in table_cols:

--- a/multiqc/modules/picard/QualityScoreDistributionMetrics.py
+++ b/multiqc/modules/picard/QualityScoreDistributionMetrics.py
@@ -1,7 +1,6 @@
 """MultiQC submodule to parse output from Picard QualityScoreDistribution"""
 
 import logging
-from collections import OrderedDict
 
 from multiqc.plots import linegraph
 
@@ -48,7 +47,7 @@ def parse_reports(self):
 
     lg = {}
     for s_name in all_data:
-        lg[s_name] = OrderedDict((qual, data["COUNT_OF_Q"]) for qual, data in all_data[s_name].items())
+        lg[s_name] = {qual: data["COUNT_OF_Q"] for qual, data in all_data[s_name].items()}
 
     self.add_section(
         name="Base Quality Distribution",

--- a/multiqc/modules/picard/QualityYieldMetrics.py
+++ b/multiqc/modules/picard/QualityYieldMetrics.py
@@ -1,7 +1,6 @@
 """MultiQC submodule to parse output from Picard QualityYieldMetrics"""
 
 import logging
-from collections import OrderedDict
 
 from multiqc import config
 from multiqc.modules.picard import util
@@ -9,21 +8,19 @@ from multiqc.modules.picard import util
 # Initialise the logger
 log = logging.getLogger(__name__)
 
-DESC = OrderedDict(
-    [
-        ("TOTAL_READS", "The total number of reads in the input file"),
-        ("PF_READS", "The number of reads that are PF - pass filter"),
-        ("READ_LENGTH", "The average read length of all the reads (will be fixed for a lane)"),
-        ("TOTAL_BASES", "The total number of bases in all reads"),
-        ("PF_BASES", "The total number of bases in all PF reads"),
-        ("Q20_BASES", "The number of bases in all reads that achieve quality score 20 or higher"),
-        ("PF_Q20_BASES", "The number of bases in PF reads that achieve quality score 20 or higher"),
-        ("Q30_BASES", "The number of bases in all reads that achieve quality score 30 or higher"),
-        ("PF_Q30_BASES", "The number of bases in PF reads that achieve quality score 30 or higher"),
-        ("Q20_EQUIVALENT_YIELD", "The sum of quality scores of all bases divided by 20"),
-        ("PF_Q20_EQUIVALENT_YIELD", "The sum of quality scores of all bases in PF reads divided by 20"),
-    ]
-)
+DESC = {
+    "TOTAL_READS": "The total number of reads in the input file",
+    "PF_READS": "The number of reads that are PF - pass filter",
+    "READ_LENGTH": "The average read length of all the reads (will be fixed for a lane)",
+    "TOTAL_BASES": "The total number of bases in all reads",
+    "PF_BASES": "The total number of bases in all PF reads",
+    "Q20_BASES": "The number of bases in all reads that achieve quality score 20 or higher",
+    "PF_Q20_BASES": "The number of bases in PF reads that achieve quality score 20 or higher",
+    "Q30_BASES": "The number of bases in all reads that achieve quality score 30 or higher",
+    "PF_Q30_BASES": "The number of bases in PF reads that achieve quality score 30 or higher",
+    "Q20_EQUIVALENT_YIELD": "The sum of quality scores of all bases divided by 20",
+    "PF_Q20_EQUIVALENT_YIELD": "The sum of quality scores of all bases in PF reads divided by 20",
+}
 
 
 def parse_reports(module):

--- a/multiqc/modules/picard/RrbsSummaryMetrics.py
+++ b/multiqc/modules/picard/RrbsSummaryMetrics.py
@@ -1,7 +1,6 @@
 """MultiQC submodule to parse output from Picard RrbsSummaryMetrics"""
 
 import logging
-from collections import OrderedDict
 from typing import Dict
 
 from multiqc.modules.picard import util
@@ -144,7 +143,7 @@ def parse_reports(module):
             - pdata[s_name]["ignored_mismatches"]
         )
 
-    keys = OrderedDict()
+    keys = {}
     keys["not_ignored"] = {"name": "Utilised reads"}
     keys["with_no_cpg"] = {"name": "Ignored (no CpG sites)"}
     keys["ignored_short"] = {"name": "Ignored (too short)"}

--- a/multiqc/modules/picard/picard.py
+++ b/multiqc/modules/picard/picard.py
@@ -284,7 +284,7 @@ class MultiqcModule(BaseMultiqcModule):
         # No DOI to cite // doi=
         tools=tuple(TOOLS),
     ):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name=name,
             anchor=anchor,
             href=href,

--- a/multiqc/modules/porechop/porechop.py
+++ b/multiqc/modules/porechop/porechop.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Porechop",
             anchor="porechop",
             href="https://github.com/rrwick/Porechop",

--- a/multiqc/modules/preseq/preseq.py
+++ b/multiqc/modules/preseq/preseq.py
@@ -80,7 +80,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Preseq",
             anchor="preseq",
             href="http://smithlabresearch.org/software/preseq/",

--- a/multiqc/modules/prinseqplusplus/prinseqplusplus.py
+++ b/multiqc/modules/prinseqplusplus/prinseqplusplus.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="PRINSEQ++",
             anchor="prinseqplusplus",
             href="https://github.com/Adrian-Cantu/PRINSEQ-plus-plus",

--- a/multiqc/modules/prokka/prokka.py
+++ b/multiqc/modules/prokka/prokka.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Prokka",
             anchor="prokka",
             href="http://www.vicbioinformatics.com/software.prokka.shtml",

--- a/multiqc/modules/purple/purple.py
+++ b/multiqc/modules/purple/purple.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="PURPLE",
             anchor="purple",
             href="https://github.com/hartwigmedical/hmftools/",

--- a/multiqc/modules/pychopper/pychopper.py
+++ b/multiqc/modules/pychopper/pychopper.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Pychopper",
             anchor="pychopper",
             href="https://github.com/nanoporetech/pychopper",

--- a/multiqc/modules/pycoqc/pycoqc.py
+++ b/multiqc/modules/pycoqc/pycoqc.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="pycoQC",
             anchor="pycoqc",
             href="https://github.com/tleonardi/pycoQC",

--- a/multiqc/modules/qc3C/qc3C.py
+++ b/multiqc/modules/qc3C/qc3C.py
@@ -130,7 +130,7 @@ def color_picker(degen):
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="qc3C",
             anchor="qc3C",
             href="http://github.com/cerebis/qc3C",

--- a/multiqc/modules/qorts/qorts.py
+++ b/multiqc/modules/qorts/qorts.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="QoRTs",
             anchor="qorts",
             href="http://hartleys.github.io/QoRTs/",

--- a/multiqc/modules/qualimap/qualimap.py
+++ b/multiqc/modules/qualimap/qualimap.py
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="QualiMap",
             anchor="qualimap",
             href="http://qualimap.bioinfo.cipf.es/",

--- a/multiqc/modules/quast/quast.py
+++ b/multiqc/modules/quast/quast.py
@@ -55,7 +55,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="QUAST",
             anchor="quast",
             href="http://quast.bioinf.spbau.ru/",

--- a/multiqc/modules/ribotish/ribotish.py
+++ b/multiqc/modules/ribotish/ribotish.py
@@ -23,7 +23,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Ribo-TISH",
             anchor="ribotish",
             href="https://github.com/zhpn1024/ribotish",

--- a/multiqc/modules/ribowaltz/ribowaltz.py
+++ b/multiqc/modules/ribowaltz/ribowaltz.py
@@ -34,7 +34,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="riboWaltz",
             anchor="ribowaltz",
             href="https://github.com/LabTranslationalArchitectomics/riboWaltz",

--- a/multiqc/modules/rna_seqc/rna_seqc.py
+++ b/multiqc/modules/rna_seqc/rna_seqc.py
@@ -24,7 +24,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="RNA-SeQC",
             anchor="rna_seqc",
             href="https://github.com/getzlab/rnaseqc",

--- a/multiqc/modules/rockhopper/rockhopper.py
+++ b/multiqc/modules/rockhopper/rockhopper.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Rockhopper",
             anchor="rockhopper",
             href="https://cs.wellesley.edu/~btjaden/Rockhopper/",

--- a/multiqc/modules/rsem/rsem.py
+++ b/multiqc/modules/rsem/rsem.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="RSEM",
             anchor="rsem",
             href="https://deweylab.github.io/RSEM/",

--- a/multiqc/modules/rseqc/rseqc.py
+++ b/multiqc/modules/rseqc/rseqc.py
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="RSeQC",
             anchor="rseqc",
             href="http://rseqc.sourceforge.net/",

--- a/multiqc/modules/salmon/salmon.py
+++ b/multiqc/modules/salmon/salmon.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Salmon",
             anchor="salmon",
             href="https://combine-lab.github.io/salmon/",

--- a/multiqc/modules/sambamba/sambamba.py
+++ b/multiqc/modules/sambamba/sambamba.py
@@ -47,7 +47,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Sambamba",
             anchor="sambamba",
             href="https://lomereiter.github.io/sambamba/",

--- a/multiqc/modules/samblaster/samblaster.py
+++ b/multiqc/modules/samblaster/samblaster.py
@@ -12,7 +12,7 @@ VERSION_REGEX = r"Version\ (\d{1}.\d+.\d+)"
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Samblaster",
             anchor="samblaster",
             href="https://github.com/GregoryFaust/samblaster",

--- a/multiqc/modules/samtools/samtools.py
+++ b/multiqc/modules/samtools/samtools.py
@@ -123,7 +123,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Samtools",
             anchor="samtools",
             target="samtools",

--- a/multiqc/modules/sargasso/sargasso.py
+++ b/multiqc/modules/sargasso/sargasso.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Sargasso",
             anchor="sargasso",
             href="http://biomedicalinformaticsgroup.github.io/Sargasso/",

--- a/multiqc/modules/seqera_cli/seqera_cli.py
+++ b/multiqc/modules/seqera_cli/seqera_cli.py
@@ -55,7 +55,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Seqera Platform CLI",
             anchor="seqera_cli",
             href="https://github.com/seqeralabs/tower-cli",

--- a/multiqc/modules/seqfu/seqfu.py
+++ b/multiqc/modules/seqfu/seqfu.py
@@ -29,7 +29,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Seqfu",
             anchor="seqfu",
             target="seqfu",

--- a/multiqc/modules/seqkit/seqkit.py
+++ b/multiqc/modules/seqkit/seqkit.py
@@ -35,7 +35,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SeqKit",
             anchor="seqkit",
             href="https://bioinf.shenwei.me/seqkit/",

--- a/multiqc/modules/sequali/sequali.py
+++ b/multiqc/modules/sequali/sequali.py
@@ -107,7 +107,7 @@ def prune_sample_dict(sample_dict: Dict[str, Any]):
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Sequali",
             anchor="sequali",
             href="https://github.com/rhpvorderman/sequali",

--- a/multiqc/modules/seqwho/seqwho.py
+++ b/multiqc/modules/seqwho/seqwho.py
@@ -16,7 +16,7 @@ SPECIES = ["human", "mouse"]
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SeqWho",
             anchor="seqwho",
             href="https://daehwankimlab.github.io/seqwho/",

--- a/multiqc/modules/seqwho/seqwho.py
+++ b/multiqc/modules/seqwho/seqwho.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from collections import OrderedDict
 
 from multiqc import config
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
@@ -98,19 +97,19 @@ class MultiqcModule(BaseMultiqcModule):
                 self.seqwho_data[s_name][i] = mle_matrix[i]
 
             # Make a Quality Score vs count  version of the data
-            self.seqwho_qualdis[s_name] = OrderedDict()
+            self.seqwho_qualdis[s_name] = {}
             qual_dist = data["Quality Dist"]
             for i in range(len(qual_dist)):
                 self.seqwho_qualdis[s_name][i] = qual_dist[i]
 
             # Make a Quality score vs position  version of the data
-            self.seqwho_qualscore[s_name] = OrderedDict()
+            self.seqwho_qualscore[s_name] = {}
             qual_scores = data["Quality Scores"]
             for i in range(len(qual_scores)):
                 self.seqwho_qualscore[s_name][i] = qual_scores[i]
 
             # Make a Read Length vs count of the data
-            self.seqwho_readdist[s_name] = OrderedDict()
+            self.seqwho_readdist[s_name] = {}
             read_dist = data["Read lengths"]
             for i in range(len(read_dist)):
                 self.seqwho_readdist[s_name][i] = read_dist[i]

--- a/multiqc/modules/seqyclean/seqyclean.py
+++ b/multiqc/modules/seqyclean/seqyclean.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SeqyClean",
             anchor="seqyclean",
             href="https://github.com/ibest/seqyclean",

--- a/multiqc/modules/sexdeterrmine/sexdeterrmine.py
+++ b/multiqc/modules/sexdeterrmine/sexdeterrmine.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SexDetErrmine",
             anchor="sexdeterrmine",
             href="https://github.com/TCLamnidis/Sex.DetERRmine",

--- a/multiqc/modules/sickle/sickle.py
+++ b/multiqc/modules/sickle/sickle.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Sickle",
             anchor="sickle",
             href="https://github.com/najoshi/sickle",

--- a/multiqc/modules/skewer/skewer.py
+++ b/multiqc/modules/skewer/skewer.py
@@ -11,7 +11,7 @@ VERSION_REGEX = r"skewer v([\d\.]+) \[.+\]"
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Skewer",
             anchor="skewer",
             href="https://github.com/relipmoc/skewer",

--- a/multiqc/modules/slamdunk/slamdunk.py
+++ b/multiqc/modules/slamdunk/slamdunk.py
@@ -16,7 +16,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Slamdunk",
             anchor="slamdunk",
             href="http://t-neumann.github.io/slamdunk/",

--- a/multiqc/modules/snippy/snippy.py
+++ b/multiqc/modules/snippy/snippy.py
@@ -20,7 +20,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Snippy",
             anchor="snippy",
             href="https://github.com/tseemann/snippy",

--- a/multiqc/modules/snpeff/snpeff.py
+++ b/multiqc/modules/snpeff/snpeff.py
@@ -19,7 +19,7 @@ class MultiqcModule(BaseMultiqcModule):
     """SnpEff"""
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SnpEff",
             anchor="snpeff",
             href="http://snpeff.sourceforge.net/",

--- a/multiqc/modules/snpsplit/snpsplit.py
+++ b/multiqc/modules/snpsplit/snpsplit.py
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SNPsplit",
             anchor="SNPsplit",
             target="SNPsplit",

--- a/multiqc/modules/somalier/somalier.py
+++ b/multiqc/modules/somalier/somalier.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Somalier",
             anchor="somalier",
             href="https://github.com/brentp/somalier",

--- a/multiqc/modules/sompy/sompy.py
+++ b/multiqc/modules/sompy/sompy.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
         """MultiQC module for processing som.py output"""
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="som.py",
             anchor="sompy",
             href="https://github.com/Illumina/hap.py/blob/master/doc/sompy.md",

--- a/multiqc/modules/sortmerna/sortmerna.py
+++ b/multiqc/modules/sortmerna/sortmerna.py
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="SortMeRNA",
             anchor="sortmerna",
             href="http://bioinfo.lifl.fr/RNA/sortmerna/",

--- a/multiqc/modules/sourmash/sourmash.py
+++ b/multiqc/modules/sourmash/sourmash.py
@@ -33,7 +33,7 @@ class MultiqcModule(BaseMultiqcModule, CompareMixin, GatherMixin):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Sourmash",
             anchor="sourmash",
             href="https://github.com/sourmash-bio/sourmash",

--- a/multiqc/modules/spaceranger/spaceranger.py
+++ b/multiqc/modules/spaceranger/spaceranger.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Space Ranger",
             anchor="spaceranger",
             href="https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/what-is-space-ranger",

--- a/multiqc/modules/stacks/stacks.py
+++ b/multiqc/modules/stacks/stacks.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Stacks",
             anchor="stacks",
             href="http://catchenlab.life.illinois.edu/stacks/",

--- a/multiqc/modules/star/star.py
+++ b/multiqc/modules/star/star.py
@@ -22,7 +22,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="STAR",
             anchor="star",
             href="https://github.com/alexdobin/STAR",

--- a/multiqc/modules/supernova/supernova.py
+++ b/multiqc/modules/supernova/supernova.py
@@ -37,7 +37,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Supernova",
             anchor="supernova",
             href="https://www.10xgenomics.com/",

--- a/multiqc/modules/sylphtax/sylphtax.py
+++ b/multiqc/modules/sylphtax/sylphtax.py
@@ -39,7 +39,7 @@ class MultiqcModule(BaseMultiqcModule):
         info="Taxonomic profiling of metagenomic reads.",
         doi="10.1038/s41587-024-02412-y",
     ):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name=name,
             anchor=anchor,
             href=href,

--- a/multiqc/modules/telseq/telseq.py
+++ b/multiqc/modules/telseq/telseq.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="telseq",
             anchor="telseq",
             href="https://github.com/zd1/telseq",

--- a/multiqc/modules/theta2/theta2.py
+++ b/multiqc/modules/theta2/theta2.py
@@ -15,7 +15,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="THetA2",
             anchor="theta2",
             href="http://compbio.cs.brown.edu/projects/theta/",

--- a/multiqc/modules/tophat/tophat.py
+++ b/multiqc/modules/tophat/tophat.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class MultiqcModule(BaseMultiqcModule):
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Tophat",
             anchor="tophat",
             href="https://ccb.jhu.edu/software/tophat/",

--- a/multiqc/modules/trimmomatic/trimmomatic.py
+++ b/multiqc/modules/trimmomatic/trimmomatic.py
@@ -30,7 +30,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Trimmomatic",
             anchor=Anchor("trimmomatic"),
             href="http://www.usadellab.org/cms/?page=trimmomatic",

--- a/multiqc/modules/truvari/truvari.py
+++ b/multiqc/modules/truvari/truvari.py
@@ -21,7 +21,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Truvari",
             anchor="truvari",
             href="https://github.com/ACEnglish/truvari",

--- a/multiqc/modules/umicollapse/umicollapse.py
+++ b/multiqc/modules/umicollapse/umicollapse.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="UMICollapse",
             anchor="umicollapse",
             href="https://github.com/Daniel-Liu-c0deb0t/UMICollapse",

--- a/multiqc/modules/umitools/umitools.py
+++ b/multiqc/modules/umitools/umitools.py
@@ -34,7 +34,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="UMI-tools",
             anchor="umitools",
             href="https://github.com/CGATOxford/UMI-tools",

--- a/multiqc/modules/varscan2/varscan2.py
+++ b/multiqc/modules/varscan2/varscan2.py
@@ -14,7 +14,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="VarScan2",
             anchor="varscan",
             href="http://dkoboldt.github.io/varscan/",

--- a/multiqc/modules/vcftools/vcftools.py
+++ b/multiqc/modules/vcftools/vcftools.py
@@ -53,7 +53,7 @@ class MultiqcModule(BaseMultiqcModule, Relatedness2Mixin, TsTvByCountMixin, TsTv
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="VCFTools",
             anchor="vcftools",
             href="https://vcftools.github.io",

--- a/multiqc/modules/vep/vep.py
+++ b/multiqc/modules/vep/vep.py
@@ -26,7 +26,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="VEP",
             anchor="vep",
             href="https://www.ensembl.org/info/docs/tools/vep/index.html",

--- a/multiqc/modules/verifybamid/verifybamid.py
+++ b/multiqc/modules/verifybamid/verifybamid.py
@@ -36,7 +36,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="VerifyBAMID",
             anchor="verifybamid",
             href="https://genome.sph.umich.edu/wiki/VerifyBamID",

--- a/multiqc/modules/vg/vg.py
+++ b/multiqc/modules/vg/vg.py
@@ -50,7 +50,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="VG",
             anchor="vg",
             href="https://github.com/vgteam/vg",

--- a/multiqc/modules/whatshap/whatshap.py
+++ b/multiqc/modules/whatshap/whatshap.py
@@ -18,7 +18,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="WhatsHap",
             anchor="whatshap",
             href="https://whatshap.readthedocs.io/",

--- a/multiqc/modules/xengsort/xengsort.py
+++ b/multiqc/modules/xengsort/xengsort.py
@@ -28,7 +28,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Xengsort",
             anchor="xengsort",
             href="https://gitlab.com/genomeinformatics/xengsort",

--- a/multiqc/modules/xenium/xenium.py
+++ b/multiqc/modules/xenium/xenium.py
@@ -41,7 +41,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Xenium",
             anchor="xenium",
             href="https://www.10xgenomics.com/platforms/xenium",

--- a/multiqc/modules/xenome/xenome.py
+++ b/multiqc/modules/xenome/xenome.py
@@ -27,7 +27,7 @@ class MultiqcModule(BaseMultiqcModule):
     """
 
     def __init__(self):
-        super(MultiqcModule, self).__init__(
+        super().__init__(
             name="Xenome",
             anchor="xenome",
             href="https://github.com/data61/gossamer/blob/master/docs/xenome.md",

--- a/multiqc/plots/linegraph.py
+++ b/multiqc/plots/linegraph.py
@@ -1,6 +1,5 @@
 """MultiQC functions to plot a linegraph"""
 
-import io
 import json
 import logging
 import math
@@ -290,7 +289,7 @@ class Dataset(BaseDataset, Generic[KeyT, ValT]):
 
             fn = f"{self.uid}.{config.data_format_extensions[config.data_format]}"
             fpath = os.path.join(report.data_tmp_dir(), fn)
-            with io.open(fpath, "w", encoding="utf-8") as f:
+            with open(fpath, "w", encoding="utf-8") as f:
                 f.write(fout.encode("utf-8", "ignore").decode("utf-8"))
         else:
             report.write_data_file(y_by_x_by_sample, self.uid)

--- a/multiqc/report.py
+++ b/multiqc/report.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import sys
 import time
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path, PosixPath
 from typing import (
@@ -127,7 +127,7 @@ general_stats_data: Dict[SectionKey, Dict[SampleGroup, List[InputRow]]]
 general_stats_headers: Dict[SectionKey, Dict[ColumnKey, ColumnDict]]
 software_versions: Dict[str, Dict[str, List[str]]]  # map software tools to unique versions
 plot_compressed_json: str
-# to make sure write_data_file don't overwrite for repeated modules. OrderedDict for fast lookup and to preserve insertion order:
+# to make sure write_data_file don't overwrite for repeated modules. dict for fast lookup and to preserve insertion order:
 saved_raw_data_keys: Dict[str, None]
 saved_raw_data: Dict[str, Any] = dict()  # only populated if preserve_module_raw_data is enabled
 
@@ -223,7 +223,7 @@ def reset():
     general_stats_headers = dict()
     software_versions = defaultdict(lambda: defaultdict(list))
     plot_compressed_json = ""
-    saved_raw_data_keys = OrderedDict()
+    saved_raw_data_keys = {}
     saved_raw_data = dict()
 
     plot_data_store.reset()
@@ -350,7 +350,7 @@ class SearchFile:
             yield count_and_block_tuple
         if self._filehandle is None:
             try:
-                self._filehandle = io.open(self.path, "rt", encoding="utf-8")
+                self._filehandle = open(self.path, "rt", encoding="utf-8")
             except Exception as e:
                 if config.report_readerrors:
                     logger.debug(f"Couldn't read file when looking for output: {self.path}, {e}")
@@ -379,7 +379,7 @@ class SearchFile:
                 logger.debug(f"No utf-8 lines were read from the file, skipping {self.path}")
             return  # No errors
         self._filehandle.close()
-        self._filehandle = io.open(self.path, "rt", encoding="utf-8", errors="ignore")
+        self._filehandle = open(self.path, "rt", encoding="utf-8", errors="ignore")
         self._iterator = file_line_block_iterator(self._filehandle)
         try:
             if self._blocks:
@@ -827,7 +827,7 @@ def exclude_file(sp, f: SearchFile):
 
 def data_sources_tofile(data_dir: Path):
     fn = f"multiqc_sources.{config.data_format_extensions[config.data_format]}"
-    with io.open(data_dir / fn, "w", encoding="utf-8") as f:
+    with open(data_dir / fn, "w", encoding="utf-8") as f:
         if config.data_format == "json":
             json.dump(data_sources, f, indent=4, ensure_ascii=False)
         elif config.data_format == "yaml":

--- a/multiqc/utils/mqc_colour.py
+++ b/multiqc/utils/mqc_colour.py
@@ -24,7 +24,7 @@ def cached_spectra_colour_scale(colours: Tuple[str]):
     return spectra.scale(list(colours))
 
 
-class mqc_colour_scale(object):
+class mqc_colour_scale:
     """Class to hold a colour scheme."""
 
     # ColorBrewer colours, taken from Chroma.js source code

--- a/multiqc/utils/util_functions.py
+++ b/multiqc/utils/util_functions.py
@@ -7,7 +7,6 @@ import math
 import shutil
 import sys
 import time
-from collections import OrderedDict, defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -76,7 +75,7 @@ def replace_defaultdicts(data: Any) -> Any:
     """
 
     def _replace(obj: Any) -> Any:
-        if isinstance(obj, (defaultdict, OrderedDict, dict)):
+        if isinstance(obj, dict):
             return {k: _replace(v) for k, v in obj.items()}
         elif isinstance(obj, list):
             return [_replace(v) for v in obj]


### PR DESCRIPTION
## Description

The custom code-quality check in `.github/workflows/code_checks.py` only recognised the legacy `super(MultiqcModule, self).__init__(` invocation, so any module written with the modern `super().__init__(` form silently skipped the `doi=` presence check. While fixing that, swept out a few other Python 2-era idioms still kicking around the codebase and added lint rules so they cannot creep back in.

### `super().__init__()` migration

- Rewrote 171 module files plus the 3 files in `multiqc/core/special_case_modules/` to use `super().__init__(...)` instead of `super(MultiqcModule, self).__init__(...)`. The two forms are equivalent on Python 3, but the modern form is DRY (no class name to keep in sync) and removes a real footgun in a codebase with 170+ identically-named `MultiqcModule` classes.
- `multiqc/modules/fastqe/fastqe.py` previously slipped past the `doi=` check because it already used the modern form. Added the standard `# doi="",  # No DOI` exemption comment used elsewhere.
- New lint entry in `must_be_avoided_after`: `("super(MultiqcModule", "class MultiqcModule", "Use 'super().__init__()' instead")` flags any future use of the legacy form in a module file.
- `docs/markdown/development/modules.md` and the two `.claude/skills/implementing-new-modules/` examples updated to teach the new style.

### Other Python 2-era cleanup

- `OrderedDict` → regular dict literals / comprehensions across `multiqc/report.py`, `multiqc/utils/util_functions.py`, `multiqc/modules/seqwho/seqwho.py`, and the picard submodules `AlignmentSummaryMetrics`, `CrosscheckFingerprints`, `QualityScoreDistributionMetrics`, `QualityYieldMetrics`, `RrbsSummaryMetrics`. Plain `dict` preserves insertion order on Python 3.7+.
- The two legacy compatibility shims (`plots/bargraph.py` and `plots/box.py`) that intentionally do `isinstance(_, OrderedDict)` to honour an old user-facing convention are left in place and explicitly exempted from the new lint.
- `isinstance(obj, (defaultdict, OrderedDict, dict))` simplified to `isinstance(obj, dict)` in `util_functions.py` — `defaultdict` and `OrderedDict` are already dict subclasses.
- `class mqc_colour_scale(object):` → `class mqc_colour_scale:` (the only remaining `(object)` base in the codebase).
- `io.open(...)` → builtin `open(...)` in `report.py`, `base_module.py`, `core/write_results.py`, `plots/linegraph.py`, `modules/fastqc/fastqc.py`. Dropped the now-unused `import io` from `linegraph.py` and `fastqc.py`.

### New global lint section

Added `must_be_avoided_globally` to `code_checks.py`. Each entry is `(forbidden_substring, suggestion, exempt_relpaths)` and scans all `multiqc/**/*.py`:

- `from __future__` — Python 3-only project, these are dead weight.
- `OrderedDict` — exempts `plots/bargraph.py` and `plots/box.py`.

### Verification

- `python .github/workflows/code_checks.py` → "No problems found!".
- `ruff check` clean on every touched file.
- `pytest tests/test_plots.py tests/test_natsort_files.py` → 55 passed, 4 skipped (these exercise bargraph/linegraph/box). The full module-run tests need the `test-data` repo, which isn't cloned in this environment.
- Detection sanity-check: temporarily reintroducing each forbidden pattern (legacy `super(MultiqcModule`, `from __future__ import annotations`, `OrderedDict`) causes the linter to fail with the expected suggestion; removing them returns it to clean.

https://claude.ai/code/session_01UVpu3JAJNzgcWASXa4wGG5