### PR TITLE
Fix custom_plot_config for deprecated camelCase aliases (e.g. yPlotBands)

### DIFF
--- a/docs/markdown/reports/customisation.md
+++ b/docs/markdown/reports/customisation.md
@@ -696,7 +696,7 @@ custom_plot_config:
   # Add a coloured band in the background to show what is a good result
   # Yes I know this doesn't make sense for this plot, it's just an example ;)
   bismark_mbias:
-    yPlotBands:
+    y_bands:
       - from: 0
         to: 40
         color: "#e6c3c3"

--- a/multiqc/plots/plot.py
+++ b/multiqc/plots/plot.py
@@ -266,6 +266,11 @@ class PConfig(ValidatedConfig):
         if self.id in config.custom_plot_config:
             for k, v in config.custom_plot_config[self.id].items():
                 if k in self.__class__.model_fields:
+                    field_info = self.__class__.model_fields[k]
+                    # Redirect deprecated aliases (e.g. yPlotBands -> y_bands) to their
+                    # modern field name so the corresponding parse_<field>() method runs.
+                    if isinstance(field_info.deprecated, str) and field_info.deprecated in self.__class__.model_fields:
+                        k = field_info.deprecated
                     # Check if there's a parse method for this field (e.g., parse_y_bands)
                     # to properly convert dictionaries to typed objects like LineBand
                     parse_method = getattr(self.__class__, f"parse_{k}", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "coloredlogs",        # logging in notebooks
     "spectra>=0.0.10",
     "pydantic>=2.7.0",
-    "typeguard",
+    "typeguard>=4",
     "tqdm",               # progress bar in notebooks
     "python-dotenv",
     "natsort",

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1291,3 +1291,43 @@ def test_linegraph_custom_plot_config_x_lines(reset):
     assert isinstance(plot.pconfig.x_lines[0], FlatLine)
     assert plot.pconfig.x_lines[0].value == 50
     assert plot.pconfig.x_lines[0].color == "#ff0000"
+
+
+def test_linegraph_custom_plot_config_deprecated_y_plot_bands(reset):
+    """
+    Test that the deprecated camelCase alias yPlotBands is still parsed correctly
+    when set via custom_plot_config — the docs example used to use this form, so
+    users on existing configs should not see pydantic serializer warnings.
+
+    Regression test for the deprecated-alias path in the fix for
+    https://github.com/MultiQC/MultiQC/issues/3457.
+    """
+    from multiqc.plots.plot import LineBand
+
+    plot_id = "test_linegraph_y_plot_bands_deprecated"
+
+    config.custom_plot_config = {
+        plot_id: {
+            "yPlotBands": [
+                {"from": 0, "to": 40, "color": "#e6c3c3"},
+                {"from": 40, "to": 80, "color": "#e6dcc3"},
+            ]
+        }
+    }
+
+    plot = _verify_rendered(
+        linegraph.plot(
+            {"Sample1": {0: 50, 1: 60, 2: 70}},
+            linegraph.LinePlotConfig(id=plot_id, title="Test: deprecated yPlotBands"),
+        )
+    )
+
+    # Deprecated alias should be redirected to the modern y_bands field and parsed
+    # into LineBand objects (not raw dicts).
+    assert plot.pconfig.y_bands is not None
+    assert len(plot.pconfig.y_bands) == 2
+    for band in plot.pconfig.y_bands:
+        assert isinstance(band, LineBand), f"Expected LineBand, got {type(band)}"
+    assert plot.pconfig.y_bands[0].from_ == 0
+    assert plot.pconfig.y_bands[0].to == 40
+    assert plot.pconfig.y_bands[0].color == "#e6c3c3"


### PR DESCRIPTION
## Summary

Follow-up to #3459 for the deprecated camelCase form of the bands/lines fields.

- `multiqc/plots/plot.py`: when applying `custom_plot_config`, if the user's key is a deprecated alias (e.g. `yPlotBands`), redirect to the modern field name (`y_bands`) before the `parse_<field>` dispatch runs. The convention in this codebase is `Field(..., deprecated="<modern_name>")`, so the redirect target falls out of `FieldInfo.deprecated`.
- `docs/markdown/reports/customisation.md`: example switched from `yPlotBands` to `y_bands` so users land on the non-deprecated form. The OP of #3457 copied the docs example verbatim and hit the bug.
- `tests/test_plots.py`: regression test `test_linegraph_custom_plot_config_deprecated_y_plot_bands` exercising the alias path alongside the existing `y_bands` test from #3459.
- `pyproject.toml`: pin `typeguard>=4`. `multiqc/validation.py:223` imports `TypeCheckError`, which only exists in typeguard 4+. With an old 2.x install the import silently falls through `except ImportError` and skips type checking entirely — masking validation bugs locally. Unrelated to the alias fix, but happened to surface while investigating, so bundling.

Before this change, the exact config from #3457:

```yaml
custom_plot_config:
  samtools-coverage:
    yPlotBands:
      - { from: 50, to: 60, color: "#c3e6c3" }
```

…still emitted a `Pydantic serializer warnings: Expected \`LineBand\` ...` and bands didn't render. After: no warning, `y_bands` is populated with parsed `LineBand` objects in `multiqc_data.json`.

Note: the OP's other ask — targeting a single tab in a multi-`data_labels` plot like `samtools-coverage` — is not addressed here; that needs a per-data-label config path and is a separate feature scope.

Fixes #3457 (the customisation/serializer half; per-tab targeting tracked separately).

## Test plan

- [x] `pytest tests/test_plots.py` — 54 passed, 4 skipped (the 2 axis-controlled-by-switches tests that fail on stale typeguard now pass with the pin)
- [x] Reproduced original issue with samtools coverage test data + the docs config form; verified no warning and `y_bands` populated in `multiqc_data.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)