### PR TITLE
Fix custom_content crash on data type conflict between files

### DIFF
--- a/multiqc/core/special_case_modules/custom_content.py
+++ b/multiqc/core/special_case_modules/custom_content.py
@@ -274,14 +274,30 @@ def custom_module_classes() -> List[BaseMultiqcModule]:
                         ccdict_by_id[c_id] = CcDict()
                     # heatmap - special data type
                     if isinstance(parsed_item, list):
+                        existing = ccdict_by_id[c_id].data
+                        if isinstance(existing, dict) and existing:
+                            log.warning(
+                                f"Conflicting data types for custom content section '{c_id}' "
+                                f"in '{f['fn']}': overwriting existing dict data with list data "
+                                f"(heatmap). To avoid this, add distinct '# id: ...' comment "
+                                f"headers to your custom content files."
+                            )
                         ccdict_by_id[c_id].data = parsed_item
                     elif plot_type == PlotType.HTML:
                         ccdict_by_id[c_id].data = parsed_item
                     else:
                         assert isinstance(parsed_item, dict)
                         d = ccdict_by_id[c_id].data
-                        assert isinstance(d, dict), (c_id, f["fn"], f["root"])
-                        d.update(parsed_item)
+                        if not isinstance(d, dict):
+                            log.warning(
+                                f"Conflicting data types for custom content section '{c_id}' "
+                                f"in '{f['fn']}': overwriting existing {type(d).__name__} data "
+                                f"with dict data. To avoid this, add distinct '# id: ...' "
+                                f"comment headers to your custom content files."
+                            )
+                            ccdict_by_id[c_id].data = parsed_item
+                        else:
+                            d.update(parsed_item)
                     assert isinstance(ccdict_by_id[c_id].config, dict)
                     ccdict_by_id[c_id].config.update(m_config)
 

--- a/tests/test_custom_content.py
+++ b/tests/test_custom_content.py
@@ -887,6 +887,30 @@ sample2,20
     assert section2.description == "<p>This is the description for section 2</p>"
 
 
+def test_data_type_conflict_does_not_crash(tmp_path):
+    """
+    Regression test for https://github.com/MultiQC/MultiQC/issues/3484
+
+    When two custom content files resolve to the same section ID but produce
+    different data types (e.g. heatmap list vs bar dict), the module should
+    warn and overwrite rather than crash with an AssertionError.
+    """
+    # Square CSV: auto-detected as heatmap (data stored as list)
+    dir1 = tmp_path / "dir1"
+    dir1.mkdir()
+    (dir1 / "test_mqc.csv").write_text(",A,B,C\nX,1,2,3\nY,4,5,6\nZ,7,8,9\n")
+
+    # Non-square CSV: auto-detected as bar graph (data stored as dict)
+    dir2 = tmp_path / "dir2"
+    dir2.mkdir()
+    (dir2 / "test_mqc.csv").write_text(",A,B,C\nX,1,2,3\nY,4,5,6\nZ,7,8,9\nW,10,11,12\nQ,13,14,15\n")
+
+    report.analysis_files = [str(dir1), str(dir2)]
+    report.search_files(["custom_content"])
+    modules = custom_module_classes()
+    assert len(modules) >= 1
+
+
 def test_parent_name_without_parent_description(tmp_path):
     """Test that descriptions work when parent_name is set but parent_description is not."""
     file1 = tmp_path / "sample1_mqc.txt"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] This comment contains a description of changes (with reason)

## Description

Fixes #3484

When multiple custom content CSV files resolve to the same section ID (e.g. due to sample name cleaning), the module crashes with `AssertionError` if the files produce different data types. This happens when one file's matrix is square (auto-detected as heatmap, stored as a `list`) and another file's matrix is not square (auto-detected as bar graph, stored as a `dict`). The assertion at line 283 expects the existing data to be a `dict`, but it can be a `list` from a previously processed heatmap file.

### Reproduction

Two CSV files matching `*_mqc.csv` that resolve to the same cleaned sample name, where one has a square matrix (triggers heatmap auto-detection) and the other does not:

```
dir1/test_mqc.csv:       dir2/test_mqc.csv:
,A,B,C                   ,A,B,C
X,1,2,3                  X,1,2,3
Y,4,5,6                  Y,4,5,6
Z,7,8,9                  Z,7,8,9
                          W,10,11,12
                          Q,13,14,15
```

Running `multiqc dir1 dir2` crashes with:
```
AssertionError: ('test', 'test_mqc.csv', 'dir2')
```

### Fix

Replace the assertion with graceful handling: log a warning and overwrite the conflicting data. The warning advises users to add distinct `# id: ...` comment headers to their custom content files to avoid the conflict. Also added a warning for the reverse case (list/heatmap data overwriting existing dict data).

### Testing

- Added regression test `test_data_type_conflict_does_not_crash`
- All 518 existing tests pass, 4 skipped
- ruff and mypy pass cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c454594e-dc72-4aa7-bbf3-bd59f8680c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c454594e-dc72-4aa7-bbf3-bd59f8680c45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

