### PR TITLE
Use Pyodide-compatible Polars dependency on Emscripten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,7 +177,6 @@ The parquet format is stable since 1.29, renaming the output file from `BETA-mul
 
 ### Infrastructure and packaging
 
-- Use the official Pyodide `polars` distribution for WASM installs ([#3310](https://github.com/MultiQC/MultiQC/issues/3310))
 - WASM workaround: if `write_parquet` not supported by polars, write a CSV file ([#3309](https://github.com/MultiQC/MultiQC/pull/3309))
 - Add Claude instructions ([#3301](https://github.com/MultiQC/MultiQC/pull/3301))
 - Add Claude review action ([#3299](https://github.com/MultiQC/MultiQC/pull/3299))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ The parquet format is stable since 1.29, renaming the output file from `BETA-mul
 
 ### Infrastructure and packaging
 
+- Use the official Pyodide `polars` distribution for WASM installs ([#3310](https://github.com/MultiQC/MultiQC/issues/3310))
 - WASM workaround: if `write_parquet` not supported by polars, write a CSV file ([#3309](https://github.com/MultiQC/MultiQC/pull/3309))
 - Add Claude instructions ([#3301](https://github.com/MultiQC/MultiQC/pull/3301))
 - Add Claude review action ([#3299](https://github.com/MultiQC/MultiQC/pull/3299))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
     "natsort",
     "tiktoken",
     "jsonschema",
-    "polars-lts-cpu",     # for parquet support. Using LTS version for compatibility with older architectures
+    # Use the official Pyodide package name on Emscripten; `polars-lts-cpu` is unavailable there.
+    "polars-lts-cpu; sys_platform != 'emscripten'",
+    "polars; sys_platform == 'emscripten'",
     "pyarrow",            # for parquet support
 ]
 # Avoid cPython bug in 3.14.1 - https://github.com/python/cpython/issues/142214

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "tiktoken",
     "jsonschema",
     # Use the official Pyodide package on Emscripten; Pyodide only publishes `polars`.
-    "polars; sys_platform == 'emscripten'",
-    "polars[rtcompat]>=1.34.0; sys_platform != 'emscripten'",  # for parquet support with runtime CPU compatibility
+    "polars>=1.34.0; sys_platform == 'emscripten'",
+    "polars[rtcompat]>=1.34.0; sys_platform != 'emscripten'",
     "pyarrow",            # for parquet support
 ]
 # Avoid cPython bug in 3.14.1 - https://github.com/python/cpython/issues/142214

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     "natsort",
     "tiktoken",
     "jsonschema",
-    # Use the official Pyodide package on Emscripten; Pyodide only publishes `polars`.
-    "polars; sys_platform == 'emscripten'",
+    # Pyodide currently publishes Polars 1.33.1; `rtcompat` is available from 1.34.0 for native installs.
+    "polars>=1.33.1; sys_platform == 'emscripten'",
     "polars[rtcompat]>=1.34.0; sys_platform != 'emscripten'",  # for parquet support with runtime CPU compatibility
     "pyarrow",            # for parquet support
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

## Summary
- Keep PR #3553's `polars[rtcompat]>=1.34.0` dependency for non-Emscripten installs.
- Use `polars>=1.33.1` on Emscripten because the current official Pyodide package index publishes `polars 1.33.1`, while the `rtcompat` extra starts at `1.34.0` for native installs.

## Testing
- `python3 - <<'PY' ... PY` dependency marker check: Linux selects `polars[rtcompat]>=1.34.0`; Emscripten selects `polars>=1.33.1`; both select `pyarrow`.
- `python3 - <<'PY' ... PY` Pyodide package availability check: found `polars-1.33.1-cp313-cp313-pyodide_2025_0_wasm32.whl`.
- `python3 -m pip install --dry-run --no-deps .` completed successfully.
- `python3 -m pip wheel --no-deps -w /tmp/multiqc-wheel-test .` completed successfully and wheel metadata contains the expected `Requires-Dist` markers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0e2e41b-5d25-48a6-b85d-4ae938b8336f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0e2e41b-5d25-48a6-b85d-4ae938b8336f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

