### PR TITLE
Samtools flagstat: Sum reads for grouped samples

### DIFF
--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -3,7 +3,9 @@ import re
 from typing import Dict
 
 from multiqc import BaseMultiqcModule, config
+from multiqc.base_module import SampleGroupingConfig
 from multiqc.plots import violin
+from multiqc.types import ColumnKey
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +61,15 @@ def parse_samtools_flagstat(module: BaseMultiqcModule):
 
     # Add headers to general stats table
     if general_stats_headers:
-        module.general_stats_addcols(samtools_flagstat, general_stats_headers, namespace="flagstat")
+        module.general_stats_addcols(
+            samtools_flagstat,
+            general_stats_headers,
+            namespace="flagstat",
+            group_samples_config=SampleGroupingConfig(
+                cols_to_sum=[ColumnKey("flagstat_total"), ColumnKey("mapped_passed")],
+                cols_to_weighted_average=[(ColumnKey("mapped_passed_pct"), ColumnKey("total_passed"))],
+            ),
+        )
 
     # Make a violin plot
     reads = {

--- a/multiqc/modules/samtools/flagstat.py
+++ b/multiqc/modules/samtools/flagstat.py
@@ -66,7 +66,7 @@ def parse_samtools_flagstat(module: BaseMultiqcModule):
             general_stats_headers,
             namespace="flagstat",
             group_samples_config=SampleGroupingConfig(
-                cols_to_sum=[ColumnKey("flagstat_total"), ColumnKey("mapped_passed")],
+                cols_to_sum=[ColumnKey("flagstat_total"), ColumnKey("mapped_passed"), ColumnKey("total_passed")],
                 cols_to_weighted_average=[(ColumnKey("mapped_passed_pct"), ColumnKey("total_passed"))],
             ),
         )

--- a/multiqc/modules/samtools/tests/test_flagstat.py
+++ b/multiqc/modules/samtools/tests/test_flagstat.py
@@ -121,5 +121,6 @@ def test_grouped_lanes_sum_mapped_reads_in_general_stats(tmp_path):
 
     group_rows = report.general_stats_data[SectionKey("samtools")][SampleGroup("sample")]
     assert group_rows[0].data[ColumnKey("mapped_passed")] == 230
+    assert group_rows[0].data[ColumnKey("total_passed")] == 300
     assert group_rows[0].data[ColumnKey("flagstat_total")] == 420
     assert group_rows[0].data[ColumnKey("mapped_passed_pct")] == pytest.approx(76.67, abs=0.01)

--- a/multiqc/modules/samtools/tests/test_flagstat.py
+++ b/multiqc/modules/samtools/tests/test_flagstat.py
@@ -6,6 +6,7 @@ import pytest
 
 from multiqc import config, report
 from multiqc.modules.samtools import MultiqcModule
+from multiqc.types import ColumnKey, SampleGroup, SectionKey
 from multiqc.utils import testing
 
 
@@ -75,3 +76,50 @@ def test_rep2(rep1, rep2):
         del res2[k]
 
     assert res1 == res2
+
+
+def _flagstat_report(total_passed: int, mapped_passed: int, total_failed: int, mapped_failed: int) -> str:
+    mapped_passed_pct = mapped_passed / total_passed * 100
+    mapped_failed_pct = mapped_failed / total_failed * 100
+    return f"""\
+{total_passed} + {total_failed} in total (QC-passed reads + QC-failed reads)
+0 + 0 secondary
+0 + 0 supplementary
+0 + 0 duplicates
+{mapped_passed} + {mapped_failed} mapped ({mapped_passed_pct:.2f}% : {mapped_failed_pct:.2f}%)
+{total_passed} + {total_failed} paired in sequencing
+{total_passed // 2} + {total_failed // 2} read1
+{total_passed // 2} + {total_failed // 2} read2
+{mapped_passed} + {mapped_failed} properly paired ({mapped_passed_pct:.2f}% : {mapped_failed_pct:.2f}%)
+{mapped_passed} + {mapped_failed} with itself and mate mapped
+0 + 0 singletons (0.00% : N/A)
+0 + 0 with mate mapped to a different chr
+0 + 0 with mate mapped to a different chr (mapQ>=5)
+"""
+
+
+def test_grouped_lanes_sum_mapped_reads_in_general_stats(tmp_path):
+    """Grouped lane-level flagstat reports should sum mapped reads."""
+    report.reset()
+    config.reset()
+
+    (tmp_path / "sample_L001.flagstat").write_text(
+        _flagstat_report(total_passed=100, mapped_passed=80, total_failed=20, mapped_failed=10)
+    )
+    (tmp_path / "sample_L002.flagstat").write_text(
+        _flagstat_report(total_passed=200, mapped_passed=150, total_failed=100, mapped_failed=50)
+    )
+
+    config.table_sample_merge = {
+        "L001": "_L001",
+        "L002": "_L002",
+    }
+    report.analysis_files = [tmp_path]
+    report.search_files(["samtools"])
+
+    MultiqcModule()
+
+    group_rows = report.general_stats_data[SectionKey("samtools")][SampleGroup("sample")]
+    assert group_rows[0].data[ColumnKey("mapped_passed")] == 230
+    assert group_rows[0].data[ColumnKey("flagstat_total")] == 420
+    assert group_rows[0].data[ColumnKey("mapped_passed_pct")] == pytest.approx(76.67, abs=0.01)


### PR DESCRIPTION
## Summary

- Configure samtools flagstat General Statistics grouping to sum total reads and reads mapped.
- Weight the grouped mapped-read percentage by QC-passed total reads.
- Add a regression test for lane-level flagstat files grouped with `table_sample_merge`.

Fixes #3580.

## Testing

- `uv run --extra dev pytest multiqc/modules/samtools/tests/test_flagstat.py -q`
- `uv run --extra dev pytest tests/test_rerun.py::test_grouped_samples_survive_df_roundtrip tests/test_rerun.py::test_grouped_samples_survive_merge -q`
- `uv run --extra dev ruff check multiqc/modules/samtools/flagstat.py multiqc/modules/samtools/tests/test_flagstat.py`
- `uv run --extra dev ruff format --check multiqc/modules/samtools/flagstat.py multiqc/modules/samtools/tests/test_flagstat.py`
- `git diff --check`
