### PR TITLE
Fix env var config overwrite: booleans/ints/floats were stored as strings

### DIFF
--- a/multiqc/config.py
+++ b/multiqc/config.py
@@ -489,15 +489,14 @@ def _env_vars_config() -> Dict:
                 except ValueError:
                     logger.warning(f"Could not parse a float value from the environment variable ${k}={v}")
                     continue
-            elif globals()[conf_key] is None:
-                pass
-            elif not isinstance(globals()[conf_key], str):
+            elif globals()[conf_key] is None or isinstance(globals()[conf_key], str):
+                env_config[conf_key] = v
+            else:
                 logger.warning(
                     f"Can only set scalar config entries (str, int, float, bool) with environment variable, "
                     f"but config.{conf_key} expects a type '{type(globals()[conf_key]).__name__}'. Ignoring ${k}"
                 )
                 continue
-            env_config[conf_key] = v
             logger.debug(f"Setting config.{conf_key} from the environment variable ${k}")
     return env_config
 

--- a/multiqc/core/update_config.py
+++ b/multiqc/core/update_config.py
@@ -138,7 +138,8 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None, log_to_file=Fal
         config.report_comment = cfg.report_comment
     if cfg.prepend_dirs is not None:
         config.prepend_dirs = cfg.prepend_dirs
-        logger.info("Prepending directory to sample names")
+        if cfg.prepend_dirs:
+            logger.info("Prepending directory to sample names")
     if cfg.dirs_depth is not None:
         config.prepend_dirs = True
         config.prepend_dirs_depth = cfg.dirs_depth
@@ -183,7 +184,8 @@ def update_config(*analysis_dir, cfg: Optional[ClConfig] = None, log_to_file=Fal
         config.megaqc_upload = not cfg.no_megaqc_upload
     if cfg.fn_clean_sample_names is not None:
         config.fn_clean_sample_names = cfg.fn_clean_sample_names
-        logger.info("Not cleaning sample names")
+        if not cfg.fn_clean_sample_names:
+            logger.info("Not cleaning sample names")
     if cfg.replace_names:
         config.load_replace_names(Path(cfg.replace_names))
     if cfg.sample_names:

--- a/tests/test_env_vars_config.py
+++ b/tests/test_env_vars_config.py
@@ -1,0 +1,144 @@
+"""Tests for MULTIQC_* environment variable config handling."""
+
+import os
+
+import pytest
+
+from multiqc import config
+
+
+class TestEnvVarsConfig:
+    """Tests for _env_vars_config() parsing MULTIQC_* environment variables."""
+
+    def test_bool_true(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "true")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is True
+        assert isinstance(result["force"], bool)
+
+    def test_bool_false(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "false")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is False
+        assert isinstance(result["force"], bool)
+
+    def test_bool_yes_no(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "yes")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is True
+
+        monkeypatch.setenv("MULTIQC_FORCE", "no")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is False
+
+    def test_bool_numeric(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "1")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is True
+
+        monkeypatch.setenv("MULTIQC_FORCE", "0")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["force"] is False
+
+    def test_make_data_dir_false(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_MAKE_DATA_DIR", "false")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["make_data_dir"] is False
+        assert isinstance(result["make_data_dir"], bool)
+
+    def test_make_report_false(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_MAKE_REPORT", "false")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["make_report"] is False
+        assert isinstance(result["make_report"], bool)
+
+    def test_int_value(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_PLOTS_FLAT_NUMSERIES", "500")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["plots_flat_numseries"] == 500
+        assert isinstance(result["plots_flat_numseries"], int)
+
+    def test_float_value(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_READ_COUNT_MULTIPLIER", "0.001")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["read_count_multiplier"] == 0.001
+        assert isinstance(result["read_count_multiplier"], float)
+
+    def test_string_value(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_DATA_FORMAT", "json")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["data_format"] == "json"
+        assert isinstance(result["data_format"], str)
+
+    def test_none_typed_value(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_TITLE", "My Report")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert result["title"] == "My Report"
+        assert isinstance(result["title"], str)
+
+    def test_empty_env_var_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "  ")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "force" not in result
+
+    def test_invalid_bool_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FORCE", "not_a_bool")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "force" not in result
+
+    def test_invalid_int_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_PLOTS_FLAT_NUMSERIES", "not_a_number")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "plots_flat_numseries" not in result
+
+    def test_unknown_key_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_NONEXISTENT_KEY", "value")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "nonexistent_key" not in result
+
+    def test_reserved_name_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_CONFIG_PATH", "/some/path")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "config_path" not in result
+
+    def test_complex_type_ignored(self, monkeypatch):
+        monkeypatch.setenv("MULTIQC_FN_IGNORE_DIRS", "some_dir")
+        config.load_defaults()
+        result = config._env_vars_config()
+        assert "fn_ignore_dirs" not in result
+
+    def test_bool_applied_to_config(self, monkeypatch):
+        """Verify that parsed boolean env vars are correctly applied to config globals."""
+        monkeypatch.setenv("MULTIQC_MAKE_DATA_DIR", "false")
+        monkeypatch.setenv("MULTIQC_MAKE_REPORT", "false")
+        config.load_defaults()
+        env_config = config._env_vars_config()
+        config._add_config(env_config)
+        assert config.make_data_dir is False
+        assert config.make_report is False
+
+    def test_int_applied_to_config(self, monkeypatch):
+        """Verify that parsed int env vars are correctly applied to config globals."""
+        monkeypatch.setenv("MULTIQC_PLOTS_FLAT_NUMSERIES", "999")
+        config.load_defaults()
+        env_config = config._env_vars_config()
+        config._add_config(env_config)
+        assert config.plots_flat_numseries == 999
+        assert isinstance(config.plots_flat_numseries, int)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

### Bug: `_env_vars_config()` overwrites parsed values with raw strings

The `_env_vars_config()` function in `multiqc/config.py` correctly parsed `MULTIQC_*` environment variables to their proper types (bool via `strtobool`, int via `int()`, float via `float()`), but then unconditionally overwrote the parsed value with the raw string on the final `env_config[conf_key] = v` line.

**Before (broken):**
```
$ MULTIQC_MAKE_DATA_DIR=false multiqc . -v
New config: {'make_data_dir': 'false', 'make_report': 'false'}
```
The string `"false"` is truthy in Python, so boolean env vars that should _disable_ features did not work. Similarly, integer config values like `MULTIQC_PLOTS_FLAT_NUMSERIES=500` were stored as the string `"500"` instead of the int `500`.

**After (fixed):**
```
$ MULTIQC_MAKE_DATA_DIR=false multiqc . -v
New config: {'make_data_dir': False, 'make_report': False}
```

### Fix: restructure the if/elif chain

The `env_config[conf_key] = v` line (which stores the raw string) now only executes for string-typed and `None`-typed config values, where storing the raw string is the correct behavior. Bool/int/float branches keep their parsed values via `continue` after assignment.

### Also fixed: misleading log messages in `update_config`

- "Prepending directory to sample names" was logged whenever `cfg.prepend_dirs is not None`, even when `prepend_dirs=False`
- "Not cleaning sample names" was logged whenever `cfg.fn_clean_sample_names is not None`, even when `fn_clean_sample_names=True`

Both messages now only log when the value actually indicates the described behavior.

### Regarding #3463

While this fix addresses a real bug in how `MULTIQC_*` environment variables are handled, I was unable to fully reproduce the exact scenario described in the issue (Python 3.13 + BioConda producing `Data: None` with a bare `multiqc .` command). The issue may require specific conda environment variables or config files that the reporter was unaware of. However, this env var handling bug is the most likely root cause if the user's conda environment was setting `MULTIQC_MAKE_DATA_DIR` or `MULTIQC_MAKE_REPORT` env vars, or if any other `MULTIQC_*` boolean env vars were being set by conda activation scripts.

### Tests

Added `tests/test_env_vars_config.py` with 18 tests covering:
- Boolean parsing (true/false/yes/no/1/0)
- Integer and float parsing
- String and None-typed config values
- Invalid values being ignored
- Unknown keys being ignored
- Reserved names being skipped
- End-to-end application of parsed values to config globals

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b8fcab3-d012-4293-97a8-8a7e5d9b26e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b8fcab3-d012-4293-97a8-8a7e5d9b26e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

