### PR TITLE
Config wizard: inline schema validation in YAML editor

### DIFF
--- a/docs/multiqc_config_wizard.html
+++ b/docs/multiqc_config_wizard.html
@@ -99,7 +99,7 @@
            primary-button surface. */
         --navy: #160f26; /* --color-brand-1100; sidebar / primary-button bg */
         --navy-2: #201637; /* --color-brand; primary-button hover */
-        --ink: #e5e5e5; /* headings */
+        --ink: #f5f5f7; /* headings */
         --ink-mute: #e3e3e3; /* body text */
         --ink-soft: #a8a8ad; /* captions / muted */
         --ink-faint: #6e6e73; /* very subtle */
@@ -1207,6 +1207,12 @@
       .validate-line-hl {
         background: rgba(49, 201, 172, 0.18);
       }
+      /* Monaco's marker-hover status bar shows "No quick fixes available"
+         whenever no code-action provider is registered. We have no actions
+         to offer, so hide the dead text but keep the "View Problem" link. */
+      .monaco-editor .hover-row.status-bar .actions > div:not(.action-container) {
+        display: none;
+      }
       .validate-line-hl-margin {
         background: var(--teal);
         width: 3px !important;
@@ -2101,6 +2107,7 @@
               "sickle",
               "skewer",
               "sortmerna",
+              "ribodetector",
               "biobloomtools",
               "seqfu",
               "fastq_screen",
@@ -8978,6 +8985,167 @@
 
       let lastValidated = { parsed: null, results: [], keyLineRanges: {} };
 
+      // Namespace for our schema-validation markers so setModelMarkers([])
+      // only clears ours.
+      const MARKERS_OWNER = "mqc-wizard-schema";
+
+      function applyValidationMarkers(markers) {
+        if (!monacoEditor) return;
+        const model = monacoEditor.getModel();
+        if (!model) return;
+        monaco.editor.setModelMarkers(model, MARKERS_OWNER, markers);
+      }
+
+      // Falls back to the full line span if the key text isn't found on the
+      // start line (e.g. an oddly-formatted multi-line block scalar).
+      function keyColumnsOnLine(lines, lineIndex, key) {
+        const line = lines[lineIndex] || "";
+        const idx = line.indexOf(key);
+        if (idx < 0) return { startColumn: 1, endColumn: Math.max(1, line.length) + 1 };
+        return { startColumn: idx + 1, endColumn: idx + key.length + 1 };
+      }
+
+      function escapeRegex(s) {
+        return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      }
+
+      // Walk an Ajv instancePath like "/report_header_info/0/contact_e_mail"
+      // down through the YAML source, returning the line + column of the
+      // deepest segment found. Naive scan: doesn't track indent strictly, so
+      // it can mis-target keys that re-appear under nested blocks, but for
+      // MultiQC configs (shallow, no re-used key names) it's accurate enough.
+      // Returns null on miss so the caller can fall back to the top-level key.
+      function findNestedRange(lines, blockRange, segments) {
+        if (!segments.length) return null;
+        let lineIdx = blockRange.start; // skip the top-level key line
+        const endIdx = blockRange.end;
+        let lastLineIdx = -1;
+        let lastWasIndex = false;
+        for (const seg of segments) {
+          const isIndex = /^\d+$/.test(seg);
+          let found = -1;
+          if (isIndex) {
+            const target = parseInt(seg, 10);
+            let count = 0;
+            while (lineIdx < endIdx) {
+              if (/^\s*-(\s|$)/.test(lines[lineIdx])) {
+                if (count === target) {
+                  found = lineIdx;
+                  break;
+                }
+                count++;
+              }
+              lineIdx++;
+            }
+          } else {
+            const re = new RegExp("(^|\\s|-\\s)" + escapeRegex(seg) + "\\s*:");
+            // Compact `- key: value` style holds the dash and the first
+            // nested key on the same line, so check the previous index's
+            // line before walking forward.
+            if (lastWasIndex && lastLineIdx >= 0 && re.test(lines[lastLineIdx])) {
+              found = lastLineIdx;
+            }
+            while (found < 0 && lineIdx < endIdx) {
+              if (re.test(lines[lineIdx])) {
+                found = lineIdx;
+                break;
+              }
+              lineIdx++;
+            }
+          }
+          if (found < 0) return null;
+          lastLineIdx = found;
+          lastWasIndex = isIndex;
+          lineIdx = found + 1;
+        }
+        const ln = lines[lastLineIdx];
+        const lastSeg = segments[segments.length - 1];
+        const needle = lastWasIndex ? "-" : lastSeg;
+        const idx = ln.indexOf(needle);
+        return {
+          line: lastLineIdx + 1,
+          startColumn: idx >= 0 ? idx + 1 : 1,
+          endColumn: idx >= 0 ? idx + needle.length + 1 : ln.length + 1,
+        };
+      }
+
+      function markersForParseError(e) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const mark = e && e.mark;
+        const line = mark && typeof mark.line === "number" ? mark.line + 1 : 1;
+        const col = mark && typeof mark.column === "number" ? mark.column + 1 : 1;
+        return [
+          {
+            severity: monaco.MarkerSeverity.Error,
+            message: e.reason || e.message || "YAML parse error",
+            startLineNumber: line,
+            endLineNumber: line,
+            startColumn: col,
+            endColumn: col + 1,
+          },
+        ];
+      }
+
+      function markersForTopLevelError(text, message) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const firstLine = text.split("\n", 1)[0] || "";
+        return [
+          {
+            severity: monaco.MarkerSeverity.Error,
+            message,
+            startLineNumber: 1,
+            endLineNumber: 1,
+            startColumn: 1,
+            endColumn: Math.max(2, firstLine.length + 1),
+          },
+        ];
+      }
+
+      function markersForResults(text, results, keyLineRanges) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const lines = text.split("\n");
+        const markers = [];
+        for (const r of results) {
+          const range = keyLineRanges[r.key];
+          if (!range) continue;
+          const topCols = keyColumnsOnLine(lines, range.start - 1, r.key);
+          const topBase = {
+            startLineNumber: range.start,
+            endLineNumber: range.start,
+            startColumn: topCols.startColumn,
+            endColumn: topCols.endColumn,
+          };
+          if (r.status === "error") {
+            for (const entry of r.messages || []) {
+              const segments = (entry.instancePath || "").split("/").slice(2);
+              const nested = segments.length ? findNestedRange(lines, range, segments) : null;
+              markers.push({
+                severity: monaco.MarkerSeverity.Error,
+                message: entry.message,
+                startLineNumber: nested ? nested.line : topBase.startLineNumber,
+                endLineNumber: nested ? nested.line : topBase.endLineNumber,
+                startColumn: nested ? nested.startColumn : topBase.startColumn,
+                endColumn: nested ? nested.endColumn : topBase.endColumn,
+              });
+            }
+          } else if (r.status === "unknown") {
+            markers.push({
+              ...topBase,
+              severity: monaco.MarkerSeverity.Warning,
+              message: r.suggestion ? `Unknown option. Did you mean "${r.suggestion}"?` : "Not a recognised option.",
+            });
+          } else if (r.status === "deprecated") {
+            markers.push({
+              ...topBase,
+              severity: monaco.MarkerSeverity.Warning,
+              message: "Deprecated option. See the description for a replacement.",
+              tags: [monaco.MarkerTag.Deprecated],
+            });
+          }
+        }
+        return markers;
+      }
+
       // Map each top-level key in the paste to its 1-indexed [start, end]
       // line range. Naive regex walk; fine for MultiQC configs (no leading
       // whitespace on top-level keys, no multi-document YAML). Trailing
@@ -9017,6 +9185,7 @@
           summary.innerHTML = "";
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers([]);
           return;
         }
 
@@ -9028,12 +9197,16 @@
             '<span class="validate-badge error">YAML parse error</span> ' + escapeHtml(e.message || String(e));
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers(markersForParseError(e));
           return;
         }
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
           summary.innerHTML = '<span class="validate-badge error">Expected a mapping at the top level.</span>';
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers(
+            markersForTopLevelError(text, "Expected a mapping at the top level (key: value pairs)."),
+          );
           return;
         }
 
@@ -9055,7 +9228,10 @@
           for (const err of filterAjvErrors(validate.errors)) {
             const top = (err.instancePath || "").split("/")[1];
             if (!top) continue;
-            (errorsByKey[top] = errorsByKey[top] || []).push(formatAjvError(err));
+            (errorsByKey[top] = errorsByKey[top] || []).push({
+              message: formatAjvError(err),
+              instancePath: err.instancePath || "",
+            });
           }
         }
 
@@ -9083,6 +9259,7 @@
         lastValidated = { parsed, results, keyLineRanges };
         renderSummary(results);
         renderCards(results);
+        applyValidationMarkers(markersForResults(text, results, keyLineRanges));
       }
 
       // Drop the active line decoration + card outline. Called on every
@@ -9259,7 +9436,7 @@
             ? `<div class="validate-msg">did you mean <code>${escapeHtml(r.suggestion)}</code>?</div>`
             : `<div class="validate-msg">not a recognised option</div>`;
         } else if (r.messages && r.messages.length) {
-          body += r.messages.map((m) => `<div class="validate-msg">${escapeHtml(m)}</div>`).join("");
+          body += r.messages.map((m) => `<div class="validate-msg">${escapeHtml(m.message)}</div>`).join("");
         } else if (r.status === "default") {
           body += `<div class="validate-msg">matches the MultiQC default: has no effect</div>`;
         } else if (r.status === "deprecated") {

--- a/docs/multiqc_config_wizard.html
+++ b/docs/multiqc_config_wizard.html
@@ -8813,6 +8813,40 @@
         monaco.editor.setTheme("mqc-dark");
       }
 
+      // Hover docs over top-level keys. Pulls description / default / type
+      // from the same propData the wizard form uses, so the editor matches
+      // the form's help text without a second source of truth.
+      function registerSchemaHover() {
+        monaco.languages.registerHoverProvider("yaml", {
+          provideHover(model, position) {
+            const word = model.getWordAtPosition(position);
+            // Top-level keys only: start at column 1 and own the start of
+            // the line. Filters out values that happen to spell a known key.
+            if (!word || word.startColumn !== 1) return null;
+            const lineText = model.getLineContent(position.lineNumber);
+            const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(lineText);
+            if (!m || m[1] !== word.word) return null;
+
+            const propData = propDataIndex[word.word] || schemaPropData(word.word);
+            if (!propData || !propData.description) return null;
+
+            const header = ["**" + word.word + "**"];
+            if (propData.type) header.push("*" + propData.type + "*");
+            if (propData.deprecated) header.push("*(deprecated)*");
+            const parts = [header.join("  ")];
+            if (propData.default !== undefined && propData.default !== null) {
+              parts.push("Default: `" + formatDefaultValue(propData.default) + "`");
+            }
+            parts.push(propData.description);
+
+            return {
+              range: new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn),
+              contents: [{ value: parts.join("\n\n") }],
+            };
+          },
+        });
+      }
+
       function ensureMonaco() {
         if (monacoReadyPromise) return monacoReadyPromise;
         if (typeof require !== "function" || typeof require.config !== "function") {
@@ -8829,6 +8863,7 @@
             // the editor reads as part of the same app rather than a foreign
             // VS Code panel.
             defineMonacoTheme();
+            registerSchemaHover();
             const container = document.getElementById("validateMonaco");
             const textarea = document.getElementById("validateInput");
             monacoEditor = monaco.editor.create(container, {

--- a/scripts/wizard_template.html
+++ b/scripts/wizard_template.html
@@ -1207,6 +1207,12 @@
       .validate-line-hl {
         background: rgba(49, 201, 172, 0.18);
       }
+      /* Monaco's marker-hover status bar shows "No quick fixes available"
+         whenever no code-action provider is registered. We have no actions
+         to offer, so hide the dead text but keep the "View Problem" link. */
+      .monaco-editor .hover-row.status-bar .actions > div:not(.action-container) {
+        display: none;
+      }
       .validate-line-hl-margin {
         background: var(--teal);
         width: 3px !important;
@@ -3018,6 +3024,167 @@
 
       let lastValidated = { parsed: null, results: [], keyLineRanges: {} };
 
+      // Namespace for our schema-validation markers so setModelMarkers([])
+      // only clears ours.
+      const MARKERS_OWNER = "mqc-wizard-schema";
+
+      function applyValidationMarkers(markers) {
+        if (!monacoEditor) return;
+        const model = monacoEditor.getModel();
+        if (!model) return;
+        monaco.editor.setModelMarkers(model, MARKERS_OWNER, markers);
+      }
+
+      // Falls back to the full line span if the key text isn't found on the
+      // start line (e.g. an oddly-formatted multi-line block scalar).
+      function keyColumnsOnLine(lines, lineIndex, key) {
+        const line = lines[lineIndex] || "";
+        const idx = line.indexOf(key);
+        if (idx < 0) return { startColumn: 1, endColumn: Math.max(1, line.length) + 1 };
+        return { startColumn: idx + 1, endColumn: idx + key.length + 1 };
+      }
+
+      function escapeRegex(s) {
+        return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      }
+
+      // Walk an Ajv instancePath like "/report_header_info/0/contact_e_mail"
+      // down through the YAML source, returning the line + column of the
+      // deepest segment found. Naive scan: doesn't track indent strictly, so
+      // it can mis-target keys that re-appear under nested blocks, but for
+      // MultiQC configs (shallow, no re-used key names) it's accurate enough.
+      // Returns null on miss so the caller can fall back to the top-level key.
+      function findNestedRange(lines, blockRange, segments) {
+        if (!segments.length) return null;
+        let lineIdx = blockRange.start; // skip the top-level key line
+        const endIdx = blockRange.end;
+        let lastLineIdx = -1;
+        let lastWasIndex = false;
+        for (const seg of segments) {
+          const isIndex = /^\d+$/.test(seg);
+          let found = -1;
+          if (isIndex) {
+            const target = parseInt(seg, 10);
+            let count = 0;
+            while (lineIdx < endIdx) {
+              if (/^\s*-(\s|$)/.test(lines[lineIdx])) {
+                if (count === target) {
+                  found = lineIdx;
+                  break;
+                }
+                count++;
+              }
+              lineIdx++;
+            }
+          } else {
+            const re = new RegExp("(^|\\s|-\\s)" + escapeRegex(seg) + "\\s*:");
+            // Compact `- key: value` style holds the dash and the first
+            // nested key on the same line, so check the previous index's
+            // line before walking forward.
+            if (lastWasIndex && lastLineIdx >= 0 && re.test(lines[lastLineIdx])) {
+              found = lastLineIdx;
+            }
+            while (found < 0 && lineIdx < endIdx) {
+              if (re.test(lines[lineIdx])) {
+                found = lineIdx;
+                break;
+              }
+              lineIdx++;
+            }
+          }
+          if (found < 0) return null;
+          lastLineIdx = found;
+          lastWasIndex = isIndex;
+          lineIdx = found + 1;
+        }
+        const ln = lines[lastLineIdx];
+        const lastSeg = segments[segments.length - 1];
+        const needle = lastWasIndex ? "-" : lastSeg;
+        const idx = ln.indexOf(needle);
+        return {
+          line: lastLineIdx + 1,
+          startColumn: idx >= 0 ? idx + 1 : 1,
+          endColumn: idx >= 0 ? idx + needle.length + 1 : ln.length + 1,
+        };
+      }
+
+      function markersForParseError(e) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const mark = e && e.mark;
+        const line = mark && typeof mark.line === "number" ? mark.line + 1 : 1;
+        const col = mark && typeof mark.column === "number" ? mark.column + 1 : 1;
+        return [
+          {
+            severity: monaco.MarkerSeverity.Error,
+            message: e.reason || e.message || "YAML parse error",
+            startLineNumber: line,
+            endLineNumber: line,
+            startColumn: col,
+            endColumn: col + 1,
+          },
+        ];
+      }
+
+      function markersForTopLevelError(text, message) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const firstLine = text.split("\n", 1)[0] || "";
+        return [
+          {
+            severity: monaco.MarkerSeverity.Error,
+            message,
+            startLineNumber: 1,
+            endLineNumber: 1,
+            startColumn: 1,
+            endColumn: Math.max(2, firstLine.length + 1),
+          },
+        ];
+      }
+
+      function markersForResults(text, results, keyLineRanges) {
+        if (!monacoEditor || typeof monaco === "undefined") return [];
+        const lines = text.split("\n");
+        const markers = [];
+        for (const r of results) {
+          const range = keyLineRanges[r.key];
+          if (!range) continue;
+          const topCols = keyColumnsOnLine(lines, range.start - 1, r.key);
+          const topBase = {
+            startLineNumber: range.start,
+            endLineNumber: range.start,
+            startColumn: topCols.startColumn,
+            endColumn: topCols.endColumn,
+          };
+          if (r.status === "error") {
+            for (const entry of r.messages || []) {
+              const segments = (entry.instancePath || "").split("/").slice(2);
+              const nested = segments.length ? findNestedRange(lines, range, segments) : null;
+              markers.push({
+                severity: monaco.MarkerSeverity.Error,
+                message: entry.message,
+                startLineNumber: nested ? nested.line : topBase.startLineNumber,
+                endLineNumber: nested ? nested.line : topBase.endLineNumber,
+                startColumn: nested ? nested.startColumn : topBase.startColumn,
+                endColumn: nested ? nested.endColumn : topBase.endColumn,
+              });
+            }
+          } else if (r.status === "unknown") {
+            markers.push({
+              ...topBase,
+              severity: monaco.MarkerSeverity.Warning,
+              message: r.suggestion ? `Unknown option. Did you mean "${r.suggestion}"?` : "Not a recognised option.",
+            });
+          } else if (r.status === "deprecated") {
+            markers.push({
+              ...topBase,
+              severity: monaco.MarkerSeverity.Warning,
+              message: "Deprecated option. See the description for a replacement.",
+              tags: [monaco.MarkerTag.Deprecated],
+            });
+          }
+        }
+        return markers;
+      }
+
       // Map each top-level key in the paste to its 1-indexed [start, end]
       // line range. Naive regex walk; fine for MultiQC configs (no leading
       // whitespace on top-level keys, no multi-document YAML). Trailing
@@ -3057,6 +3224,7 @@
           summary.innerHTML = "";
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers([]);
           return;
         }
 
@@ -3068,12 +3236,16 @@
             '<span class="validate-badge error">YAML parse error</span> ' + escapeHtml(e.message || String(e));
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers(markersForParseError(e));
           return;
         }
         if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
           summary.innerHTML = '<span class="validate-badge error">Expected a mapping at the top level.</span>';
           cards.innerHTML = "";
           lastValidated = { parsed: null, results: [], keyLineRanges: {} };
+          applyValidationMarkers(
+            markersForTopLevelError(text, "Expected a mapping at the top level (key: value pairs)."),
+          );
           return;
         }
 
@@ -3095,7 +3267,10 @@
           for (const err of filterAjvErrors(validate.errors)) {
             const top = (err.instancePath || "").split("/")[1];
             if (!top) continue;
-            (errorsByKey[top] = errorsByKey[top] || []).push(formatAjvError(err));
+            (errorsByKey[top] = errorsByKey[top] || []).push({
+              message: formatAjvError(err),
+              instancePath: err.instancePath || "",
+            });
           }
         }
 
@@ -3123,6 +3298,7 @@
         lastValidated = { parsed, results, keyLineRanges };
         renderSummary(results);
         renderCards(results);
+        applyValidationMarkers(markersForResults(text, results, keyLineRanges));
       }
 
       // Drop the active line decoration + card outline. Called on every
@@ -3299,7 +3475,7 @@
             ? `<div class="validate-msg">did you mean <code>${escapeHtml(r.suggestion)}</code>?</div>`
             : `<div class="validate-msg">not a recognised option</div>`;
         } else if (r.messages && r.messages.length) {
-          body += r.messages.map((m) => `<div class="validate-msg">${escapeHtml(m)}</div>`).join("");
+          body += r.messages.map((m) => `<div class="validate-msg">${escapeHtml(m.message)}</div>`).join("");
         } else if (r.status === "default") {
           body += `<div class="validate-msg">matches the MultiQC default: has no effect</div>`;
         } else if (r.status === "deprecated") {

--- a/scripts/wizard_template.html
+++ b/scripts/wizard_template.html
@@ -2852,6 +2852,40 @@
         monaco.editor.setTheme("mqc-dark");
       }
 
+      // Hover docs over top-level keys. Pulls description / default / type
+      // from the same propData the wizard form uses, so the editor matches
+      // the form's help text without a second source of truth.
+      function registerSchemaHover() {
+        monaco.languages.registerHoverProvider("yaml", {
+          provideHover(model, position) {
+            const word = model.getWordAtPosition(position);
+            // Top-level keys only: start at column 1 and own the start of
+            // the line. Filters out values that happen to spell a known key.
+            if (!word || word.startColumn !== 1) return null;
+            const lineText = model.getLineContent(position.lineNumber);
+            const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(lineText);
+            if (!m || m[1] !== word.word) return null;
+
+            const propData = propDataIndex[word.word] || schemaPropData(word.word);
+            if (!propData || !propData.description) return null;
+
+            const header = ["**" + word.word + "**"];
+            if (propData.type) header.push("*" + propData.type + "*");
+            if (propData.deprecated) header.push("*(deprecated)*");
+            const parts = [header.join("  ")];
+            if (propData.default !== undefined && propData.default !== null) {
+              parts.push("Default: `" + formatDefaultValue(propData.default) + "`");
+            }
+            parts.push(propData.description);
+
+            return {
+              range: new monaco.Range(position.lineNumber, word.startColumn, position.lineNumber, word.endColumn),
+              contents: [{ value: parts.join("\n\n") }],
+            };
+          },
+        });
+      }
+
       function ensureMonaco() {
         if (monacoReadyPromise) return monacoReadyPromise;
         if (typeof require !== "function" || typeof require.config !== "function") {
@@ -2868,6 +2902,7 @@
             // the editor reads as part of the same app rather than a foreign
             // VS Code panel.
             defineMonacoTheme();
+            registerSchemaHover();
             const container = document.getElementById("validateMonaco");
             const textarea = document.getElementById("validateInput");
             monacoEditor = monaco.editor.create(container, {


### PR DESCRIPTION
Surface Ajv schema errors as Monaco markers (squiggles + hover) so users see problems in the editor rather than just the cards below.

<img width="2764" height="1108" alt="CleanShot 2026-05-13 at 17 00 08@2x" src="https://github.com/user-attachments/assets/99a7c3b0-a4db-4a72-bad6-255cbe7d05fc" />


- Error squiggles for schema violations (type, enum, required), with Ajv's formatted message in the hover tooltip.
- Warning squiggles on unknown options, carrying the existing did-you-mean suggestion.
- Deprecated tag (strikethrough) on deprecated options.
- Parse errors pinned to the line/column js-yaml reports.

Nested instancePaths like `/report_header_info/0/bad_field` are walked through the YAML source by `findNestedRange` so the squiggle lands on the actual offending line, including the compact `"- key: value"` style where the dash and first nested key share a line.

Hides Monaco's dead `"No quick fixes available"` link in the hover status bar, since the wizard registers no code-action provider.

