### PR TITLE
Fix grouped sample totals and hierarchy lost during parquet merging

### DIFF
--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -26,6 +26,8 @@ from multiqc.plots.table_object import (
     ColumnMeta,
     DataTable,
     ExtValueT,
+    GroupT,
+    InputRow,
     SectionT,
     TableConfig,
     ValueT,
@@ -213,11 +215,7 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         show_table_by_default = df.select("show_table_by_default").row(0)[0]
 
-        # Prepare data structure for DataTable creation.
-        # Use GroupT (which accepts List[InputRow]) so multi-row groups survive the round-trip.
-        from multiqc.plots.table_object import InputRow as _InputRow
-
-        data_dict: Dict[SectionKey, Dict[str, Any]] = {}
+        data_dict: Dict[SectionKey, Dict[str, GroupT]] = {}
         headers_dict: Dict[SectionKey, Dict[ColumnKey, ColumnDict]] = {}
 
         # Extract all columns as lists for efficient access (avoiding repeated iter_rows)
@@ -261,10 +259,10 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         for section_key, group_map in section_group_row_indices.items():
             section_headers: Dict[ColumnKey, ColumnDict] = {}
-            section_data: Dict[str, Any] = {}
+            section_data: Dict[str, GroupT] = {}
 
             for group_sample, row_sample_map in group_map.items():
-                input_rows: List[_InputRow] = []
+                input_rows: List[InputRow] = []
                 for row_sample, indices in row_sample_map.items():
                     if has_section_order and all_section_order is not None:
                         indices = sorted(indices, key=lambda idx: all_section_order[idx])
@@ -277,11 +275,11 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
                             section_headers[metric_name] = json.loads(all_column_meta[idx])
 
                     if val_by_metric:
-                        input_rows.append(_InputRow(sample=SampleName(str(row_sample)), data=val_by_metric))
+                        input_rows.append(InputRow(sample=SampleName(str(row_sample)), data=val_by_metric))
 
                 if input_rows:
-                    if len(input_rows) == 1 and str(input_rows[0].sample) == group_sample:
-                        section_data[group_sample] = input_rows[0].data
+                    if len(input_rows) == 1:
+                        section_data[group_sample] = input_rows[0]
                     else:
                         section_data[group_sample] = input_rows
 
@@ -291,7 +289,7 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         # Create DataTable if we have data
         dt = table_object.DataTable.create(
-            data=cast(Dict[SectionKey, SectionT], data_dict),
+            data=data_dict,  # type: ignore[arg-type]
             table_id=pconf.id,
             table_anchor=table_anchor,
             pconfig=pconf.model_copy(),

--- a/multiqc/plots/violin.py
+++ b/multiqc/plots/violin.py
@@ -80,6 +80,7 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
                             "section_key": str(section_key),
                             "section_order": section_order,  # Store original index for ordering
                             "sample": str(sample_name),
+                            "row_sample": str(row.sample),
                             "metric": str(metric_name),
                             "val_raw": float(cell.raw) if isinstance(cell.raw, (int, float)) else float("nan"),
                             "val_raw_type": type(cell.raw).__name__,  # Store type name
@@ -212,13 +213,18 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
 
         show_table_by_default = df.select("show_table_by_default").row(0)[0]
 
-        # Prepare data structure for DataTable creation
-        data_dict: Dict[SectionKey, Dict[SampleName, Dict[ColumnKeyT, Optional[ExtValueT]]]] = {}
+        # Prepare data structure for DataTable creation.
+        # Use GroupT (which accepts List[InputRow]) so multi-row groups survive the round-trip.
+        from multiqc.plots.table_object import InputRow as _InputRow
+
+        data_dict: Dict[SectionKey, Dict[str, Any]] = {}
         headers_dict: Dict[SectionKey, Dict[ColumnKey, ColumnDict]] = {}
 
         # Extract all columns as lists for efficient access (avoiding repeated iter_rows)
         all_section_keys = df.get_column("section_key").to_list()
         all_samples = df.get_column("sample").to_list()
+        has_row_sample = "row_sample" in df.columns
+        all_row_samples = df.get_column("row_sample").to_list() if has_row_sample else all_samples
         all_metrics = df.get_column("metric").to_list()
         all_val_raw = df.get_column("val_raw").to_list()
         all_val_raw_type = df.get_column("val_raw_type").to_list()
@@ -229,61 +235,58 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
         has_section_order = "section_order" in df.columns
         all_section_order = df.get_column("section_order").to_list() if has_section_order else None
 
-        # Build index for grouping: section_key -> sample -> list of row indices
-        section_sample_indices: Dict[str, Dict[str, List[int]]] = {}
-        for i, (section_key, sample) in enumerate(zip(all_section_keys, all_samples)):
-            if section_key not in section_sample_indices:
-                section_sample_indices[section_key] = {}
-            if sample not in section_sample_indices[section_key]:
-                section_sample_indices[section_key][sample] = []
-            section_sample_indices[section_key][sample].append(i)
+        # Build index: section_key -> group_sample -> row_sample -> [indices]
+        section_group_row_indices: Dict[str, Dict[str, Dict[str, List[int]]]] = {}
+        for i, (section_key, group_sample, row_sample) in enumerate(
+            zip(all_section_keys, all_samples, all_row_samples)
+        ):
+            section_group_row_indices.setdefault(section_key, {}).setdefault(group_sample, {}).setdefault(
+                row_sample, []
+            ).append(i)
 
-        # Process each section
-        for section_key, sample_indices in section_sample_indices.items():
-            val_by_sample_by_metric: Dict[SampleName, Dict[ColumnKeyT, Optional[ExtValueT]]] = {}
+        def _parse_cell(idx: int) -> Cell:
+            val_raw: Any = all_val_raw[idx]
+            if not math.isnan(val_raw):
+                if all_val_raw_type[idx] == "int":
+                    val_raw = int(val_raw)
+                elif all_val_raw_type[idx] == "bool":
+                    val_raw = bool(val_raw)
+            val_mod: Any = all_val_mod[idx]
+            if not math.isnan(val_mod):
+                if all_val_mod_type[idx] == "int":
+                    val_mod = int(val_mod)
+                elif all_val_mod_type[idx] == "bool":
+                    val_mod = bool(val_mod)
+            return Cell(raw=val_raw, mod=val_mod, fmt=all_val_fmt[idx])
+
+        for section_key, group_map in section_group_row_indices.items():
             section_headers: Dict[ColumnKey, ColumnDict] = {}
+            section_data: Dict[str, Any] = {}
 
-            for sample_name, row_indices in sample_indices.items():
-                # Sort indices by section_order if available
-                if has_section_order and all_section_order is not None:
-                    row_indices = sorted(row_indices, key=lambda idx: all_section_order[idx])
+            for group_sample, row_sample_map in group_map.items():
+                input_rows: List[_InputRow] = []
+                for row_sample, indices in row_sample_map.items():
+                    if has_section_order and all_section_order is not None:
+                        indices = sorted(indices, key=lambda idx: all_section_order[idx])
 
-                val_by_metric: Dict[ColumnKeyT, Optional[ExtValueT]] = {}
+                    val_by_metric: Dict[ColumnKeyT, Optional[ExtValueT]] = {}
+                    for idx in indices:
+                        metric_name = all_metrics[idx]
+                        val_by_metric[ColumnKey(str(metric_name))] = _parse_cell(idx)
+                        if metric_name not in section_headers:
+                            section_headers[metric_name] = json.loads(all_column_meta[idx])
 
-                for idx in row_indices:
-                    metric_name = all_metrics[idx]
+                    if val_by_metric:
+                        input_rows.append(_InputRow(sample=SampleName(str(row_sample)), data=val_by_metric))
 
-                    # Convert string values back to their original types
-                    val_raw: Any = all_val_raw[idx]
-                    if not math.isnan(val_raw):
-                        if all_val_raw_type[idx] == "int":
-                            val_raw = int(val_raw)
-                        elif all_val_raw_type[idx] == "bool":
-                            val_raw = bool(val_raw)
-                    val_mod: Any = all_val_mod[idx]
-                    if not math.isnan(val_mod):
-                        if all_val_mod_type[idx] == "int":
-                            val_mod = int(val_mod)
-                        elif all_val_mod_type[idx] == "bool":
-                            val_mod = bool(val_mod)
-                    val_by_metric[ColumnKey(str(metric_name))] = Cell(
-                        raw=val_raw,
-                        mod=val_mod,
-                        fmt=all_val_fmt[idx],
-                    )
+                if input_rows:
+                    if len(input_rows) == 1 and str(input_rows[0].sample) == group_sample:
+                        section_data[group_sample] = input_rows[0].data
+                    else:
+                        section_data[group_sample] = input_rows
 
-                    # Create header if it doesn't exist
-                    if metric_name not in section_headers:
-                        # Parse column metadata from JSON
-                        section_headers[metric_name] = json.loads(all_column_meta[idx])
-
-                # Add sample data to section
-                if val_by_metric:
-                    val_by_sample_by_metric[SampleName(str(sample_name))] = val_by_metric
-
-            # Add section data and headers to dictionary
-            if val_by_sample_by_metric:
-                data_dict[SectionKey(str(section_key))] = val_by_sample_by_metric
+            if section_data:
+                data_dict[SectionKey(str(section_key))] = section_data
                 headers_dict[SectionKey(str(section_key))] = section_headers
 
         # Create DataTable if we have data
@@ -399,9 +402,9 @@ class ViolinPlotInputData(NormalizedPlotInputData[TableConfig]):
             metric_order_map = pl.Series("__metric_order", [metric_order.get(m, 99999) for m in metric_list])
             merged_df = merged_df.with_columns(metric_order_map)
 
-            # Sort by creation_date (newest last), then use unique with keep="last" to deduplicate
-            # This is O(n log n) instead of O(n²) from the previous implementation
-            key_columns = ["dt_anchor", "section_key", "sample", "metric"]
+            # Sort by creation_date (newest last), then use unique with keep="last" to deduplicate.
+            # Include row_sample so that aggregate and member rows within a group are not collapsed.
+            key_columns = ["dt_anchor", "section_key", "sample", "row_sample", "metric"]
             merged_df = merged_df.sort("creation_date").unique(
                 subset=key_columns,
                 keep="last",

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -5,7 +5,11 @@ from datetime import datetime, timedelta
 import polars as pl
 
 import multiqc
+from multiqc.core import tmp_dir
+from multiqc.core.plot_data_store import flush_to_parquet
+from multiqc.core.special_case_modules.load_multiqc_data import create_plot_input_data_only
 from multiqc.core.update_config import ClConfig
+from multiqc.plots import table_object
 from multiqc.plots.bargraph import BarPlotConfig, BarPlotInputData, CatConf
 from multiqc.plots.linegraph import LinePlotConfig, LinePlotNormalizedInputData, Series
 from multiqc.plots.plot import PlotType, plot_anchor
@@ -285,8 +289,6 @@ def _make_grouped_violin_data() -> ViolinPlotInputData:
     anchor = plot_anchor(pconfig)
     table_anchor = Anchor(f"{anchor}_table")
 
-    from multiqc.plots import table_object
-
     grouped_data: dict = {
         SectionKey("section1"): {
             SampleGroup("SampleA"): [
@@ -377,8 +379,6 @@ def test_grouped_samples_survive_merge():
     anchor = plot_anchor(pconfig)
     table_anchor = Anchor(f"{anchor}_table")
 
-    from multiqc.plots import table_object
-
     grouped_data2: dict = {
         SectionKey("section1"): {
             SampleGroup("SampleC"): [
@@ -435,20 +435,17 @@ def test_grouped_samples_parquet_roundtrip(tmp_path):
     original = _make_grouped_violin_data()
     original.save_to_parquet()
 
-    from multiqc.core.plot_data_store import flush_to_parquet
-    from multiqc.core import tmp_dir
-
     flush_to_parquet()
     parquet_path = tmp_dir.parquet_file()
     assert parquet_path.exists()
 
     df = pl.read_parquet(parquet_path)
-    plot_input_rows = df.filter(pl.col("type") == "plot_input")
-    assert plot_input_rows.height >= 1
+    plot_input_rows = df.filter(
+        (pl.col("type") == "plot_input") & (pl.col("anchor") == str(original.anchor))
+    )
+    assert plot_input_rows.height == 1
 
     plot_input_json = json.loads(plot_input_rows.get_column("plot_input_data")[0])
-    from multiqc.core.special_case_modules.load_multiqc_data import create_plot_input_data_only
-
     loaded = create_plot_input_data_only(plot_input_json)
     assert isinstance(loaded, ViolinPlotInputData)
 

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -9,7 +9,9 @@ from multiqc.core.update_config import ClConfig
 from multiqc.plots.bargraph import BarPlotConfig, BarPlotInputData, CatConf
 from multiqc.plots.linegraph import LinePlotConfig, LinePlotNormalizedInputData, Series
 from multiqc.plots.plot import PlotType, plot_anchor
-from multiqc.types import SampleName
+from multiqc.plots.table_object import InputRow, TableConfig
+from multiqc.plots.violin import ViolinPlotInputData
+from multiqc.types import Anchor, ColumnKey, SampleGroup, SampleName, SectionKey
 
 
 def test_rerun_parquet(data_dir, tmp_path):
@@ -272,3 +274,187 @@ def test_merge_bargraph():
     sample3_cat3 = merged_df.filter((pl.col("sample") == "Sample3") & (pl.col("category") == "Cat3"))
     assert sample3_cat3.height == 1
     assert float(sample3_cat3.select("bar_value").item()) == 45.0
+
+
+def _make_grouped_violin_data() -> ViolinPlotInputData:
+    """
+    Build a ViolinPlotInputData with a multi-row group (aggregate + members),
+    simulating what table_sample_merge produces.
+    """
+    pconfig = TableConfig(id="test_grouped", title="Test Grouped Table")
+    anchor = plot_anchor(pconfig)
+    table_anchor = Anchor(f"{anchor}_table")
+
+    from multiqc.plots import table_object
+
+    grouped_data: dict = {
+        SectionKey("section1"): {
+            SampleGroup("SampleA"): [
+                InputRow(sample=SampleName("SampleA"), data={"reads": 20000, "quality": 35.0}),
+                InputRow(sample=SampleName("SampleA R1"), data={"reads": 10000, "quality": 34.0}),
+                InputRow(sample=SampleName("SampleA R2"), data={"reads": 10000, "quality": 36.0}),
+            ],
+            SampleGroup("SampleB"): [
+                InputRow(sample=SampleName("SampleB"), data={"reads": 15000}),
+            ],
+        }
+    }
+    headers: dict = {
+        SectionKey("section1"): {
+            ColumnKey("reads"): {"title": "Total Reads"},
+            ColumnKey("quality"): {"title": "Quality"},
+        }
+    }
+
+    dt = table_object.DataTable.create(
+        data=grouped_data,
+        table_id=pconfig.id,
+        table_anchor=table_anchor,
+        pconfig=pconfig.model_copy(),
+        headers=headers,
+    )
+
+    return ViolinPlotInputData(
+        dt=dt,
+        plot_type=PlotType.VIOLIN,
+        pconfig=pconfig,
+        anchor=anchor,
+        show_table_by_default=True,
+        creation_date=datetime.now(),
+    )
+
+
+def test_grouped_samples_survive_df_roundtrip():
+    """
+    Verify that sample groups (aggregate row + member rows) survive
+    serialization to DataFrame and deserialization back.
+    """
+    original = _make_grouped_violin_data()
+
+    section = list(original.dt.section_by_id.values())[0]
+    assert SampleGroup("SampleA") in section.rows_by_sgroup
+    assert len(section.rows_by_sgroup[SampleGroup("SampleA")]) == 3
+    assert section.rows_by_sgroup[SampleGroup("SampleA")][0].sample == SampleName("SampleA")
+    assert section.rows_by_sgroup[SampleGroup("SampleA")][0].data[ColumnKey("reads")].raw == 20000
+
+    df = original.to_df()
+
+    assert "row_sample" in df.columns
+    group_a_rows = df.filter(pl.col("sample") == "SampleA")
+    row_samples = sorted(group_a_rows.get_column("row_sample").unique().to_list())
+    assert row_samples == ["SampleA", "SampleA R1", "SampleA R2"]
+
+    reconstructed = ViolinPlotInputData.from_df(df, original.pconfig, original.anchor)
+    section_r = list(reconstructed.dt.section_by_id.values())[0]
+
+    assert SampleGroup("SampleA") in section_r.rows_by_sgroup
+    group_a = section_r.rows_by_sgroup[SampleGroup("SampleA")]
+    assert len(group_a) == 3
+
+    row_sample_names = [str(r.sample) for r in group_a]
+    assert "SampleA" in row_sample_names
+    assert "SampleA R1" in row_sample_names
+    assert "SampleA R2" in row_sample_names
+
+    agg_row = next(r for r in group_a if str(r.sample) == "SampleA")
+    assert agg_row.data[ColumnKey("reads")].raw == 20000
+
+    r1_row = next(r for r in group_a if str(r.sample) == "SampleA R1")
+    assert r1_row.data[ColumnKey("reads")].raw == 10000
+
+    assert SampleGroup("SampleB") in section_r.rows_by_sgroup
+    assert len(section_r.rows_by_sgroup[SampleGroup("SampleB")]) == 1
+
+
+def test_grouped_samples_survive_merge():
+    """
+    Verify that merging two ViolinPlotInputData objects with grouped samples
+    preserves the group hierarchy and resolved values.
+    """
+    data1 = _make_grouped_violin_data()
+
+    pconfig = TableConfig(id="test_grouped", title="Test Grouped Table")
+    anchor = plot_anchor(pconfig)
+    table_anchor = Anchor(f"{anchor}_table")
+
+    from multiqc.plots import table_object
+
+    grouped_data2: dict = {
+        SectionKey("section1"): {
+            SampleGroup("SampleC"): [
+                InputRow(sample=SampleName("SampleC"), data={"reads": 30000, "quality": 38.0}),
+                InputRow(sample=SampleName("SampleC R1"), data={"reads": 15000, "quality": 37.0}),
+                InputRow(sample=SampleName("SampleC R2"), data={"reads": 15000, "quality": 39.0}),
+            ],
+        }
+    }
+    headers: dict = {
+        SectionKey("section1"): {
+            ColumnKey("reads"): {"title": "Total Reads"},
+            ColumnKey("quality"): {"title": "Quality"},
+        }
+    }
+    dt2 = table_object.DataTable.create(
+        data=grouped_data2,
+        table_id=pconfig.id,
+        table_anchor=table_anchor,
+        pconfig=pconfig.model_copy(),
+        headers=headers,
+    )
+    data2 = ViolinPlotInputData(
+        dt=dt2,
+        plot_type=PlotType.VIOLIN,
+        pconfig=pconfig,
+        anchor=anchor,
+        show_table_by_default=True,
+        creation_date=datetime.now() + timedelta(seconds=1),
+    )
+
+    merged = ViolinPlotInputData.merge(data1, data2)
+
+    section = list(merged.dt.section_by_id.values())[0]
+
+    assert SampleGroup("SampleA") in section.rows_by_sgroup
+    group_a = section.rows_by_sgroup[SampleGroup("SampleA")]
+    assert len(group_a) == 3
+    agg_a = next(r for r in group_a if str(r.sample) == "SampleA")
+    assert agg_a.data[ColumnKey("reads")].raw == 20000
+
+    assert SampleGroup("SampleC") in section.rows_by_sgroup
+    group_c = section.rows_by_sgroup[SampleGroup("SampleC")]
+    assert len(group_c) == 3
+    agg_c = next(r for r in group_c if str(r.sample) == "SampleC")
+    assert agg_c.data[ColumnKey("reads")].raw == 30000
+
+
+def test_grouped_samples_parquet_roundtrip(tmp_path):
+    """
+    End-to-end test: write grouped sample data to parquet, load it back,
+    and verify group hierarchy and resolved values are preserved.
+    """
+    original = _make_grouped_violin_data()
+    original.save_to_parquet()
+
+    from multiqc.core.plot_data_store import flush_to_parquet
+    from multiqc.core import tmp_dir
+
+    flush_to_parquet()
+    parquet_path = tmp_dir.parquet_file()
+    assert parquet_path.exists()
+
+    df = pl.read_parquet(parquet_path)
+    plot_input_rows = df.filter(pl.col("type") == "plot_input")
+    assert plot_input_rows.height >= 1
+
+    plot_input_json = json.loads(plot_input_rows.get_column("plot_input_data")[0])
+    from multiqc.core.special_case_modules.load_multiqc_data import create_plot_input_data_only
+
+    loaded = create_plot_input_data_only(plot_input_json)
+    assert isinstance(loaded, ViolinPlotInputData)
+
+    section = list(loaded.dt.section_by_id.values())[0]
+    assert SampleGroup("SampleA") in section.rows_by_sgroup
+    group_a = section.rows_by_sgroup[SampleGroup("SampleA")]
+    assert len(group_a) == 3
+    agg = next(r for r in group_a if str(r.sample) == "SampleA")
+    assert agg.data[ColumnKey("reads")].raw == 20000

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -440,9 +440,7 @@ def test_grouped_samples_parquet_roundtrip(tmp_path):
     assert parquet_path.exists()
 
     df = pl.read_parquet(parquet_path)
-    plot_input_rows = df.filter(
-        (pl.col("type") == "plot_input") & (pl.col("anchor") == str(original.anchor))
-    )
+    plot_input_rows = df.filter((pl.col("type") == "plot_input") & (pl.col("anchor") == str(original.anchor)))
     assert plot_input_rows.height == 1
 
     plot_input_json = json.loads(plot_input_rows.get_column("plot_input_data")[0])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

## Description

Fixes #3520

When merging reports via Parquet files, sample groups created by `table_sample_merge` (e.g. R1/R2 pairs with resolved totals) were losing both their aggregated values and their expandable group hierarchy.

### Root cause

`ViolinPlotInputData.to_df()` stored only the group key in the `sample` column for every row in a group. This caused two problems:

1. **Aggregate values lost**: During `merge()`, the dedup key `["dt_anchor", "section_key", "sample", "metric"]` treated aggregate and member rows as duplicates (same `sample`), so only the last one survived. The resolved total (e.g. 20,000 summed reads) was overwritten by an individual component (e.g. 10,000).

2. **Hierarchy lost**: `from_df()` reconstructed a flat `Dict[SampleName, Dict[...]]` per section, which `DataTable.create()` turned into single-row groups. The multi-row expandable structure was destroyed.

### Fix

Three targeted changes in `multiqc/plots/violin.py`:

- **`to_df()`**: Added a `row_sample` column that stores each `Row`'s individual sample name, preserving the distinction between aggregate and member rows within a group.

- **`from_df()`**: When `row_sample` is present, groups rows by the group-level `sample` column, then builds separate `InputRow` objects per distinct `row_sample`. Multi-row groups are passed as `List[InputRow]` to `DataTable.create()`, which preserves the expandable hierarchy.

- **`merge()`**: Added `row_sample` to the dedup key columns so that aggregate and member rows within the same group are no longer collapsed.

Backward compatible: `from_df()` falls back to using `sample` when `row_sample` is absent (old parquet files).

### Testing

- Added three new tests in `tests/test_rerun.py`:
  - `test_grouped_samples_survive_df_roundtrip`: verifies DataFrame serialization/deserialization preserves groups
  - `test_grouped_samples_survive_merge`: verifies merging two grouped datasets preserves hierarchy and values
  - `test_grouped_samples_parquet_roundtrip`: end-to-end parquet write/load/reconstruct test
- All 364 existing tests pass with no regressions
- End-to-end manual test confirms the exact scenario from #3520 (R1/R2 grouped samples merged via parquet) now works correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81508f08-9def-4b68-bda9-00388a5606b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81508f08-9def-4b68-bda9-00388a5606b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

