### PR TITLE
Fix ValueError in bar plot when all categories are zero

### DIFF
--- a/multiqc/plots/bargraph.py
+++ b/multiqc/plots/bargraph.py
@@ -822,6 +822,9 @@ class BarPlot(Plot[Dataset, BarPlotConfig]):
                 plot_samples.append(ordered_samples_names)
                 plot_data.append(cat_data_dicts)
 
+        if not plot_samples:
+            return None
+
         return BarPlot.create(
             cats_lists=plot_data,
             samples_lists=plot_samples,

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -415,6 +415,20 @@ def test_bar_plot_no_matching_cats():
     assert plot is None
 
 
+def test_bar_plot_all_zero_cats():
+    """
+    All categories are zero for all samples. With hide_zero_cats=True (default),
+    all categories get filtered, so the plot should return None gracefully
+    instead of raising ValueError. Regression test for #3481.
+    """
+    plot = bargraph.plot(
+        {"Sample1": {"Cat1": 0, "Cat2": 0}, "Sample2": {"Cat1": 0, "Cat2": 0}},
+        ["Cat1", "Cat2"],
+        {"id": "test_bar_plot_all_zero_cats", "title": "Test: Bar Graph"},
+    )
+    assert plot is None
+
+
 def test_bar_plot_cats_dicts():
     """
     Advanced cats spec - dict with cat properties instead of a simple list


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3481

- [x] This comment contains a description of changes (with reason)

## Description

When `hide_zero_cats` is `True` (the default) and all categories have zero values for all samples, `BarPlot.from_inputs()` would pass empty lists to `BarPlot.create()`, which then raised `ValueError("No datasets to plot")` in `Plot.initialize()`.

This affected the Xenium module when using imported segmentation (via `proseg + xeniumranger import-segmentation`) where `segmented_cell_boundary_count` is 0, causing the `xenium_extra` plugin's segmentation bar plot to crash.

## Fix

Added a guard in `BarPlot.from_inputs()` to return `None` when all categories are filtered out, consistent with how `bargraph.plot()` already handles the `is_empty()` case. Callers of `bargraph.plot()` already handle `None` returns gracefully.

## Testing

Added a regression test `test_bar_plot_all_zero_cats` that verifies `bargraph.plot()` returns `None` instead of raising `ValueError` when all categories are zero with `hide_zero_cats=True`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3a31d89-29fa-4e43-9b0f-d576182182aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3a31d89-29fa-4e43-9b0f-d576182182aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

