### PR TITLE
Replace deprecated polars-lts-cpu dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "natsort",
     "tiktoken",
     "jsonschema",
-    "polars-lts-cpu",     # for parquet support. Using LTS version for compatibility with older architectures
+    "polars[rtcompat]",   # for parquet support with runtime CPU compatibility
     "pyarrow",            # for parquet support
 ]
 # Avoid cPython bug in 3.14.1 - https://github.com/python/cpython/issues/142214

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "natsort",
     "tiktoken",
     "jsonschema",
-    "polars[rtcompat]",   # for parquet support with runtime CPU compatibility
+    "polars[rtcompat]>=1.34.0",  # for parquet support with runtime CPU compatibility
     "pyarrow",            # for parquet support
 ]
 # Avoid cPython bug in 3.14.1 - https://github.com/python/cpython/issues/142214


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

## Summary

Replace the deprecated `polars-lts-cpu` runtime dependency with `polars[rtcompat]>=1.34.0` to keep runtime CPU compatibility without pulling in a second, conflicting Polars distribution. The lower bound is the first Polars release tested here that provides the `rtcompat` extra.

Fixes #3510

## Testing

- `python3 --version && python3 - <<'PY' ... PY`
- `python3 -m pip install --dry-run --ignore-installed -e . --break-system-packages`
- `python3 -m pip install --target /tmp/multiqc-polars-target-0da0 . --break-system-packages && PYTHONPATH=/tmp/multiqc-polars-target-0da0 python3 - <<'PY' ... PY`
- `PYTHONPATH=/tmp/multiqc-polars-target-0da0:/workspace python3 -m pytest tests/test_rerun.py -q`
- `python3 - <<'PY' ... PY`
- `python3 -m pip install --dry-run --ignore-installed -e . 'polars==1.30.0' --break-system-packages`
- `python3 -m pip install --dry-run --ignore-installed -e . 'polars==1.34.0' --break-system-packages`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7551b9ee-4982-4744-b953-407d5ccb0da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7551b9ee-4982-4744-b953-407d5ccb0da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

