### PR TITLE
handle multiple freyja pathogens

### DIFF
--- a/docs/markdown/modules/freyja.md
+++ b/docs/markdown/modules/freyja.md
@@ -1,7 +1,7 @@
 ---
 title: Freyja
 displayed_sidebar: multiqcSidebar
-description: "Recovers relative lineage abundances from mixed SARS-CoV-2 samples."
+description: "Recovers relative lineage abundances from mixed samples."
 ---
 
 <!--
@@ -14,12 +14,12 @@ File path for the source of this content: multiqc/modules/freyja/freyja.py
 -->
 
 :::note
-Recovers relative lineage abundances from mixed SARS-CoV-2 samples.
+Recovers relative lineage abundances from mixed samples.
 
 [https://github.com/andersen-lab/Freyja](https://github.com/andersen-lab/Freyja)
 :::
 
-Freyja is a tool to recover relative lineage abundances from mixed SARS-CoV-2 samples from a
+Freyja is a tool to recover relative lineage abundances from mixed samples from a
 sequencing dataset and uses lineage-determining mutational "barcodes" derived from the UShER global
 phylogenetic tree to solve the constrained (unit sum, non-negative) de-mixing problem.
 

--- a/multiqc/modules/freyja/freyja.py
+++ b/multiqc/modules/freyja/freyja.py
@@ -1,12 +1,20 @@
+import csv
 import logging
+import re
 from ast import literal_eval
 from typing import Dict
 
+from natsort import natsorted
+
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
 from multiqc.plots import bargraph
+from multiqc.plots.table_object import ColumnDict
 from multiqc.utils import mqc_colour
 
 log = logging.getLogger(__name__)
+
+# Pathogen reported by legacy Freyja versions that do not emit a "pathogen" line.
+DEFAULT_PATHOGEN = "SARS-CoV-2"
 
 
 class MultiqcModule(BaseMultiqcModule):
@@ -15,91 +23,123 @@ class MultiqcModule(BaseMultiqcModule):
             name="Freyja",
             anchor="freyja",
             href="https://github.com/andersen-lab/Freyja",
-            info="Recovers relative lineage abundances from mixed SARS-CoV-2 samples.",
+            info="Recovers relative lineage abundances from mixed samples.",
             extra="""
-            Freyja is a tool to recover relative lineage abundances from mixed SARS-CoV-2 samples from a 
-            sequencing dataset and uses lineage-determining mutational "barcodes" derived from the UShER global 
+            Freyja is a tool to recover relative lineage abundances from mixed samples from a
+            sequencing dataset and uses lineage-determining mutational "barcodes" derived from the UShER global
             phylogenetic tree to solve the constrained (unit sum, non-negative) de-mixing problem.
             """,
             doi="10.1038/s41586-022-05049-6",
         )
 
-        # To store the summary data
-        data_by_sample: Dict[str, Dict] = dict()
+        # Store the summary data grouped by pathogen:
+        #   data_by_pathogen[pathogen][s_name] = {lineage: abundance}
+        data_by_pathogen: Dict[str, Dict[str, Dict[str, float]]] = {}
 
         for f in self.find_log_files("freyja", filehandles=True):
-            # Freyja has multiple summary files, but we only need to parse the one from the demix command.
-            # More specifically, we only need the line that starts with "summarized".
+            # The demix report is a TSV with one "key\tvalue" row per field. We need the
+            # "summarized" row, and, for newer Freyja versions, the "pathogen" row that names
+            # the analysed organism:
             # ...
             # summarized	[('BQ.1*', 0.983), ('Omicron', 0.011), ('key', value)]
             # ...
-
+            # pathogen	SARS-CoV-2
+            # ...
             s_name: str = f["s_name"]
 
-            # This will not raise because the search pattern requires it to be there:
-            summarized_line = next(line for line in f["f"] if line.startswith("summarized\t"))
-            dict_str = summarized_line.split("\t")[1].strip()
+            # Collect the value of each field, keyed by the field name in the first column.
+            fields: Dict[str, str] = {}
+            for row in csv.reader(f["f"], delimiter="\t"):
+                if len(row) >= 2:
+                    fields[row[0]] = row[1]
+
+            # This will be present because the search pattern requires the "summarized" row to be there:
+            summarized = fields["summarized"]
+
+            # Legacy Freyja reports do not include a pathogen field; they only ever covered SARS-CoV-2.
+            pathogen = fields.get("pathogen") or DEFAULT_PATHOGEN
+
             try:
-                sample_dict: Dict[str, float] = dict(literal_eval(dict_str))
+                sample_dict: Dict[str, float] = dict(literal_eval(summarized))
             except (ValueError, SyntaxError):
-                log.error(f"Error parsing 'summarized' line for '{s_name}': {dict_str}, skipping sample")
+                log.error(f"Error parsing 'summarized' line for '{s_name}': {summarized}, skipping sample")
                 continue
             if not sample_dict:
-                log.debug(f"No data in the 'summarized' line for '{s_name}': {dict_str}, skipping sample")
+                log.debug(f"No data in the 'summarized' line for '{s_name}': {summarized}, skipping sample")
                 continue
 
-            if s_name in data_by_sample:
-                log.debug(f"Duplicate sample name found! Overwriting: {s_name}")
-            data_by_sample[s_name] = sample_dict
+            samples = data_by_pathogen.setdefault(pathogen, {})
+            if s_name in samples:
+                log.debug(f"Duplicate sample name found for pathogen '{pathogen}'! Overwriting: {s_name}")
+            samples[s_name] = sample_dict
             self.add_data_source(f, s_name)
 
         # Remove filtered samples
-        data_by_sample = self.ignore_samples(data_by_sample)
+        for pathogen in list(data_by_pathogen.keys()):
+            data_by_pathogen[pathogen] = self.ignore_samples(data_by_pathogen[pathogen])
+            if not data_by_pathogen[pathogen]:
+                del data_by_pathogen[pathogen]
 
         # Let MultiQC know this module found no data
-        if len(data_by_sample) == 0:
+        if not data_by_pathogen:
             raise ModuleNoSamplesFound
 
-        log.info(f"Found {len(data_by_sample)} reports")
+        total_samples = sum(len(samples) for samples in data_by_pathogen.values())
+        log.info(f"Found {total_samples} reports")
 
         # Superfluous function call to confirm that it is used in this module
         # Replace None with actual version if it is available
         self.add_software_version(None)
 
-        self.write_data_file(data_by_sample, "multiqc_freyja")
-
-        # sort data_by_sample to keep the reproducible order - as the files are discovered in a non-deterministic order
-        data_by_sample = dict(sorted(data_by_sample.items()))
-
-        top_lineages_dict = {}
-        all_lineages = set()
-        for s_name, sample_data in data_by_sample.items():
-            top_lineage, top_lineage_value = max(sample_data.items(), key=lambda xv: xv[1])
-            top_lineages_dict[s_name] = {
-                "Top_lineage_freyja": top_lineage,
-                "Top_lineage_freyja_percentage": top_lineage_value,
-            }
-            all_lineages.add(top_lineage)
-        for s_name, sample_data in data_by_sample.items():
-            for lineage, val in sorted(sample_data.items(), key=lambda xv: xv[1], reverse=True):
-                if lineage not in all_lineages:
-                    all_lineages.add(lineage)
-
         self.scale = mqc_colour.mqc_colour_scale("plot_defaults")
-        self.general_stats_cols(top_lineages_dict, all_lineages)
-        self.add_freyja_section(all_lineages, data_by_sample)
 
-    def general_stats_cols(self, top_lineages_dict, all_lineages):
-        """Add a single column displaying the most abundant lineage to the General Statistics table"""
-        headers = {
-            "Top_lineage_freyja": {
-                "title": "Top lineage",
-                "description": "The most abundant lineage in the sample",
+        for pathogen in natsorted(data_by_pathogen.keys()):
+            # Sort samples to keep a reproducible order - files are discovered non-deterministically
+            samples = data_by_pathogen[pathogen]
+            data_by_sample = {s_name: samples[s_name] for s_name in natsorted(samples.keys())}
+
+            suffix = f" ({pathogen})"
+            # Slugs disambiguate section anchors and column keys per pathogen.
+            base_slug = re.sub(r"[^a-zA-Z0-9]+", "-", pathogen).strip("-").lower()
+            anchor_slug = f"-{base_slug}"  # e.g. "freyja-summary-sars-cov-2"
+            col_slug = f"_{base_slug.replace('-', '_')}"  # e.g. "Top_lineage_freyja_sars_cov_2"
+
+            top_lineages_dict: Dict[str, Dict] = {}
+            all_lineages: set = set()
+            for s_name, sample_data in data_by_sample.items():
+                top_lineage, top_lineage_value = max(sample_data.items(), key=lambda xv: xv[1])
+                top_lineages_dict[s_name] = {
+                    f"Top_lineage_freyja{col_slug}": top_lineage,
+                    f"Top_lineage_freyja{col_slug}_percentage": top_lineage_value,
+                }
+                all_lineages.add(top_lineage)
+            for s_name, sample_data in data_by_sample.items():
+                for lineage, val in sorted(sample_data.items(), key=lambda xv: xv[1], reverse=True):
+                    if lineage not in all_lineages:
+                        all_lineages.add(lineage)
+
+            self.general_stats_cols(top_lineages_dict, all_lineages, suffix, col_slug)
+            self.add_freyja_section(all_lineages, data_by_sample, suffix, anchor_slug)
+
+        # Write the data file at the very end, after all sections are added.
+        # Disambiguate sample names with the pathogen.
+        combined: Dict[str, Dict[str, float]] = {}
+        for pathogen, samples in data_by_pathogen.items():
+            for s_name, sample_data in samples.items():
+                combined[f"{s_name} ({pathogen})"] = sample_data
+        self.write_data_file(combined, "multiqc_freyja")
+
+    def general_stats_cols(self, top_lineages_dict, all_lineages, suffix, slug):
+        """Add a column displaying the most abundant lineage to the General Statistics table"""
+        headers: Dict[str, ColumnDict] = {
+            f"Top_lineage_freyja{slug}": {
+                "title": f"Top lineage{suffix}",
+                "description": f"The most abundant lineage in the sample{suffix}",
                 "bgcols": {x: self.scale.get_colour(i) for i, x in enumerate(all_lineages)},
             },
-            "Top_lineage_freyja_percentage": {
-                "title": "Top lineage %",
-                "description": "The percentage of the most abundant lineage in the sample",
+            f"Top_lineage_freyja{slug}_percentage": {
+                "title": f"Top lineage %{suffix}",
+                "description": f"The percentage of the most abundant lineage in the sample{suffix}",
                 "max": 100,
                 "min": 0,
                 "scale": "Blues",
@@ -107,13 +147,12 @@ class MultiqcModule(BaseMultiqcModule):
                 "suffix": "%",
             },
         }
-
         self.general_stats_addcols(top_lineages_dict, headers)
 
-    def add_freyja_section(self, lineages, data_by_sample):
+    def add_freyja_section(self, lineages, data_by_sample, suffix, slug):
         pconfig = {
-            "id": "Freyja_plot",
-            "title": "Freyja: Top lineages",
+            "id": f"Freyja_plot{slug}",
+            "title": f"Freyja: Top lineages{suffix}",
             "ylab": "relative abundance",
             "y_clipmax": 1,
             "cpswitch": False,
@@ -122,17 +161,17 @@ class MultiqcModule(BaseMultiqcModule):
         cats = {x: {"name": x, "color": self.scale.get_colour(i, lighten=1)} for i, x in enumerate(lineages)}
 
         self.add_section(
-            name="Freyja Summary",
-            anchor="freyja-summary",
+            name=f"Freyja Summary{suffix}",
+            anchor=f"freyja-summary{slug}",
             description="""
-                Relative lineage abundances from mixed SARS-CoV-2 samples. Hover over the column headers for descriptions and click _Help_ for more in-depth documentation. 
+                Relative lineage abundances from mixed samples. Hover over the column headers for descriptions and click _Help_ for more in-depth documentation.
                 """,
             helptext="""
-                The graph denotes a sum of all lineage abundances in a particular WHO designation , otherwise they are grouped into "Other".
-                Lineages abundances are calculated as the number of reads that are assigned to a particular lineage. 
-                Lineages and their corresponding abundances are summarized by constellation. 
+                The graph denotes a sum of all lineage abundances in a particular WHO designation, otherwise they are grouped into "Other".
+                Lineages abundances are calculated as the number of reads that are assigned to a particular lineage.
+                Lineages and their corresponding abundances are summarized by constellation.
 
-                > **Note**: Lineage designation is based on the used WHO nomenclature, which could vary over time. 
+                > **Note**: Lineage designation is based on the used WHO nomenclature, which could vary over time.
                 """,
             plot=bargraph.plot(data_by_sample, cats, pconfig),
         )

--- a/tests/test_modules_run.py
+++ b/tests/test_modules_run.py
@@ -241,3 +241,93 @@ def test_path_filters(multiqc_reset, tmp_path, data_dir, anchors, expected_raw_d
     assert set(report.general_stats_data[SectionKey(anchors[1] or "adapterremoval-1")].keys()) == {
         Path(fn).name for fn in expected_pe_files
     }
+
+
+def _run_freyja(tmp_path):
+    from multiqc.modules.freyja.freyja import MultiqcModule
+
+    report.reset()
+    report.analysis_files = [tmp_path]
+    report.search_files(["freyja"])
+    return MultiqcModule()
+
+
+def _freyja_stats_cols(sample):
+    """Column keys recorded across all freyja general-stats sections for a given sample."""
+    cols: set = set()
+    for section_key, section in report.general_stats_data.items():
+        if not str(section_key).startswith("freyja"):
+            continue
+        for row in section.get(sample, []):
+            cols.update(row.data.keys())
+    return cols
+
+
+def test_freyja_legacy_no_pathogen(tmp_path):
+    """Legacy Freyja reports without a 'pathogen' line default to SARS-CoV-2."""
+    (tmp_path / "sample.demix_out.tsv").write_text(
+        "\tvariant_files/sample.demix_out.tsv\n"
+        "summarized\t[('BA.5* [Omicron (BA.5.X)]', 0.9), ('Omicron', 0.1)]\n"
+        "lineages\tBF.5.1 BF.7.7\n"
+        "abundances\t0.5 0.5\n"
+        "resid\t0.06\n"
+        "coverage\t1.83\n"
+    )
+
+    module = _run_freyja(tmp_path)
+
+    # The pathogen (defaulted to SARS-CoV-2) is included in anchors and column keys
+    assert {s.anchor for s in module.sections} == {"freyja-summary-sars-cov-2"}
+    assert _freyja_stats_cols("sample.demix_out") == {
+        "Top_lineage_freyja_sars_cov_2",
+        "Top_lineage_freyja_sars_cov_2_percentage",
+    }
+
+
+def test_freyja_multiple_pathogens(tmp_path):
+    """When reports declare different pathogens, each gets its own section and columns."""
+    (tmp_path / "covid.demix_out.tsv").write_text(
+        "\tvariant_files/covid.demix_out.tsv\n"
+        "summarized\t[('BA.5* [Omicron (BA.5.X)]', 0.9), ('Omicron', 0.1)]\n"
+        "lineages\tBF.5.1 BF.7.7\n"
+        "abundances\t0.5 0.5\n"
+        "resid\t0.06\n"
+        "coverage\t1.83\n"
+        "pathogen\tSARS-CoV-2\n"
+    )
+    # A legacy report with no pathogen line should be grouped with SARS-CoV-2
+    (tmp_path / "covid_legacy.demix_out.tsv").write_text(
+        "\tvariant_files/covid_legacy.demix_out.tsv\n"
+        "summarized\t[('BA.5* [Omicron (BA.5.X)]', 0.8), ('Omicron', 0.2)]\n"
+        "lineages\tBF.5.1\n"
+        "abundances\t1.0\n"
+        "resid\t0.1\n"
+        "coverage\t1.83\n"
+    )
+    (tmp_path / "rsv.demix_out.tsv").write_text(
+        "\tvariant_files/rsv.demix_out.tsv\n"
+        "summarized\t[('A.D.1', 0.7), ('A.D.5.2', 0.3)]\n"
+        "lineages\tA.D.1 A.D.5.2\n"
+        "abundances\t0.7 0.3\n"
+        "resid\t0.05\n"
+        "coverage\t1.9\n"
+        "pathogen\tRSV-A\n"
+    )
+
+    module = _run_freyja(tmp_path)
+
+    assert {s.anchor for s in module.sections} == {"freyja-summary-sars-cov-2", "freyja-summary-rsv-a"}
+
+    # The legacy sample (no pathogen line) is grouped under SARS-CoV-2 alongside the explicit one
+    assert _freyja_stats_cols("covid.demix_out") == {
+        "Top_lineage_freyja_sars_cov_2",
+        "Top_lineage_freyja_sars_cov_2_percentage",
+    }
+    assert _freyja_stats_cols("covid_legacy.demix_out") == {
+        "Top_lineage_freyja_sars_cov_2",
+        "Top_lineage_freyja_sars_cov_2_percentage",
+    }
+    assert _freyja_stats_cols("rsv.demix_out") == {
+        "Top_lineage_freyja_rsv_a",
+        "Top_lineage_freyja_rsv_a_percentage",
+    }


### PR DESCRIPTION
I PR'd freyja to include the pathogen in their output: https://github.com/andersen-lab/Freyja/pull/313

This means multiqc can now support:
1. Different samples with different freyja pathogens
2. The same sample with different freyja pathogens

Sample reports:

- [same_samples.html](https://github.com/user-attachments/files/29613874/same_samples.html)
- [diff_samples.html](https://github.com/user-attachments/files/29613876/diff_samples.html)
