### PR TITLE
Bcftools: Fix stats zero-depth plot crash

### DIFF
--- a/multiqc/modules/bcftools/stats.py
+++ b/multiqc/modules/bcftools/stats.py
@@ -421,6 +421,7 @@ def parse_bcftools_stats(module: BaseMultiqcModule) -> int:
                     ysuffix="X",
                     cpswitch_counts_label="Sequencing depth",
                     cpswitch=False,
+                    hide_zero_cats=False,
                     data_labels=list(bcftools_stats_sample_depth),
                 ),
             ),

--- a/tests/test_modules_run.py
+++ b/tests/test_modules_run.py
@@ -51,11 +51,21 @@ def test_all_modules(module_id, entry_point, data_dir):
         assert len(report.general_stats_data) > 0 or len(m.sections) > 0
 
 
-def test_bcftools_stats_zero_depth_samples(data_dir):
+def test_bcftools_stats_zero_depth_samples(tmp_path):
     """All-zero average depth values should still render a sequencing-depth plot."""
-    mod_dir = data_dir / "modules" / "bcftools" / "issue_3488"
+    stats_file = tmp_path / "rotavirus.stats.txt"
+    stats_file.write_text(
+        """# This file was produced by bcftools stats (1.19+htslib-1.19.1) and can be plotted using plot-vcfstats.
+ID\t0\trotavirus.vcf.gz
+SN\t0\tnumber of records:\t2
+SN\t0\tnumber of SNPs:\t2
+ST\t0\tA>C\t2
+PSC\t0\tS1\t0\t0\t1\t1\t1\t0\t0.0\t0\t0\t0\t0
+PSC\t0\tS2\t0\t0\t1\t1\t1\t0\t0.0\t0\t0\t0\t0
+"""
+    )
 
-    report.analysis_files = [mod_dir]
+    report.analysis_files = [stats_file]
     report.search_files(["bcftools"])
 
     from multiqc.modules.bcftools.bcftools import MultiqcModule

--- a/tests/test_modules_run.py
+++ b/tests/test_modules_run.py
@@ -51,6 +51,21 @@ def test_all_modules(module_id, entry_point, data_dir):
         assert len(report.general_stats_data) > 0 or len(m.sections) > 0
 
 
+def test_bcftools_stats_zero_depth_samples(data_dir):
+    """All-zero average depth values should still render a sequencing-depth plot."""
+    mod_dir = data_dir / "modules" / "bcftools" / "issue_3488"
+
+    report.analysis_files = [mod_dir]
+    report.search_files(["bcftools"])
+
+    from multiqc.modules.bcftools.bcftools import MultiqcModule
+
+    module = MultiqcModule()
+
+    assert "bcftools-stats_sequencing_depth" in {section.id for section in module.sections}
+    assert "bcftools-stats-sequencing-depth" in report.plot_by_id
+
+
 @pytest.mark.parametrize("module_id,entry_point", modules)
 def test_ignore_samples(module_id, entry_point, data_dir):
     """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

Fixes MultiQC/MultiQC#3488 by keeping the bcftools stats sequencing-depth bar category visible when every per-sample average depth is `0.0`. The default bargraph behavior hides all-zero categories, which left this plot with no datasets and raised `ValueError("No datasets to plot")`.

Adds a self-contained regression test that creates a minimal bcftools stats file with all-zero average depths and asserts that the sequencing-depth section and plot are created.

Verification:
- `pytest tests/test_modules_run.py::test_bcftools_stats_zero_depth_samples -q`
- `python3 -m multiqc /tmp/multiqc-3488/rotavirus.stats.txt --module bcftools --outdir /tmp/multiqc-3488/out-fixed --force --strict -v`
- `pytest tests/test_modules_run.py::test_all_modules -q -k bcftools`
- `ruff check multiqc/modules/bcftools/stats.py tests/test_modules_run.py`
- `git diff --check`

- [x] Code is tested and works locally (including with `--strict` flag)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b40344a3-0b9a-4e2e-9cfa-ca200844f1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b40344a3-0b9a-4e2e-9cfa-ca200844f1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

